### PR TITLE
Remove Microsoft.DotNet.PlatformAbstractions dependency for .NET Standard

### DIFF
--- a/YAXLib/YAXLib.csproj
+++ b/YAXLib/YAXLib.csproj
@@ -18,8 +18,10 @@
     <None Include="../Logo/YAXLib_256x256.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Not needed, the packages is obsolete, and  also fixes #104