### PR TITLE
YAXAttributeForClass doesn't work in certain use cases

### DIFF
--- a/YAXLibTests/SampleClasses/AttributeContainerSample.cs
+++ b/YAXLibTests/SampleClasses/AttributeContainerSample.cs
@@ -1,4 +1,7 @@
-﻿using YAXLib;
+﻿using System.Collections;
+using System.Collections.Generic;
+
+using YAXLib;
 
 namespace YAXLibTests.SampleClasses
 {
@@ -39,4 +42,35 @@ namespace YAXLibTests.SampleClasses
         public int? To { get; set; }
     }
 
+    public interface IAttributeSample<T> : IList<T>
+    {
+        string Url { get; set; }
+        int Page { get; }
+    }
+
+    public abstract class AttributeSampleBase<T> : List<T>, IAttributeSample<T>
+    {
+        [YAXSerializeAs("url")]
+        [YAXAttributeForClass]
+        public string Url { get; set; }
+
+        [YAXSerializeAs("page")]
+        [YAXAttributeForClass]
+        public int Page
+        {
+            get { return 1; }
+        }
+    }
+
+    [YAXSerializeAs("subclass")]
+    public class AttributeSubclassSample : AttributeSampleBase<AttributeSample>
+    {
+        public static AttributeSubclassSample GetSampleInstance()
+        {
+            return new AttributeSubclassSample
+            {
+                Url = "http://example.com/subclass/1",
+            };
+        }
+    }
 }

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -1564,6 +1564,15 @@ namespace YAXLibTests
             Assert.That(expectedResult, Is.EqualTo(result));
         }
 
+        [Test]
+        public void AttributeForSubclassTest()
+        {
+            var ser = new YAXSerializer(typeof(AttributeSubclassSample));
+            string result = ser.Serialize(AttributeSubclassSample.GetSampleInstance());
+
+            const string expectedResult = @"<subclass url=""http://example.com/subclass/1"" page=""1"" />";
+            Assert.That(result, Is.EqualTo(expectedResult));
+        }
 
         [Test]
         public void DictionaryKeyValueAsContentTest()


### PR DESCRIPTION
The provided unit test shows how `YAXAttributeForClass` doesn't serialize properties to attributes as it should.
