### PR TITLE
Update YAXAttributes.cs

### DIFF
--- a/YAXLib/YAXAttributes.cs
+++ b/YAXLib/YAXAttributes.cs
@@ -336,6 +336,22 @@ namespace YAXLib
         #endregion
     }
 
+      /// <summary>
+    /// Attribute used when you want to deserialize an xml into a certain type. Type is
+    /// specified into the attribute constructor.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class YAXDeserializeIntoAttribute : YAXBaseAttribute
+    {
+        public Type Type { get; set; }
+
+        public YAXDeserializeIntoAttribute(Type type)
+        {
+            Type = type;
+        }
+    }
+
+
     /// <summary>
     /// Makes a property or field to appear as a child element 
     /// for another element. This attribute is applicable to fields and properties.


### PR DESCRIPTION
Added new attribute, called YAXDeserializeInto.

This attribute is used when you want to deserialize an xml type into a certain type, for example, we have issues when deserialize into IEnumerable.

 [YAXDeserializeInto(typeof(List<ParameterGroup>))]
  public IEnumerable<ParameterGroup> ParameterGroups { get; set; }
