### PR TITLE
Adding *ShouldSerialize* ability to YAXLib

### DIFF
--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -844,5 +844,15 @@ namespace YAXLib
             var result = method.Invoke(srcObj, args);
             return result;
         }
+
+        public static MethodInfo GetShouldSerializeMethodInfo(Type srcType, MemberWrapper member)
+        {
+            string methodName = string.Format("ShouldSerialize{0}", member.OriginalName);
+            var method = srcType.GetMethods()
+                .Where(m => m.Name == methodName 
+                    && m.ReturnType == typeof(bool) 
+                    && m.GetParameters().Length == 0).FirstOrDefault();
+            return method;
+        }
     }
 }

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -658,6 +658,9 @@ namespace YAXLib
                     if (!member.CanRead)
                         continue;
 
+                    if (m_udtWrapper.IgnoreMemberWrapper(member, obj))
+                        continue;
+
                     // ignore this member if it is attributed as dont serialize
                     if (member.IsAttributedAsDontSerialize)
                         continue;
@@ -1553,7 +1556,10 @@ namespace YAXLib
                         {
                             OnExceptionOccurred(new YAXAttributeMissingException(
                                 StringUtils.CombineLocationAndElementName(serializationLocation, member.Alias)),
-                                (!member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization) ? YAXExceptionTypes.Ignore : member.TreatErrorsAs);
+                                ((!member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization) 
+                                || m_udtWrapper.HasShouldSerialiseMethod(member))   
+                                ? YAXExceptionTypes.Ignore 
+                                : member.TreatErrorsAs);
                         }
                     }
                     else
@@ -1570,7 +1576,10 @@ namespace YAXLib
                     {
                         OnExceptionOccurred(new YAXElementMissingException(
                                 serializationLocation),
-                                (!member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization) ? YAXExceptionTypes.Ignore : member.TreatErrorsAs);
+                                ((!member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization)
+                                || m_udtWrapper.HasShouldSerialiseMethod(member)) 
+                                ? YAXExceptionTypes.Ignore 
+                                : member.TreatErrorsAs);
                     }
                     else
                     {
@@ -1587,7 +1596,10 @@ namespace YAXLib
                             else
                             {
                                 OnExceptionOccurred(new YAXElementValueMissingException(serializationLocation),
-                                    (!member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization) ? YAXExceptionTypes.Ignore : member.TreatErrorsAs);
+                                    ((!member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization)
+                                    || m_udtWrapper.HasShouldSerialiseMethod(member)) 
+                                    ? YAXExceptionTypes.Ignore 
+                                    : member.TreatErrorsAs);
                             }
                         }
                         else
@@ -1640,7 +1652,10 @@ namespace YAXLib
                         {
                             OnExceptionOccurred(new YAXElementMissingException(
                                 StringUtils.CombineLocationAndElementName(serializationLocation, member.Alias.OverrideNsIfEmpty(TypeNamespace))),
-                                (!member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization) ? YAXExceptionTypes.Ignore : member.TreatErrorsAs);
+                                ((!member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization)
+                                || m_udtWrapper.HasShouldSerialiseMethod(member))
+                                ? YAXExceptionTypes.Ignore 
+                                : member.TreatErrorsAs);
                         }
                     }
                     else
@@ -1807,6 +1822,7 @@ namespace YAXLib
             {
                 if (!member.CanWrite)
                     continue;
+                
 
                 // ignore this member if it is attributed as dont serialize
                 if (member.IsAttributedAsDontSerialize)

--- a/YAXLibTests/KnownTypeTests.cs
+++ b/YAXLibTests/KnownTypeTests.cs
@@ -114,14 +114,14 @@ namespace YAXLibTests
         public void RectangleSerializationTest()
         {
             const string result =
-@"<RectangleDynamicKnownType>
+@"<RectangleDynamicKnownTypeSample>
   <Rect>
     <Left>10</Left>
     <Top>20</Top>
     <Width>30</Width>
     <Height>40</Height>
   </Rect>
-</RectangleDynamicKnownType>";
+</RectangleDynamicKnownTypeSample>";
             var serializer = new YAXSerializer(typeof(SampleClasses.RectangleDynamicKnownTypeSample), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
             string got = serializer.Serialize(SampleClasses.RectangleDynamicKnownTypeSample.GetSampleInstance());
             Assert.That(got, Is.EqualTo(result));
@@ -131,7 +131,7 @@ namespace YAXLibTests
         public void DataSetAndDataTableSerializationTest()
         {
             const string result =
-@"<DataTableSample>
+@"<DataSetAndDataTableKnownTypeSample>
   <TheDataTable>
     <NewDataSet>
       <TableName xmlns=""http://tableNs/"">
@@ -168,7 +168,7 @@ namespace YAXLibTests
       </Table2>
     </MyDataSet>
   </TheDataSet>
-</DataTableSample>";
+</DataSetAndDataTableKnownTypeSample>";
 
             var serializer = new YAXSerializer(typeof(DataSetAndDataTableKnownTypeSample), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
             string got = serializer.Serialize(DataSetAndDataTableKnownTypeSample.GetSampleInstance());

--- a/YAXLibTests/SampleClasses/SimpleBookClassShouldSerialize.cs
+++ b/YAXLibTests/SampleClasses/SimpleBookClassShouldSerialize.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses
+{
+    [YAXComment("This example demonstrates serailizing a very simple class")]
+    public class BookShouldSerialize
+    {
+        public string Title { get; set; }
+        public string Author { get; set; }
+        public int PublishYear { get; set; }
+        public double Price { get; set; }
+
+        public bool ShouldSerializePrice()
+        {
+            return Price != 0;
+        }
+
+        public override string ToString()
+        {
+            return GeneralToStringProvider.GeneralToString(this);
+        }
+
+        public static BookShouldSerialize GetSampleInstance()
+        {
+            return new BookShouldSerialize()
+            {
+                Title = "Inside C#",
+                Author = "Tom Archer & Andrew Whitechapel",
+                PublishYear = 2002,
+                Price = 0
+            };
+        }
+    }
+}

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -66,6 +66,39 @@ namespace YAXLibTests
         }
 
         [Test]
+        public void BookTestShouldNot()
+        {
+            const string result =
+@"<!-- This example demonstrates serailizing a very simple class -->
+<BookShouldSerialize>
+  <Title>Inside C#</Title>
+  <Author>Tom Archer &amp; Andrew Whitechapel</Author>
+  <PublishYear>2002</PublishYear>
+</BookShouldSerialize>";
+            var serializer = new YAXSerializer(typeof(BookShouldSerialize), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
+            string got = serializer.Serialize(BookShouldSerialize.GetSampleInstance());
+            Assert.That(got, Is.EqualTo(result));
+        }
+
+        [Test]
+        public void BookTestShouldNot_Exception()
+        {
+            const string result =
+@"<!-- This example demonstrates serailizing a very simple class -->
+<BookShouldSerialize>
+  <Title>Inside C#</Title>
+  <Author>Tom Archer &amp; Andrew Whitechapel</Author>
+  <PublishYear>2002</PublishYear>
+</BookShouldSerialize>";
+            var serializer = new YAXSerializer(typeof(BookShouldSerialize), YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error, YAXSerializationOptions.SerializeNullObjects);
+            Assert.DoesNotThrow(() =>
+            {
+                var book = (BookShouldSerialize)serializer.Deserialize(result);
+            });
+        }
+
+
+        [Test]
         public void ThreadingTest()
         {
             try

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="SampleClasses\CollectionWithExtraProperties.cs" />
     <Compile Include="SampleClasses\ColorExample.cs" />
     <Compile Include="SampleClasses\CollectionWithExtraPropertiesAttributedAsNotCollection.cs" />
+    <Compile Include="SampleClasses\SimpleBookClassShouldSerialize.cs" />
     <Compile Include="SampleClasses\DataSetAndDataTableKnownTypeSample.cs" />
     <Compile Include="SampleClasses\DictionaryWithExtraPropertiesAttributedAsNotCollection.cs" />
     <Compile Include="SampleClasses\DictionaryWithExtraProperties.cs" />


### PR DESCRIPTION
I was swapping out the default .NET Serialiser for YAXLib however the code was using the ShouldSerialize pattern to perform conditional serialization logic. So I decided it was easier to add that logic to YAXLib.

Added a few unit tests and fixed a couple of existing unit tests

Also I apologies for this commit, it seems visual studio probably changed the line endings so GitHub thinks all the file contents has changed when its only a few lines here and there. 

If you know how I can fix this, I'll happily do so.
