### PR TITLE
Continue rather than throw a YAXAttributeAlreadyExistsException.

### DIFF
--- a/YAXLib/XMLUtils.cs
+++ b/YAXLib/XMLUtils.cs
@@ -374,7 +374,7 @@ namespace YAXLib
             {
                 if (dst.Attribute(attr.Name) != null)
                 {
-                    throw new YAXAttributeAlreadyExistsException(attr.Name.ToString());
+                    continue;
                 }
 
                 dst.Add(attr);


### PR DESCRIPTION
This was causing an error when serializing IEnumerables.
