### PR TITLE
Allow to set D/Serialization Culture

### DIFF
--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -124,7 +124,7 @@ namespace YAXLib
                 int backqIndex = name.IndexOf('`');
                 if (backqIndex == 0)
                 {
-                    throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, "Bad type name: {0}", name));
+                    throw new InvalidOperationException(String.Format(YAXSerializer.CurrentCulture, "Bad type name: {0}", name));
                 }
                 else if (backqIndex > 0)
                 {
@@ -141,7 +141,7 @@ namespace YAXLib
             else if (type.IsArray)
             {
                 Type t = type.GetElementType();
-                name = String.Format(CultureInfo.InvariantCulture, "Array{0}Of{1}", type.GetArrayRank(), GetTypeFriendlyName(t));
+                name = String.Format(YAXSerializer.CurrentCulture, "Array{0}Of{1}", type.GetArrayRank(), GetTypeFriendlyName(t));
             }
 
             return name;
@@ -708,12 +708,12 @@ namespace YAXLib
             }
             else if (dstType == typeof(DateTime))
             {
-                convertedObj = StringUtils.ParseDateTimeTimeZoneSafe(value.ToString(), CultureInfo.InvariantCulture);
+                convertedObj = StringUtils.ParseDateTimeTimeZoneSafe(value.ToString(), YAXSerializer.CurrentCulture);
             }
             else if (dstType == typeof(decimal))
             {
                 // to fix the asymetry of used locales for this type between serialization and deseralization
-                convertedObj = Convert.ChangeType(value, dstType, CultureInfo.InvariantCulture);
+                convertedObj = Convert.ChangeType(value, dstType, YAXSerializer.CurrentCulture);
             }
             else if (dstType == typeof(bool))
             {
@@ -745,7 +745,7 @@ namespace YAXLib
                     return ConvertBasicType(value, nullableType);
                 }
 
-                IFormatProvider ifProvider = CultureInfo.InvariantCulture;
+                IFormatProvider ifProvider = YAXSerializer.CurrentCulture;
                 convertedObj = Convert.ChangeType(value, dstType, ifProvider);
             }
 

--- a/YAXLib/XMLUtils.cs
+++ b/YAXLib/XMLUtils.cs
@@ -449,13 +449,13 @@ namespace YAXLib
           switch (typeName)
           {
             case "Double":
-              return ((double)self).ToString("R", CultureInfo.InvariantCulture);
+              return ((double)self).ToString("R", YAXSerializer.CurrentCulture);
             case "Single":
-              return ((Single)self).ToString("R", CultureInfo.InvariantCulture);
+              return ((Single)self).ToString("R", YAXSerializer.CurrentCulture);
             case "BigInteger":
-              return ReflectionUtils.InvokeMethod(self, "ToString", "R", CultureInfo.InvariantCulture) as string;
+              return ReflectionUtils.InvokeMethod(self, "ToString", "R", YAXSerializer.CurrentCulture) as string;
           }
-          return Convert.ToString((self ?? String.Empty), CultureInfo.InvariantCulture);
+          return Convert.ToString((self ?? String.Empty), YAXSerializer.CurrentCulture);
         }
 
         public static XAttribute AddAttributeNamespaceSafe(this XElement parent, XName attrName, object attrValue, XNamespace documentDefaultNamespace)

--- a/YAXLib/YAXExceptions.cs
+++ b/YAXLib/YAXExceptions.cs
@@ -121,7 +121,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "An attribute with this name already exists: '{0}'.", this.AttrName);
+                return String.Format(YAXSerializer.CurrentCulture, "An attribute with this name already exists: '{0}'.", this.AttrName);
             }
         }
 
@@ -166,7 +166,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "No attributes with this name found: '{0}'.", this.AttributeName);
+                return String.Format(YAXSerializer.CurrentCulture, "No attributes with this name found: '{0}'.", this.AttributeName);
             }
         }
 
@@ -211,7 +211,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "Element with the given name does not contain text values: '{0}'.", this.ElementName);
+                return String.Format(YAXSerializer.CurrentCulture, "Element with the given name does not contain text values: '{0}'.", this.ElementName);
             }
         }
 
@@ -257,7 +257,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "Element with the given name already has value: '{0}'.", this.ElementName);
+                return String.Format(YAXSerializer.CurrentCulture, "Element with the given name already has value: '{0}'.", this.ElementName);
             }
         }
 
@@ -303,7 +303,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "No elements with this name found: '{0}'.", this.ElementName);
+                return String.Format(YAXSerializer.CurrentCulture, "No elements with this name found: '{0}'.", this.ElementName);
             }
         }
 
@@ -358,7 +358,7 @@ namespace YAXLib
             get
             {
                 return String.Format(
-                    CultureInfo.CurrentCulture,
+                    YAXSerializer.CurrentCulture,
                     "The format of the value specified for the property '{0}' is not proper: '{1}'.",
                     this.ElementName,
                     this.BadInput);
@@ -407,7 +407,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "Could not assign to the property '{0}'.", this.PropertyName);
+                return String.Format(YAXSerializer.CurrentCulture, "Could not assign to the property '{0}'.", this.PropertyName);
             }
         }
 
@@ -461,7 +461,7 @@ namespace YAXLib
             get
             {
                 return String.Format(
-                    CultureInfo.CurrentCulture,
+                    YAXSerializer.CurrentCulture,
                     "Could not add object ('{0}') to the collection ('{1}').",
                     this.ObjectToAdd,
                     this.PropertyName);
@@ -518,7 +518,7 @@ namespace YAXLib
             get
             {
                 return String.Format(
-                    CultureInfo.CurrentCulture,
+                    YAXSerializer.CurrentCulture,
                     "Could not assign the default value specified ('{0}') for the property '{1}'.",
                     this.TheDefaultValue,
                     this.PropertyName);
@@ -580,7 +580,7 @@ namespace YAXLib
 
                 if (this.innerException != null)
                 {
-                    msg += String.Format(CultureInfo.CurrentCulture, "\r\nMore Details:\r\n{0}", this.innerException.Message);
+                    msg += String.Format(YAXSerializer.CurrentCulture, "\r\nMore Details:\r\n{0}", this.innerException.Message);
                 }
 
                 return msg;
@@ -637,7 +637,7 @@ namespace YAXLib
             get
             {
                 return String.Format(
-                    CultureInfo.CurrentCulture,
+                    YAXSerializer.CurrentCulture,
                     "Could not format objects of type '{0}' with the format string '{1}'",
                     this.ObjectType.Name,
                     this.Format);
@@ -684,7 +684,7 @@ namespace YAXLib
         {
             get
             {
-                return String.Format(CultureInfo.CurrentCulture, "Self Referential types ('{0}') cannot be serialized.", this.SelfReferentialType.FullName);
+                return String.Format(YAXSerializer.CurrentCulture, "Self Referential types ('{0}') cannot be serialized.", this.SelfReferentialType.FullName);
             }
         }
 
@@ -737,7 +737,7 @@ namespace YAXLib
             get
             {
                 return String.Format(
-                   CultureInfo.CurrentCulture,
+                   YAXSerializer.CurrentCulture,
                    "Expected an object of type '{0}' but received an object of type '{1}'.",
                    this.ExpectedType.Name,
                    this.ReceivedType.Name);

--- a/YAXLib/YAXParsingErrors.cs
+++ b/YAXLib/YAXParsingErrors.cs
@@ -115,7 +115,7 @@ namespace YAXLib
 
             this.listExceptions.ForEach(pair =>
             {
-                sb.AppendLine(String.Format(CultureInfo.CurrentCulture, "{0,-8} : {1}", pair.Value, pair.Key.Message));
+                sb.AppendLine(String.Format(YAXSerializer.CurrentCulture, "{0,-8} : {1}", pair.Value, pair.Key.Message));
                 sb.AppendLine();
             });
 

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -28,6 +28,9 @@ namespace YAXLib
     /// </summary>
     public class YAXSerializer
     {
+
+        public static CultureInfo CurrentCulture { get; set; } = CultureInfo.InvariantCulture;
+
         /// <summary>
         /// The class or structure that is to be serialized/deserialized.
         /// </summary>
@@ -185,9 +188,9 @@ namespace YAXLib
 
         internal XNamespace TypeNamespace { get; set; }
 
-        internal bool HasTypeNamespace 
-        { 
-            get 
+        internal bool HasTypeNamespace
+        {
+            get
             {
                 return TypeNamespace.IsEmpty();
             }
@@ -267,7 +270,7 @@ namespace YAXLib
         /// <summary>
         /// The URI address which holds the xmlns:yaxlib definition.
         /// </summary>
-        public XNamespace YaxLibNamespaceUri 
+        public XNamespace YaxLibNamespaceUri
         {
             get
             {
@@ -288,7 +291,7 @@ namespace YAXLib
             {
                 return m_yaxLibNamespacePrefix;
             }
-            
+
             set
             {
                 m_yaxLibNamespacePrefix = value;
@@ -388,7 +391,7 @@ namespace YAXLib
         public void SerializeToFile(object obj, string fileName)
         {
             string ser = String.Format(
-                CultureInfo.CurrentCulture,
+                YAXSerializer.CurrentCulture,
                 "{0}{1}{2}",
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
                 Environment.NewLine,
@@ -533,7 +536,7 @@ namespace YAXLib
         {
             // This method must be called by any public Serialize method
             m_isSerializing = true;
-            if(m_serializedStack == null)
+            if (m_serializedStack == null)
                 m_serializedStack = new Stack<object>();
             m_mainDocument = new XDocument();
             m_mainDocument.Add(SerializeBase(obj));
@@ -559,7 +562,7 @@ namespace YAXLib
             // to serialize stand-alone collection or dictionary objects
             if (m_udtWrapper.IsTreatedAsDictionary)
             {
-                var elemResult = MakeDictionaryElement(null, m_udtWrapper.Alias, obj, 
+                var elemResult = MakeDictionaryElement(null, m_udtWrapper.Alias, obj,
                     m_udtWrapper.DictionaryAttributeInstance, m_udtWrapper.CollectionAttributeInstance, m_udtWrapper.IsNotAllowdNullObjectSerialization);
                 if (m_udtWrapper.PreservesWhitespace)
                     XMLUtils.AddPreserveSpaceAttribute(elemResult);
@@ -576,7 +579,7 @@ namespace YAXLib
                     AddNamespacesToElement(elemResult);
                 return elemResult;
             }
-            else if(ReflectionUtils.IsBasicType(m_udtWrapper.UnderlyingType))
+            else if (ReflectionUtils.IsBasicType(m_udtWrapper.UnderlyingType))
             {
                 bool dummyAlreadyAdded;
                 var elemResult = MakeBaseElement(null, m_udtWrapper.Alias, obj, out dummyAlreadyAdded);
@@ -586,7 +589,7 @@ namespace YAXLib
                     AddNamespacesToElement(elemResult);
                 return elemResult;
             }
-            else if(!m_udtWrapper.UnderlyingType.EqualsOrIsNullableOf(obj.GetType()))
+            else if (!m_udtWrapper.UnderlyingType.EqualsOrIsNullableOf(obj.GetType()))
             {
                 // this block of code runs if the serializer is instantiated with a
                 // another base value such as System.Object but is provided with an
@@ -699,7 +702,7 @@ namespace YAXLib
 
             // if the containing element is set to preserve spaces, then emit the 
             // required attribute
-            if(m_udtWrapper.PreservesWhitespace)
+            if (m_udtWrapper.PreservesWhitespace)
             {
                 XMLUtils.AddPreserveSpaceAttribute(m_baseElement);
             }
@@ -709,7 +712,7 @@ namespace YAXLib
             {
                 InvokeCustomSerializerToElement(m_udtWrapper.CustomSerializerType, obj, m_baseElement);
             }
-            else if(KnownTypes.IsKnowType(m_type))
+            else if (KnownTypes.IsKnowType(m_type))
             {
                 KnownTypes.Serialize(obj, m_baseElement, TypeNamespace);
             }
@@ -734,14 +737,14 @@ namespace YAXLib
                     // ignore this member if it is attributed as dont serialize
                     if (member.IsAttributedAsDontSerialize)
                         continue;
-                    
+
                     object elementValue = member.GetValue(obj);
 
                     // make this flat true, so that we know that this object was not empty of fields
                     isAnythingFoundToSerialize = true;
 
                     // ignore this member if it is null and we are not about to serialize null objects
-                    if (elementValue == null && 
+                    if (elementValue == null &&
                         m_udtWrapper.IsNotAllowdNullObjectSerialization)
                     {
                         continue;
@@ -773,8 +776,8 @@ namespace YAXLib
                         if (!XMLUtils.AttributeExists(m_baseElement, serializationLocation, member.Alias.OverrideNsIfEmpty(TypeNamespace)))
                         {
                             XAttribute attrToCreate = XMLUtils.CreateAttribute(m_baseElement,
-                                serializationLocation, member.Alias.OverrideNsIfEmpty(TypeNamespace), 
-                                (hasCustomSerializer || isCollectionSerially || isKnownType) ? String.Empty : elementValue, 
+                                serializationLocation, member.Alias.OverrideNsIfEmpty(TypeNamespace),
+                                (hasCustomSerializer || isCollectionSerially || isKnownType) ? String.Empty : elementValue,
                                 m_documentDefaultNamespace);
 
                             RegisterNamespace(member.Alias.OverrideNsIfEmpty(TypeNamespace).Namespace, null);
@@ -797,7 +800,7 @@ namespace YAXLib
                                 // TODO: create a functionality to serialize to XAttributes
                                 //KnownTypes.Serialize(attrToCreate, member.MemberType);
                             }
-                            else if(isCollectionSerially)
+                            else if (isCollectionSerially)
                             {
                                 var tempLoc = new XElement("temp");
                                 var added = MakeCollectionElement(tempLoc, "name", elementValue, member.CollectionAttributeInstance, member.Format);
@@ -838,7 +841,7 @@ namespace YAXLib
                         {
                             valueToSet = InvokeCustomSerializerToValue(member.MemberTypeWrapper.CustomSerializerType, elementValue);
                         }
-                        else if(isKnownType)
+                        else if (isKnownType)
                         {
                             var tempLoc = new XElement("temp");
                             KnownTypes.Serialize(elementValue, tempLoc, String.Empty);
@@ -899,7 +902,7 @@ namespace YAXLib
                             if (member.PreservesWhitespace)
                                 XMLUtils.AddPreserveSpaceAttribute(elemToFill);
                         }
-                        else if(isKnownType)
+                        else if (isKnownType)
                         {
                             var elemToFill = new XElement(member.Alias.OverrideNsIfEmpty(TypeNamespace));
                             parElem.Add(elemToFill);
@@ -938,10 +941,10 @@ namespace YAXLib
                             if (moveDescOnly)// if only the descendants of the resulting element are going to be added ...
                             {
                                 XMLUtils.MoveDescendants(elemToAdd, parElem);
-                                if(elemToAdd.Parent == parElem)
+                                if (elemToAdd.Parent == parElem)
                                     elemToAdd.Remove();
                             }
-                            else if(!alreadyAdded)
+                            else if (!alreadyAdded)
                             {
                                 // see if such element already exists
                                 XElement existingElem = parElem.Element(member.Alias.OverrideNsIfEmpty(TypeNamespace));
@@ -962,7 +965,7 @@ namespace YAXLib
                                     }
                                 }
                             }
-                            
+
                         }
                     } // end of if serialize data as Element
                 } // end of foreach var member
@@ -1059,8 +1062,8 @@ namespace YAXLib
                         // check the namespace associated with this prefix
                         var existing = rootNode.GetNamespaceOfPrefix(prefix);
                         if (existing != ns)
-                            throw new InvalidOperationException(String.Format("You cannot have two different namespaces with the same prefix." + 
-                                Environment.NewLine + 
+                            throw new InvalidOperationException(String.Format("You cannot have two different namespaces with the same prefix." +
+                                Environment.NewLine +
                                 "Prefix: {0}, Namespaces: \"{1}\", and \"{2}\"",
                                 prefix, ns, existing));
                     }
@@ -1331,13 +1334,13 @@ namespace YAXLib
             if (udt != null && udt.IsTreatedAsDictionary)
             {
                 elemToAdd = MakeDictionaryElement(elem, alias, obj, null, null, udt.IsNotAllowdNullObjectSerialization);
-                if(elemToAdd.Parent != elem)
+                if (elemToAdd.Parent != elem)
                     elem.Add(elemToAdd);
             }
             else if (udt != null && udt.IsTreatedAsCollection)
             {
                 elemToAdd = MakeCollectionElement(elem, alias, obj, null, null);
-                if(elemToAdd.Parent != elem)
+                if (elemToAdd.Parent != elem)
                     elem.Add(elemToAdd);
             }
             else if (udt != null && udt.IsEnum)
@@ -1432,7 +1435,7 @@ namespace YAXLib
                     }
                     else
                     {
-                        sb.AppendFormat(CultureInfo.InvariantCulture, "{0}{1}", seperator, objToAdd);
+                        sb.AppendFormat(YAXSerializer.CurrentCulture, "{0}{1}", seperator, objToAdd);
                     }
                 }
 
@@ -1450,8 +1453,8 @@ namespace YAXLib
                 {
                     objToAdd = (format == null) ? obj : ReflectionUtils.TryFormatObject(obj, format);
                     var curElemName = eachElementName;
-                    
-                    if(curElemName == null)
+
+                    if (curElemName == null)
                     {
                         curElemName = colItemsUdt.Alias;
                     }
@@ -1499,7 +1502,7 @@ namespace YAXLib
             else if (ReflectionUtils.IsStringConvertibleIFormattable(value.GetType()))
             {
                 var elementValue = value.GetType().InvokeMethod("ToString", value, new object[0]);
-        		//object elementValue = value.GetType().InvokeMember("ToString", BindingFlags.InvokeMethod, null, value, new object[0]);
+                //object elementValue = value.GetType().InvokeMember("ToString", BindingFlags.InvokeMethod, null, value, new object[0]);
                 return new XElement(name, elementValue);
             }
             else
@@ -1571,7 +1574,7 @@ namespace YAXLib
 
             object o;
             o = m_desObject ?? Activator.CreateInstance(m_type, new object[0]);
-        	// o = m_desObject ?? m_type.InvokeMember(string.Empty, BindingFlags.CreateInstance, null, null, new object[0]);
+            // o = m_desObject ?? m_type.InvokeMember(string.Empty, BindingFlags.CreateInstance, null, null, new object[0]);
 
             foreach (var member in GetFieldsToBeSerialized())
             {
@@ -1632,7 +1635,7 @@ namespace YAXLib
                     else
                     {
                         XText[] values = elem.Nodes().OfType<XText>().ToArray();
-                        if(values.Length <= 0)
+                        if (values.Length <= 0)
                         {
                             // loook for an element with the same name AND a yaxlib:realtype attribute
                             XElement innerelem = XMLUtils.FindElement(baseElement, serializationLocation, member.Alias.OverrideNsIfEmpty(TypeNamespace));
@@ -1789,10 +1792,10 @@ namespace YAXLib
                     xelemValue.Remove();
                 }
 
-                if(RemoveDeserializedXmlNodes)
+                if (RemoveDeserializedXmlNodes)
                 {
-                    if(xattrValue != null) xattrValue.Remove();
-                    else if(xelemValue != null) xelemValue.Remove();
+                    if (xattrValue != null) xattrValue.Remove();
+                    else if (xelemValue != null) xelemValue.Remove();
                 }
             }
 
@@ -1882,8 +1885,8 @@ namespace YAXLib
                     XElement xelem = XMLUtils.FindElement(elem, member.SerializationLocation, member.Alias);
                     if (xelem == null)
                     {
-                        if (!ReflectionUtils.IsBasicType(member.MemberType) 
-                            && !member.IsTreatedAsCollection 
+                        if (!ReflectionUtils.IsBasicType(member.MemberType)
+                            && !member.IsTreatedAsCollection
                             && !member.IsTreatedAsDictionary
                             && member.MemberType != m_type) // searching for same type objects will lead to infinite loops
                         {
@@ -2028,7 +2031,7 @@ namespace YAXLib
                 ser.IsCraetedToDeserializeANonCollectionMember = !(member.IsTreatedAsDictionary || member.IsTreatedAsCollection);
 
                 if (m_desObject != null) // i.e. it is in resuming mode
-                     ser.SetDeserializationBaseObject(member.GetValue(o));
+                    ser.SetDeserializationBaseObject(member.GetValue(o));
 
                 object convertedObj = ser.DeserializeBase(xelemValue);
                 FinalizeNewSerializer(ser, false);
@@ -2079,7 +2082,7 @@ namespace YAXLib
                 // can white space characters be added to the separators?
                 if (colAttrInstance.IsWhiteSpaceSeparator)
                 {
-                    seps = seps.Union(new [] { ' ', '\t', '\r', '\n' }).ToArray();
+                    seps = seps.Union(new[] { ' ', '\t', '\r', '\n' }).ToArray();
                 }
 
                 string elemValue = xelemValue.Value;
@@ -2219,7 +2222,7 @@ namespace YAXLib
                     object value = itemType.GetProperty("Value").GetValue(lstItem, null);
                     try
                     {
-                        colType.InvokeMethod("Add", dic, new[] {key, value});
+                        colType.InvokeMethod("Add", dic, new[] { key, value });
                         //colType.InvokeMember("Add", BindingFlags.InvokeMethod, null, dic, new[] { key, value });
                     }
                     catch
@@ -2240,7 +2243,7 @@ namespace YAXLib
 
                     try
                     {
-                        colType.InvokeMethod("Add", col, new[] {key, value});
+                        colType.InvokeMethod("Add", col, new[] { key, value });
                         //colType.InvokeMember("Add", BindingFlags.InvokeMethod, null, col, new[] { key, value });
                     }
                     catch
@@ -2265,7 +2268,7 @@ namespace YAXLib
                     }
                 }
 
-                var col = Activator.CreateInstance(colType, new object[] {bArray});
+                var col = Activator.CreateInstance(colType, new object[] { bArray });
                 //object col = colType.InvokeMember(string.Empty, BindingFlags.CreateInstance, null, null, new object[] { bArray });
 
                 return col;
@@ -2282,7 +2285,7 @@ namespace YAXLib
                 {
                     try
                     {
-                        colType.InvokeMethod(additionMethodName, col, new[] {lst[i]});
+                        colType.InvokeMethod(additionMethodName, col, new[] { lst[i] });
                         //colType.InvokeMember(additionMethodName, BindingFlags.InvokeMethod, null, col, new[] { lst[i] });
                     }
                     catch
@@ -2301,7 +2304,7 @@ namespace YAXLib
                 object col = containerObj;
 
                 string additionMethodName = "Add";
-                
+
                 if (ReflectionUtils.IsTypeEqualOrInheritedFromType(colType, typeof(Queue)) ||
                     ReflectionUtils.IsTypeEqualOrInheritedFromType(colType, typeof(Queue<>)))
                 {
@@ -2316,7 +2319,7 @@ namespace YAXLib
                 {
                     try
                     {
-                        colType.InvokeMethod(additionMethodName, col, new object[] {lstItem});
+                        colType.InvokeMethod(additionMethodName, col, new object[] { lstItem });
                     }
                     catch
                     {
@@ -2387,7 +2390,7 @@ namespace YAXLib
             return result;
         }
 
-        private object DeserializeTaggedDictionaryValue(XElement xelemValue, XName alias, Type type, 
+        private object DeserializeTaggedDictionaryValue(XElement xelemValue, XName alias, Type type,
             YAXCollectionAttribute colAttributeInstance, YAXDictionaryAttribute dicAttrInstance)
         {
             // otherwise the "else if(member.IsTreatedAsCollection)" block solves the problem
@@ -2521,7 +2524,7 @@ namespace YAXLib
 
                 try
                 {
-                    type.InvokeMethod("Add", dic, new object[] {key, value});
+                    type.InvokeMethod("Add", dic, new object[] { key, value });
                     //type.InvokeMember("Add", BindingFlags.InvokeMethod, null, dic, new object[] { key, value });
                 }
                 catch
@@ -2541,10 +2544,10 @@ namespace YAXLib
             serializer.MaxRecursion = MaxRecursion == 0 ? 0 : MaxRecursion - 1;
             serializer.m_serializedStack = m_serializedStack;
             serializer.m_documentDefaultNamespace = m_documentDefaultNamespace;
-            if(namespaceToOverride != null)
+            if (namespaceToOverride != null)
                 serializer.SetNamespaceToOverrideEmptyNamespace(namespaceToOverride);
 
-            if(insertionLocation != null)
+            if (insertionLocation != null)
                 serializer.SetBaseElement(insertionLocation);
 
             return serializer;
@@ -2558,7 +2561,7 @@ namespace YAXLib
             if (popFromSerializationStack && m_isSerializing && serializer.m_type != null && !serializer.m_type.IsValueType())
                 m_serializedStack.Pop();
 
-            if(importNamespaces)
+            if (importNamespaces)
                 ImportNamespaces(serializer);
             m_parsingErrors.AddRange(serializer.ParsingErrors);
         }
@@ -2596,7 +2599,7 @@ namespace YAXLib
         private bool VerifyDictionaryPairElements(ref Type keyType, ref bool isKeyAttrib, ref bool isKeyContent, XName keyAlias, XElement childElem)
         {
             bool isKeyFound = false;
-            
+
             if (isKeyAttrib && childElem.Attribute_NamespaceSafe(keyAlias, m_documentDefaultNamespace) != null)
             {
                 isKeyFound = true;
@@ -2677,11 +2680,11 @@ namespace YAXLib
             }
             else if (ReflectionUtils.IsStringConvertibleIFormattable(keyType))
             {
-                keyValue = Activator.CreateInstance(keyType, new object[] {baseElement.Element(xnameKey).Value});
+                keyValue = Activator.CreateInstance(keyType, new object[] { baseElement.Element(xnameKey).Value });
             }
             else if (ReflectionUtils.IsCollectionType(keyType))
             {
-                keyValue = DeserializeCollectionValue(keyType, 
+                keyValue = DeserializeCollectionValue(keyType,
                     baseElement.Element(xnameKey), xnameKey, null);
             }
             else
@@ -2708,7 +2711,7 @@ namespace YAXLib
             }
             else if (ReflectionUtils.IsCollectionType(valueType))
             {
-                valueValue = DeserializeCollectionValue(valueType, 
+                valueValue = DeserializeCollectionValue(valueType,
                     baseElement.Element(xnameValue), xnameValue, null);
             }
             else
@@ -2718,14 +2721,14 @@ namespace YAXLib
                 FinalizeNewSerializer(ser, false);
             }
 
-            var pair = Activator.CreateInstance(m_type, new [] { keyValue, valueValue });
+            var pair = Activator.CreateInstance(m_type, new[] { keyValue, valueValue });
             return pair;
         }
 
         private static object InvokeCustomDeserializerFromElement(Type customDeserType, XElement elemToDeser)
         {
             var customDeserializer = Activator.CreateInstance(customDeserType, new object[0]);
-            return customDeserType.InvokeMethod("DeserializeFromElement", customDeserializer, new object[] {elemToDeser});
+            return customDeserType.InvokeMethod("DeserializeFromElement", customDeserializer, new object[] { elemToDeser });
         }
 
         private static object InvokeCustomDeserializerFromAttribute(Type customDeserType, XAttribute attrToDeser)
@@ -2743,7 +2746,7 @@ namespace YAXLib
         private static void InvokeCustomSerializerToElement(Type customSerType, object objToSerialize, XElement elemToFill)
         {
             var customSerializer = Activator.CreateInstance(customSerType, new object[0]);
-            customSerType.InvokeMethod("SerializeToElement", customSerializer, new[] {objToSerialize, elemToFill});
+            customSerType.InvokeMethod("SerializeToElement", customSerializer, new[] { objToSerialize, elemToFill });
         }
 
         private static void InvokeCustomSerializerToAttribute(Type customSerType, object objToSerialize, XAttribute attrToFill)
@@ -2755,7 +2758,7 @@ namespace YAXLib
         private static string InvokeCustomSerializerToValue(Type customSerType, object objToSerialize)
         {
             var customSerializer = Activator.CreateInstance(customSerType, new object[0]);
-            return (string) customSerType.InvokeMethod("SerializeToValue", customSerializer, new[] {objToSerialize});
+            return (string)customSerType.InvokeMethod("SerializeToValue", customSerializer, new[] { objToSerialize });
         }
 
         /// <summary>
@@ -2785,8 +2788,8 @@ namespace YAXLib
                             continue;
                     }
 
-                    if((typeWrapper.IsCollectionType || typeWrapper.IsDictionaryType)) //&& typeWrapper.IsAttributedAsNotCollection)
-                        if(ReflectionUtils.IsPartOfNetFx(member))
+                    if ((typeWrapper.IsCollectionType || typeWrapper.IsDictionaryType)) //&& typeWrapper.IsAttributedAsNotCollection)
+                        if (ReflectionUtils.IsPartOfNetFx(member))
                             continue;
 
                     var memInfo = new MemberWrapper(member, this);
@@ -2805,7 +2808,7 @@ namespace YAXLib
         /// <returns>the sequence of fields to be serialized for the serializer's underlying type.</returns>
         private IEnumerable<MemberWrapper> GetFieldsToBeSerialized()
         {
-            return GetFieldsToBeSerialized(m_udtWrapper).OrderBy(t=>t.Order);
+            return GetFieldsToBeSerialized(m_udtWrapper).OrderBy(t => t.Order);
         }
 
         private void AddMetadataAttribute(XElement parent, XName attrName, object attrValue, XNamespace documentDefaultNamespace)

--- a/YAXLibTests/DeserializationTest.cs
+++ b/YAXLibTests/DeserializationTest.cs
@@ -35,6 +35,12 @@ namespace YAXLibTests
 #endif
         }
 
+        [SetUp]
+        public void Init()
+        {
+            YAXSerializer.CurrentCulture = CultureInfo.InvariantCulture;
+        }
+
         private void PerformTest(object obj)
         {
             PerformTestAndReturn(obj);
@@ -730,5 +736,38 @@ namespace YAXLibTests
             Assert.That(deserialzedInstance.Items.Length, Is.EqualTo(1));
         }
 
+
+        [Test]
+        public void PtBr()
+        {
+            var ptbr = new PtBr
+            {
+                Name = "João da Silva Sabiá",
+                Age = 18,
+                BirthDate = new DateTime(2017, 12, 1, 11, 59, 59),
+                DecimalMoney = 1203.88m,
+                LongMoney = 53,
+                SchoolFirstDay = null,
+
+            };
+
+            YAXSerializer.CurrentCulture = CultureInfo.GetCultureInfo("pt-br");
+
+            var ser = new YAXSerializer(typeof(PtBr));
+
+            var result = ser.Serialize(ptbr);
+
+            var deserialzedInstance = ser.Deserialize(result) as PtBr;
+
+            
+
+            Assert.That(deserialzedInstance.Name, Is.EqualTo(ptbr.Name));
+            Assert.That(deserialzedInstance.Age, Is.EqualTo(ptbr.Age));
+            Assert.That(deserialzedInstance.BirthDate, Is.EqualTo(ptbr.BirthDate));
+            Assert.That(deserialzedInstance.DecimalMoney, Is.EqualTo(ptbr.DecimalMoney));
+            Assert.That(deserialzedInstance.LongMoney, Is.EqualTo(ptbr.LongMoney));
+            Assert.That(deserialzedInstance.SchoolFirstDay, Is.EqualTo(ptbr.SchoolFirstDay));
+
+        }
     }
 }

--- a/YAXLibTests/SampleClasses/PtBr.cs
+++ b/YAXLibTests/SampleClasses/PtBr.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace YAXLibTests.SampleClasses
+{
+    public class PtBr
+    {
+
+        public string Name { get; set; }
+
+
+
+        public DateTime BirthDate { get; set; }
+
+        public DateTime? SchoolFirstDay { get; set; }
+
+
+        public int Age { get; set; }
+
+        public decimal DecimalMoney { get; set; }
+
+        public long LongMoney { get; set; }
+
+    }
+   
+}

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -30,13 +30,23 @@ namespace YAXLibTests
 #else
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
 #endif
+
+           
         }
+
+
+        [SetUp]
+        public void Init()
+        {
+            YAXSerializer.CurrentCulture = CultureInfo.InvariantCulture;
+        }
+
 
         [Test]
         public void BasicTypeSerializationTest()
         {
-            var objs = new object[] {123, 654.321, "SomeString", 24234L};
-            var types = new [] {typeof (int), typeof (double), typeof (string), typeof (long)};
+            var objs = new object[] { 123, 654.321, "SomeString", 24234L };
+            var types = new[] { typeof(int), typeof(double), typeof(string), typeof(long) };
             var serializedResults = new[] { "<Int32>123</Int32>", "<Double>654.321</Double>", "<String>SomeString</String>", "<Int64>24234</Int64>" };
 
             for (int i = 0; i < objs.Length; i++)
@@ -233,12 +243,12 @@ namespace YAXLibTests
             string got = serializer.Serialize(WarehouseWithArray.GetSampleInstance());
             Assert.That(got, Is.EqualTo(result));
         }
-        
+
         [Test]
         public void DictionaryWithNullValue()
         {
             const string theKey = "TheKey";
-            var d = new Dictionary<string, object>() {{ theKey, null}};
+            var d = new Dictionary<string, object>() { { theKey, null } };
             var serializer = new YAXSerializer(typeof(Dictionary<string, object>), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.DontSerializeNullObjects);
             var got = serializer.Serialize(d);
             var gotDes = serializer.Deserialize(got) as Dictionary<string, object>;
@@ -625,7 +635,7 @@ namespace YAXLibTests
   </SomeDic>
 </GUIDTest>", g1.ToString(), g2.ToString(), g3.ToString(), g4.ToString());
             var serializer = new YAXSerializer(typeof(GUIDTest), YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
-            string got = serializer.Serialize(GUIDTest.GetSampleInstance(g1,g2,g3,g4));
+            string got = serializer.Serialize(GUIDTest.GetSampleInstance(g1, g2, g3, g4));
             Assert.That(got, Is.EqualTo(result));
         }
 
@@ -1396,10 +1406,10 @@ namespace YAXLibTests
             Assert.That(got, Is.EqualTo(result));
         }
 
-        [Test] 
+        [Test]
         public void SerializingPathAndAliasTogetherTest()
         {
-            const string result = 
+            const string result =
 @"<PathAndAliasAssignmentSample>
   <Title value=""Inside C#"" />
   <Price value=""30.5"" />
@@ -1492,7 +1502,7 @@ namespace YAXLibTests
             var initialInstance = ClassContainingXElement.GetSampleInstance();
             string initialInstanceString = initialInstance.ToString();
 
-            var ser = new YAXSerializer(typeof (ClassContainingXElement), YAXExceptionHandlingPolicies.DoNotThrow,
+            var ser = new YAXSerializer(typeof(ClassContainingXElement), YAXExceptionHandlingPolicies.DoNotThrow,
                                         YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
 
             var initialXmlSer = ser.Serialize(initialInstance);
@@ -1615,7 +1625,7 @@ namespace YAXLibTests
             var ser = new YAXSerializer(typeof(object));
             string xmlResult = ser.Serialize(content);
 
-            string expectedResult = 
+            string expectedResult =
 @"<Object yaxlib:realtype=""System.String"" xmlns:yaxlib=""http://www.sinairv.com/yaxlib/"">this is just a simple test</Object>";
 
             Assert.That(xmlResult, Is.EqualTo(expectedResult));
@@ -1627,7 +1637,7 @@ namespace YAXLibTests
         [Test]
         public void PolymorphicSerializationThroughListTest()
         {
-            var lst = new List<int> {1, 2, 3};
+            var lst = new List<int> { 1, 2, 3 };
             var ser = new YAXSerializer(typeof(object));
             string xmlResult = ser.Serialize(lst);
 #if FXCORE
@@ -1638,7 +1648,7 @@ namespace YAXLibTests
   <Int32>3</Int32>
 </Object>";
 #else
-            const string expectedResult = 
+            const string expectedResult =
 @"<Object yaxlib:realtype=""System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"" xmlns:yaxlib=""http://www.sinairv.com/yaxlib/"">
   <Int32>1</Int32>
   <Int32>2</Int32>
@@ -1762,7 +1772,7 @@ namespace YAXLibTests
             var dictionary = DictionarySample.GetSampleInstance();
             var ser = new YAXSerializer(typeof(DictionarySample));
             string result = ser.Serialize(dictionary);
-            
+
             const string expectedResult =
 @"<TheItems xmlns=""http://example.com/"">
   <TheItem TheKey=""key1"">00000001-0002-0003-0405-060708090a0b</TheItem>
@@ -1897,13 +1907,13 @@ namespace YAXLibTests
             string got = serializer.Serialize(AttributeInheritanceWithPropertyOverride.GetSampleInstance());
             Assert.That(got, Is.EqualTo(result));
         }
-        
+
         [Test]
         public void ListOfPolymorphicObjectsTest()
         {
             var ser = new YAXSerializer(typeof(PolymorphicSampleList));
             string result = ser.Serialize(PolymorphicSampleList.GetSampleInstance());
-            
+
             const string expectedResult =
 @"<samples xmlns:yaxlib=""http://www.sinairv.com/yaxlib/"">
   <sample yaxlib:realtype=""YAXLibTests.SampleClasses.PolymorphicOneSample"" />
@@ -1915,7 +1925,7 @@ namespace YAXLibTests
         [Test]
         public void OneLetterPathTest()
         {
-            var ser = new YAXSerializer(typeof (OneLetterAlias));
+            var ser = new YAXSerializer(typeof(OneLetterAlias));
             string result = ser.Serialize(OneLetterAlias.GetSampleInstance());
 
             const string expectedResult =
@@ -1930,7 +1940,7 @@ namespace YAXLibTests
         [Test]
         public void IndexerPropertiesAreNotSerialized()
         {
-            var ser = new YAXSerializer(typeof (IndexerSample));
+            var ser = new YAXSerializer(typeof(IndexerSample));
             string result = ser.Serialize(IndexerSample.GetSampleInstance());
 
             const string expectedResult =
@@ -1945,7 +1955,7 @@ namespace YAXLibTests
         [Test]
         public void SingleLetterPropertyNamesAreSerializedProperly()
         {
-            var ser = new YAXSerializer(typeof (SingleLetterPropertyNames));
+            var ser = new YAXSerializer(typeof(SingleLetterPropertyNames));
             string result = ser.Serialize(SingleLetterPropertyNames.GetSampleInstance());
 
             const string expectedResult =
@@ -1970,10 +1980,10 @@ namespace YAXLibTests
         [Test]
         public void DelegatesAndFunctionPointersMustBeIgnored()
         {
-            var ser = new YAXSerializer(typeof (DelegateInstances));
+            var ser = new YAXSerializer(typeof(DelegateInstances));
             string result = ser.Serialize(DelegateInstances.GetSampleInstance());
 
-            const string expectedResult = 
+            const string expectedResult =
 @"<DelegateInstances>
   <SomeNumber>12</SomeNumber>
 </DelegateInstances>";
@@ -1984,7 +1994,7 @@ namespace YAXLibTests
         [Test]
         public void RepetitiveReferencesAreNotLoop()
         {
-            var ser = new YAXSerializer(typeof (RepetitiveReferenceIsNotLoop));
+            var ser = new YAXSerializer(typeof(RepetitiveReferenceIsNotLoop));
             string result = ser.Serialize(RepetitiveReferenceIsNotLoop.GetSampleInstance());
 
             const string expectedResult =
@@ -2002,7 +2012,7 @@ namespace YAXLibTests
         [Test]
         public void SelfReferringTypeIsNotNecessarilyASelfReferringObject()
         {
-            var ser = new YAXSerializer(typeof (DirectSelfReferringObject));
+            var ser = new YAXSerializer(typeof(DirectSelfReferringObject));
             string result = ser.Serialize(DirectSelfReferringObject.GetSampleInstance());
 
             const string expenctedResult =
@@ -2020,8 +2030,8 @@ namespace YAXLibTests
         [Test]
         public void SerializingASelfReferringObjectThrowsException_WhenTheRelevantSerializationOptionIsSet()
         {
-            Assert.Throws<YAXCannotSerializeSelfReferentialTypes>(() => 
-                {             
+            Assert.Throws<YAXCannotSerializeSelfReferentialTypes>(() =>
+                {
                     var ser = new YAXSerializer(typeof(DirectSelfReferringObject), YAXSerializationOptions.ThrowUponSerializingCyclingReferences);
                     string result = ser.Serialize(DirectSelfReferringObject.GetSampleInstanceWithCycle());
                 });
@@ -2030,7 +2040,7 @@ namespace YAXLibTests
         [Test]
         public void SerializingAnIndirectSelfReferringTypeWithougLoopMustPass()
         {
-            var ser = new YAXSerializer(typeof (IndirectSelfReferringObject));
+            var ser = new YAXSerializer(typeof(IndirectSelfReferringObject));
             string result = ser.Serialize(IndirectSelfReferringObject.GetSampleInstance());
 
             const string expectedResult =
@@ -2107,7 +2117,7 @@ namespace YAXLibTests
         {
             Assert.Throws<YAXCannotSerializeSelfReferentialTypes>(() =>
             {
-                var ser = new YAXSerializer(typeof (DirectSelfReferringObject),
+                var ser = new YAXSerializer(typeof(DirectSelfReferringObject),
                     YAXExceptionHandlingPolicies.ThrowWarningsAndErrors, YAXExceptionTypes.Error,
                     YAXSerializationOptions.ThrowUponSerializingCyclingReferences);
                 string result = ser.Serialize(DirectSelfReferringObject.GetSampleInstanceWithCycle());
@@ -2199,7 +2209,7 @@ namespace YAXLibTests
             try
             {
                 throw new ArgumentOutOfRangeException("index",
-                    new InvalidOperationException("Inner exception 1", 
+                    new InvalidOperationException("Inner exception 1",
                         new Exception("Inner Exception 2")));
             }
             catch (Exception ex)
@@ -2219,7 +2229,7 @@ namespace YAXLibTests
             YAXSerializer serializer = new YAXSerializer(typeof(Dictionary<string, object>));
             string result = serializer.Serialize(dict);
 
-            const string expectedResult = 
+            const string expectedResult =
 @"<DictionaryOfStringObject>
   <KeyValuePairOfStringObject>
     <Key>foo</Key>
@@ -2238,7 +2248,7 @@ namespace YAXLibTests
             list.Add("3");
             YAXSerializer serializer = new YAXSerializer(typeof(List<string>));
             string result = serializer.Serialize(list);
-            const string @expectedResult = 
+            const string @expectedResult =
 @"<ListOfString>
   <String>1</String>
   <String />
@@ -2257,7 +2267,7 @@ namespace YAXLibTests
 
             YAXSerializer serializer = new YAXSerializer(typeof(List<object>));
             string result = serializer.Serialize(list);
-            const string expectedResult = 
+            const string expectedResult =
 @"<ListOfObject xmlns:yaxlib=""http://www.sinairv.com/yaxlib/"">
   <Object yaxlib:realtype=""System.String"">1</Object>
   <Object />
@@ -2292,6 +2302,40 @@ namespace YAXLibTests
             const string expectedResult = "<Object />";
 
             Assert.That(result, Is.EqualTo(expectedResult));
+        }
+
+        [Test]
+        public void PtBr()
+        {
+            var ptbr = new PtBr
+            {
+                Name = "João da Silva Sabiá",
+                Age = 18,
+                BirthDate = new DateTime(2017, 12, 1, 11, 59, 59),
+                DecimalMoney = 1203.88m,
+                LongMoney = 53,
+                SchoolFirstDay = null,
+
+            };
+
+            YAXSerializer.CurrentCulture = CultureInfo.GetCultureInfo("pt-br");
+
+            var ser = new YAXSerializer(typeof(PtBr));
+
+            var result = ser.Serialize(ptbr);
+
+            const string expectedResult =
+@"<PtBr>
+  <Name>João da Silva Sabiá</Name>
+  <BirthDate>01/12/2017 11:59:59</BirthDate>
+  <SchoolFirstDay />
+  <Age>18</Age>
+  <DecimalMoney>1203,88</DecimalMoney>
+  <LongMoney>53</LongMoney>
+</PtBr>";
+
+            Assert.That(result, Is.EqualTo(expectedResult));
+
         }
     }
 }

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="SampleClasses\PolymorphicSerialization\MultipleYaxTypeAttributesWithSameAlias.cs" />
     <Compile Include="SampleClasses\PolymorphicSerialization\MultipleYaxTypeAttributesWithSameType.cs" />
     <Compile Include="SampleClasses\PolymorphicSerialization\PolymorphicCollectionWithNoContainingElement.cs" />
+    <Compile Include="SampleClasses\PtBr.cs" />
     <Compile Include="SampleClasses\RectangleDynamicKnownTypeSample.cs" />
     <Compile Include="SampleClasses\SelfReferencingObjects\CalculatedPropertiesCanCauseInfiniteLoop.cs" />
     <Compile Include="SampleClasses\SelfReferencingObjects\RepetitiveReferenceIsNotLoop.cs" />


### PR DESCRIPTION
The goal of this pull request is to allow to set D/Serialization Culture according
the user/client necessity.

The class YAXSerializer received the static property:
`public static CultureInfo CurrentCulture { get; set; } = CultureInfo.InvariantCulture;`


