### PR TITLE
Normalize indent width csproj files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -121,3 +121,8 @@ dotnet_style_qualification_for_property = false:suggestion
 # Copyright file header
 file_header_template = Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.\nLicensed under the MIT license.\n
 
+[*.csproj]
+
+#use soft tabs (spaces) for indentation
+indent_style = space
+indent_size = 2

--- a/YAXLib.sln
+++ b/YAXLib.sln
@@ -7,7 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YAXLibTests", "YAXLibTests\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YAXLib", "YAXLib\YAXLib.csproj", "{F1C4D174-C948-4D18-A125-F6855EF55683}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoApplication", "DemoApplication\DemoApplication.csproj", "{40A6C570-2CC0-44BF-8A2A-FD41CE598C41}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DemoApplication", "DemoApplication\DemoApplication.csproj", "{40A6C570-2CC0-44BF-8A2A-FD41CE598C41}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D33FA678-7C1C-43D0-9167-B4FDEDF26637}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/YAXLib/YAXLib.csproj
+++ b/YAXLib/YAXLib.csproj
@@ -1,35 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    
-    <PropertyGroup>
-        <SignAssembly>true</SignAssembly>
-        <AssemblyOriginatorKeyFile>../Key/YAXLib.DevKey.snk</AssemblyOriginatorKeyFile>
-        <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-        <PackageId>YAXLib</PackageId>
-        <Title>YAXLib</Title>
-        <Description>YAXLib is an XML Serialization library which allows the programmer to structure freely the XML result, choose the fields to serialize (public, or non-public properties, or member variables), serialize all known generic and non-generic collections, serialize different kinds of arrays (single-dimensional, multi-dimensional, and jagged arrays), serialize objects through a reference to their base-class or interface (polymorphic serialization), define custom serializers, add comments for the elements in the XML result, and many more ...</Description>
-        <PackageProjectUrl>https://github.com/YAXLib/YAXLib</PackageProjectUrl>
-        <PackageIcon>YAXLib_256x256.png</PackageIcon>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageTags>XML Serialization Serializer Serialize Deserialize .NETFramework .NETStandard .NET</PackageTags>
-        <PackageReleaseNotes></PackageReleaseNotes>
-    </PropertyGroup>
-    
-    <ItemGroup>
-        <None Include="../Logo/YAXLib_256x256.png" Pack="true" Visible="false" PackagePath="" />
-    </ItemGroup>
-    
-    <ItemGroup>
-        <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-    
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>YAXLibTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d7f87eefee568e19ff867da48567811d16853dbc045adcae7a9682012ad27a39dd24c9959db4e87965a589859f8a2cfc33c2d4997bf969dc4baa159ceefe1a85f45368d76918c764df03763848f50370e660da01bb4b2614fb67f8d0f7183c0c640b16c61d47628d8e4ba20f86dc6bab11b0528425efd05607c28ac576f92ca1</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
-    
+
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../Key/YAXLib.DevKey.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <PackageId>YAXLib</PackageId>
+    <Title>YAXLib</Title>
+    <Description>YAXLib is an XML Serialization library which allows the programmer to structure freely the XML result, choose the fields to serialize (public, or non-public properties, or member variables), serialize all known generic and non-generic collections, serialize different kinds of arrays (single-dimensional, multi-dimensional, and jagged arrays), serialize objects through a reference to their base-class or interface (polymorphic serialization), define custom serializers, add comments for the elements in the XML result, and many more ...</Description>
+    <PackageProjectUrl>https://github.com/YAXLib/YAXLib</PackageProjectUrl>
+    <PackageIcon>YAXLib_256x256.png</PackageIcon>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>XML Serialization Serializer Serialize Deserialize .NETFramework .NETStandard .NET</PackageTags>
+    <PackageReleaseNotes></PackageReleaseNotes>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../Logo/YAXLib_256x256.png" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>YAXLibTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d7f87eefee568e19ff867da48567811d16853dbc045adcae7a9682012ad27a39dd24c9959db4e87965a589859f8a2cfc33c2d4997bf969dc4baa159ceefe1a85f45368d76918c764df03763848f50370e660da01bb4b2614fb67f8d0f7183c0c640b16c61d47628d8e4ba20f86dc6bab11b0528425efd05607c28ac576f92ca1</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <SignAssembly>true</SignAssembly>
-        <AssemblyOriginatorKeyFile>../Key/YAXLib.DevKey.snk</AssemblyOriginatorKeyFile>
-        <DelaySign>false</DelaySign>
-        <TargetFrameworks>net462;net5.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../Key/YAXLib.DevKey.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+    <TargetFrameworks>net462;net5.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="NUnit" Version="3.13.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\YAXLib\YAXLib.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\YAXLib\YAXLib.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
some csproj has 2 spaces, other 4.

It was confusing, as without the .editorcondig the format document made it 2 spaces. It's now explicit and fixed for all csprojs


hint for review:

![image](https://user-images.githubusercontent.com/5808377/111508712-4e8c1680-874c-11eb-9156-3db4ac1b8cb3.png)
