### PR TITLE
Remove Hungarian notation

### DIFF
--- a/YAXLib/Attributes/YAXSerializableTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializableTypeAttribute.cs
@@ -37,7 +37,7 @@ namespace YAXLib
         /// </returns>
         public bool IsSerializationOptionSet()
         {
-            return m_isOptionSet;
+            return _isOptionSet;
         }
 
         #endregion
@@ -48,12 +48,12 @@ namespace YAXLib
         ///     determines whether the serialization options property has been explicitly
         ///     set by the user.
         /// </summary>
-        private bool m_isOptionSet;
+        private bool _isOptionSet;
 
         /// <summary>
         ///     Private variable to hold the serialization options
         /// </summary>
-        private YAXSerializationOptions m_serializationOptions = YAXSerializationOptions.SerializeNullObjects;
+        private YAXSerializationOptions _serializationOptions = YAXSerializationOptions.SerializeNullObjects;
 
         #endregion
 
@@ -71,12 +71,12 @@ namespace YAXLib
         /// <value>The options.</value>
         public YAXSerializationOptions Options
         {
-            get { return m_serializationOptions; }
+            get { return _serializationOptions; }
 
             set
             {
-                m_serializationOptions = value;
-                m_isOptionSet = true;
+                _serializationOptions = value;
+                _isOptionSet = true;
             }
         }
 

--- a/YAXLib/EnumWrapper.cs
+++ b/YAXLib/EnumWrapper.cs
@@ -15,12 +15,12 @@ namespace YAXLib
         /// <summary>
         ///     maps real enum names to their corresponding user defined aliases
         /// </summary>
-        private readonly Dictionary<string, string> m_enumMembers = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> _enumMembers = new Dictionary<string, string>();
 
         /// <summary>
         ///     The enum underlying type
         /// </summary>
-        private readonly Type m_enumType;
+        private readonly Type _enumType;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="EnumWrapper" /> class.
@@ -31,7 +31,7 @@ namespace YAXLib
             if (!t.IsEnum)
                 throw new ArithmeticException();
 
-            m_enumType = t;
+            _enumType = t;
 
             foreach (var m in t.GetFields())
                 if (m.FieldType == t)
@@ -44,10 +44,10 @@ namespace YAXLib
 
                     if (alias != originalName)
                     {
-                        if (!m_enumMembers.ContainsKey(alias))
-                            m_enumMembers.Add(m.Name, alias);
-                        else if (!m_enumMembers.ContainsKey(originalName))
-                            m_enumMembers.Add(m.Name, originalName);
+                        if (!_enumMembers.ContainsKey(alias))
+                            _enumMembers.Add(m.Name, alias);
+                        else if (!_enumMembers.ContainsKey(originalName))
+                            _enumMembers.Add(m.Name, originalName);
                         else
                             throw new YAXException("Enum alias already exists");
                     }
@@ -76,7 +76,7 @@ namespace YAXLib
                     sb.Append(realName);
                 }
 
-                return Enum.Parse(m_enumType, sb.ToString());
+                return Enum.Parse(_enumType, sb.ToString());
             }
 
             throw new Exception("Invalid enum alias");
@@ -96,7 +96,7 @@ namespace YAXLib
             if (components.Length == 1)
             {
                 string alias;
-                if (m_enumMembers.TryGetValue(originalName, out alias))
+                if (_enumMembers.TryGetValue(originalName, out alias))
                     return alias;
                 return enumMember;
             }
@@ -110,7 +110,7 @@ namespace YAXLib
                         result.Append(", ");
 
                     string alias;
-                    if (m_enumMembers.TryGetValue(components[i], out alias))
+                    if (_enumMembers.TryGetValue(components[i], out alias))
                         result.Append(alias);
                     else
                         result.Append(components[i]);
@@ -130,7 +130,7 @@ namespace YAXLib
         private string FindRealNameFromAlias(string alias)
         {
             alias = alias.Trim();
-            foreach (var pair in m_enumMembers)
+            foreach (var pair in _enumMembers)
                 if (pair.Value == alias)
                     return pair.Key;
 

--- a/YAXLib/KnownTypes/KnownTypes.cs
+++ b/YAXLib/KnownTypes/KnownTypes.cs
@@ -18,9 +18,9 @@ namespace YAXLib
     /// </summary>
     internal class KnownTypes
     {
-        private static readonly Dictionary<Type, IKnownType> s_dictKnownTypes = new Dictionary<Type, IKnownType>();
+        private static readonly Dictionary<Type, IKnownType> _dictKnownTypes = new Dictionary<Type, IKnownType>();
 
-        private static readonly Dictionary<string, IKnownType> s_dictDynamicKnownTypes =
+        private static readonly Dictionary<string, IKnownType> _dictDynamicKnownTypes =
             new Dictionary<string, IKnownType>();
 
         static KnownTypes()
@@ -41,17 +41,17 @@ namespace YAXLib
 
         public static void Add(IKnownType kt)
         {
-            s_dictKnownTypes[kt.Type] = kt;
+            _dictKnownTypes[kt.Type] = kt;
         }
 
         public static void AddDynamicKnownType(DynamicKnownType dkt)
         {
-            s_dictDynamicKnownTypes[dkt.TypeName] = dkt;
+            _dictDynamicKnownTypes[dkt.TypeName] = dkt;
         }
 
         public static bool IsKnowType(Type type)
         {
-            return s_dictKnownTypes.ContainsKey(type) || s_dictDynamicKnownTypes.ContainsKey(type.FullName);
+            return _dictKnownTypes.ContainsKey(type) || _dictDynamicKnownTypes.ContainsKey(type.FullName);
         }
 
         public static void Serialize(object obj, XElement elem, XNamespace overridingNamespace)
@@ -59,18 +59,18 @@ namespace YAXLib
             if (obj == null)
                 return;
 
-            if (s_dictKnownTypes.ContainsKey(obj.GetType()))
-                s_dictKnownTypes[obj.GetType()].Serialize(obj, elem, overridingNamespace);
-            else if (s_dictDynamicKnownTypes.ContainsKey(obj.GetType().FullName))
-                s_dictDynamicKnownTypes[obj.GetType().FullName].Serialize(obj, elem, overridingNamespace);
+            if (_dictKnownTypes.ContainsKey(obj.GetType()))
+                _dictKnownTypes[obj.GetType()].Serialize(obj, elem, overridingNamespace);
+            else if (_dictDynamicKnownTypes.ContainsKey(obj.GetType().FullName))
+                _dictDynamicKnownTypes[obj.GetType().FullName].Serialize(obj, elem, overridingNamespace);
         }
 
         public static object Deserialize(XElement elem, Type type, XNamespace overridingNamespace)
         {
-            if (s_dictKnownTypes.ContainsKey(type))
-                return s_dictKnownTypes[type].Deserialize(elem, overridingNamespace);
-            if (s_dictDynamicKnownTypes.ContainsKey(type.FullName))
-                return s_dictDynamicKnownTypes[type.FullName].Deserialize(elem, overridingNamespace);
+            if (_dictKnownTypes.ContainsKey(type))
+                return _dictKnownTypes[type].Deserialize(elem, overridingNamespace);
+            if (_dictDynamicKnownTypes.ContainsKey(type.FullName))
+                return _dictDynamicKnownTypes[type.FullName].Deserialize(elem, overridingNamespace);
             return null;
         }
     }

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -17,73 +17,73 @@ namespace YAXLib
         /// <summary>
         ///     the <c>FieldInfo</c> instance, if this member corresponds to a field, <c>null</c> otherwise
         /// </summary>
-        private readonly FieldInfo m_fieldInfoInstance;
+        private readonly FieldInfo _fieldInfoInstance;
 
         /// <summary>
         ///     <c>true</c> if this instance corresponds to a property, <c>false</c>
         ///     if it corresponds to a field (i.e., a member variable)
         /// </summary>
-        private readonly bool m_isProperty;
+        private readonly bool _isProperty;
 
         /// <summary>
         ///     reference to the underlying <c>MemberInfo</c> from which this instance is built
         /// </summary>
-        private readonly MemberInfo m_memberInfo;
+        private readonly MemberInfo _memberInfo;
 
         /// <summary>
         ///     the member type of the underlying member
         /// </summary>
-        private readonly Type m_memberType;
+        private readonly Type _memberType;
 
         /// <summary>
         ///     a type wrapper around the underlying member type
         /// </summary>
-        private readonly UdtWrapper m_memberTypeWrapper;
+        private readonly UdtWrapper _memberTypeWrapper;
 
-        private readonly List<YAXCollectionItemTypeAttribute> m_possibleCollectionItemRealTypes =
+        private readonly List<YAXCollectionItemTypeAttribute> _possibleCollectionItemRealTypes =
             new List<YAXCollectionItemTypeAttribute>();
 
-        private readonly List<YAXTypeAttribute> m_possibleRealTypes = new List<YAXTypeAttribute>();
+        private readonly List<YAXTypeAttribute> _possibleRealTypes = new List<YAXTypeAttribute>();
 
         /// <summary>
         ///     the <c>PropertyInfo</c> instance, if this member corresponds to a property, <c>null</c> otherwise
         /// </summary>
-        private readonly PropertyInfo m_propertyInfoInstance;
+        private readonly PropertyInfo _propertyInfoInstance;
 
         /// <summary>
         ///     The alias specified by the user
         /// </summary>
-        private XName m_alias;
+        private XName _alias;
 
         /// <summary>
         ///     The collection attribute instance
         /// </summary>
-        private YAXCollectionAttribute m_collectionAttributeInstance;
+        private YAXCollectionAttribute _collectionAttributeInstance;
 
         /// <summary>
         ///     the dictionary attribute instance
         /// </summary>
-        private YAXDictionaryAttribute m_dictionaryAttributeInstance;
+        private YAXDictionaryAttribute _dictionaryAttributeInstance;
 
         /// <summary>
         ///     specifies whether this member is going to be serialized as an attribute
         /// </summary>
-        private bool m_isSerializedAsAttribute;
+        private bool _isSerializedAsAttribute;
 
         /// <summary>
         ///     specifies whether this member is going to be serialized as a value for another element
         /// </summary>
-        private bool m_isSerializedAsValue;
+        private bool _isSerializedAsValue;
 
         /// <summary>
         ///     The xml-namespace this member is going to be serialized under.
         /// </summary>
-        private XNamespace m_namespace = XNamespace.None;
+        private XNamespace _namespace = XNamespace.None;
 
         /// <summary>
         ///     The location of the serialization
         /// </summary>
-        private string m_serializationLocation = "";
+        private string _serializationLocation = "";
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="MemberWrapper" /> class.
@@ -97,23 +97,23 @@ namespace YAXLib
             if (!(memberInfo.MemberType == MemberTypes.Property || memberInfo.MemberType == MemberTypes.Field))
                 throw new Exception("Member must be either property or field");
 
-            m_memberInfo = memberInfo;
-            m_isProperty = memberInfo.MemberType == MemberTypes.Property;
+            _memberInfo = memberInfo;
+            _isProperty = memberInfo.MemberType == MemberTypes.Property;
 
-            Alias = StringUtils.RefineSingleElement(m_memberInfo.Name);
+            Alias = StringUtils.RefineSingleElement(_memberInfo.Name);
 
-            if (m_isProperty)
-                m_propertyInfoInstance = (PropertyInfo) memberInfo;
+            if (_isProperty)
+                _propertyInfoInstance = (PropertyInfo) memberInfo;
             else
-                m_fieldInfoInstance = (FieldInfo) memberInfo;
+                _fieldInfoInstance = (FieldInfo) memberInfo;
 
-            m_memberType = m_isProperty ? m_propertyInfoInstance.PropertyType : m_fieldInfoInstance.FieldType;
+            _memberType = _isProperty ? _propertyInfoInstance.PropertyType : _fieldInfoInstance.FieldType;
 
-            m_memberTypeWrapper = TypeWrappersPool.Pool.GetTypeWrapper(MemberType, callerSerializer);
-            if (m_memberTypeWrapper.HasNamespace)
+            _memberTypeWrapper = TypeWrappersPool.Pool.GetTypeWrapper(MemberType, callerSerializer);
+            if (_memberTypeWrapper.HasNamespace)
             {
-                Namespace = m_memberTypeWrapper.Namespace;
-                NamespacePrefix = m_memberTypeWrapper.NamespacePrefix;
+                Namespace = _memberTypeWrapper.Namespace;
+                NamespacePrefix = _memberTypeWrapper.NamespacePrefix;
             }
 
             InitInstance();
@@ -125,11 +125,11 @@ namespace YAXLib
                 {typeof(YAXCustomSerializerAttribute), typeof(YAXCollectionAttribute)};
             foreach (var attrType in attrsToProcessEarlier)
             {
-                var customSerAttrs = Attribute.GetCustomAttributes(m_memberInfo, attrType, true);
+                var customSerAttrs = Attribute.GetCustomAttributes(_memberInfo, attrType, true);
                 foreach (var attr in customSerAttrs) ProcessYaxAttribute(attr);
             }
 
-            foreach (var attr in Attribute.GetCustomAttributes(m_memberInfo, true))
+            foreach (var attr in Attribute.GetCustomAttributes(_memberInfo, true))
             {
                 // no need to process, it has been processed earlier
                 if (attrsToProcessEarlier.Contains(attr.GetType()))
@@ -142,12 +142,12 @@ namespace YAXLib
             // now override some values from member-type-wrapper into member-wrapper
             // if member-type has collection attributes while the member itself does not have them, 
             // then use those of the member-type
-            if (m_collectionAttributeInstance == null && m_memberTypeWrapper.CollectionAttributeInstance != null)
-                m_collectionAttributeInstance = m_memberTypeWrapper.CollectionAttributeInstance;
-            m_memberInfo.GetCustomAttributes(true);
+            if (_collectionAttributeInstance == null && _memberTypeWrapper.CollectionAttributeInstance != null)
+                _collectionAttributeInstance = _memberTypeWrapper.CollectionAttributeInstance;
+            _memberInfo.GetCustomAttributes(true);
 
-            if (m_dictionaryAttributeInstance == null && m_memberTypeWrapper.DictionaryAttributeInstance != null)
-                m_dictionaryAttributeInstance = m_memberTypeWrapper.DictionaryAttributeInstance;
+            if (_dictionaryAttributeInstance == null && _memberTypeWrapper.DictionaryAttributeInstance != null)
+                _dictionaryAttributeInstance = _memberTypeWrapper.DictionaryAttributeInstance;
         }
 
         /// <summary>
@@ -156,19 +156,19 @@ namespace YAXLib
         /// <value>The alias specified for this member.</value>
         public XName Alias
         {
-            get { return m_alias; }
+            get { return _alias; }
 
             private set
             {
                 if (Namespace.IsEmpty())
                 {
-                    m_alias = Namespace + value.LocalName;
+                    _alias = Namespace + value.LocalName;
                 }
                 else
                 {
-                    m_alias = value;
-                    if (m_alias.Namespace.IsEmpty())
-                        m_namespace = m_alias.Namespace;
+                    _alias = value;
+                    if (_alias.Namespace.IsEmpty())
+                        _namespace = _alias.Namespace;
                 }
             }
         }
@@ -181,8 +181,8 @@ namespace YAXLib
         {
             get
             {
-                if (m_isProperty)
-                    return m_propertyInfoInstance.CanRead;
+                if (_isProperty)
+                    return _propertyInfoInstance.CanRead;
                 return true;
             }
         }
@@ -195,8 +195,8 @@ namespace YAXLib
         {
             get
             {
-                if (m_isProperty)
-                    return m_propertyInfoInstance.CanWrite;
+                if (_isProperty)
+                    return _propertyInfoInstance.CanWrite;
                 return true;
             }
         }
@@ -277,14 +277,14 @@ namespace YAXLib
         /// </value>
         public bool IsSerializedAsAttribute
         {
-            get { return m_isSerializedAsAttribute; }
+            get { return _isSerializedAsAttribute; }
 
             private set
             {
-                m_isSerializedAsAttribute = value;
+                _isSerializedAsAttribute = value;
                 if (value)
                     // a field cannot be both serialized as an attribute and a value
-                    m_isSerializedAsValue = false;
+                    _isSerializedAsValue = false;
             }
         }
 
@@ -296,14 +296,14 @@ namespace YAXLib
         /// </value>
         public bool IsSerializedAsValue
         {
-            get { return m_isSerializedAsValue; }
+            get { return _isSerializedAsValue; }
 
             private set
             {
-                m_isSerializedAsValue = value;
+                _isSerializedAsValue = value;
                 if (value)
                     // a field cannot be both serialized as an attribute and a value
-                    m_isSerializedAsAttribute = false;
+                    _isSerializedAsAttribute = false;
             }
         }
 
@@ -322,8 +322,8 @@ namespace YAXLib
             {
                 if (value)
                 {
-                    m_isSerializedAsAttribute = false;
-                    m_isSerializedAsValue = false;
+                    _isSerializedAsAttribute = false;
+                    _isSerializedAsValue = false;
                 }
             }
         }
@@ -332,24 +332,24 @@ namespace YAXLib
         ///     Gets the type of the member.
         /// </summary>
         /// <value>The type of the member.</value>
-        public Type MemberType => m_memberType;
+        public Type MemberType => _memberType;
 
         /// <summary>
         ///     Gets the type wrapper instance corresponding to the member-type of this instance.
         /// </summary>
         /// <value>The type wrapper instance corresponding to the member-type of this instance.</value>
-        public UdtWrapper MemberTypeWrapper => m_memberTypeWrapper;
+        public UdtWrapper MemberTypeWrapper => _memberTypeWrapper;
 
         /// <summary>
         ///     Gets a value indicating whether the underlying type is a known-type
         /// </summary>
-        public bool IsKnownType => m_memberTypeWrapper.IsKnownType;
+        public bool IsKnownType => _memberTypeWrapper.IsKnownType;
 
         /// <summary>
         ///     Gets the original of this member (as opposed to its alias).
         /// </summary>
         /// <value>The original of this member .</value>
-        public string OriginalName => m_memberInfo.Name;
+        public string OriginalName => _memberInfo.Name;
 
         /// <summary>
         ///     Gets the serialization location.
@@ -357,9 +357,9 @@ namespace YAXLib
         /// <value>The serialization location.</value>
         public string SerializationLocation
         {
-            get { return m_serializationLocation; }
+            get { return _serializationLocation; }
 
-            private set { m_serializationLocation = StringUtils.RefineLocationString(value); }
+            private set { _serializationLocation = StringUtils.RefineLocationString(value); }
         }
 
         /// <summary>
@@ -372,13 +372,13 @@ namespace YAXLib
         ///     Gets the collection attribute instance.
         /// </summary>
         /// <value>The collection attribute instance.</value>
-        public YAXCollectionAttribute CollectionAttributeInstance => m_collectionAttributeInstance;
+        public YAXCollectionAttribute CollectionAttributeInstance => _collectionAttributeInstance;
 
         /// <summary>
         ///     Gets the dictionary attribute instance.
         /// </summary>
         /// <value>The dictionary attribute instance.</value>
-        public YAXDictionaryAttribute DictionaryAttributeInstance => m_dictionaryAttributeInstance;
+        public YAXDictionaryAttribute DictionaryAttributeInstance => _dictionaryAttributeInstance;
 
         /// <summary>
         ///     Gets a value indicating whether this instance is treated as a collection.
@@ -386,7 +386,7 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance is treated as a collection; otherwise, <c>false</c>.
         /// </value>
-        public bool IsTreatedAsCollection => !IsAttributedAsNotCollection && m_memberTypeWrapper.IsTreatedAsCollection;
+        public bool IsTreatedAsCollection => !IsAttributedAsNotCollection && _memberTypeWrapper.IsTreatedAsCollection;
 
         /// <summary>
         ///     Gets a value indicating whether this instance is treated as a dictionary.
@@ -394,7 +394,7 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance is treated as a dictionary; otherwise, <c>false</c>.
         /// </value>
-        public bool IsTreatedAsDictionary => !IsAttributedAsNotCollection && m_memberTypeWrapper.IsTreatedAsDictionary;
+        public bool IsTreatedAsDictionary => !IsAttributedAsNotCollection && _memberTypeWrapper.IsTreatedAsDictionary;
 
         /// <summary>
         ///     Gets or sets the type of the custom serializer.
@@ -429,13 +429,13 @@ namespace YAXLib
         /// </remarks>
         public XNamespace Namespace
         {
-            get { return m_namespace; }
+            get { return _namespace; }
 
             private set
             {
-                m_namespace = value;
+                _namespace = value;
                 // explicit namespace definition overrides namespace definitions in SerializeAs attributes.
-                m_alias = m_namespace + m_alias.LocalName;
+                _alias = _namespace + _alias.LocalName;
             }
         }
 
@@ -464,7 +464,7 @@ namespace YAXLib
         // TODO: move to public methods section
         public YAXTypeAttribute GetRealTypeDefinition(Type type)
         {
-            return m_possibleRealTypes.FirstOrDefault(x => ReferenceEquals(x.Type, type));
+            return _possibleRealTypes.FirstOrDefault(x => ReferenceEquals(x.Type, type));
         }
 
 
@@ -478,9 +478,9 @@ namespace YAXLib
         /// <returns>the original value of this member in the specified object</returns>
         public object GetOriginalValue(object obj, object[] index)
         {
-            if (m_isProperty)
-                return m_propertyInfoInstance.GetValue(obj, index);
-            return m_fieldInfoInstance.GetValue(obj);
+            if (_isProperty)
+                return _propertyInfoInstance.GetValue(obj, index);
+            return _fieldInfoInstance.GetValue(obj);
         }
 
         /// <summary>
@@ -495,7 +495,7 @@ namespace YAXLib
             if (elementValue == null)
                 return null;
 
-            if (m_memberTypeWrapper.IsEnum) return m_memberTypeWrapper.EnumWrapper.GetAlias(elementValue);
+            if (_memberTypeWrapper.IsEnum) return _memberTypeWrapper.EnumWrapper.GetAlias(elementValue);
 
             // trying to build the element value
             if (HasFormat && !IsTreatedAsCollection)
@@ -513,10 +513,10 @@ namespace YAXLib
         /// <param name="value">The value.</param>
         public void SetValue(object obj, object value)
         {
-            if (m_isProperty)
-                m_propertyInfoInstance.SetValue(obj, value, null);
+            if (_isProperty)
+                _propertyInfoInstance.SetValue(obj, value, null);
             else
-                m_fieldInfoInstance.SetValue(obj, value);
+                _fieldInfoInstance.SetValue(obj, value);
         }
 
         /// <summary>
@@ -530,7 +530,7 @@ namespace YAXLib
         public bool IsAllowedToBeSerialized(YAXSerializationFields serializationFields,
             bool dontSerializePropertiesWithNoSetter)
         {
-            if (dontSerializePropertiesWithNoSetter && m_isProperty && !m_propertyInfoInstance.CanWrite)
+            if (dontSerializePropertiesWithNoSetter && _isProperty && !_propertyInfoInstance.CanWrite)
                 return false;
 
             if (serializationFields == YAXSerializationFields.AllFields)
@@ -538,8 +538,8 @@ namespace YAXLib
             if (serializationFields == YAXSerializationFields.AttributedFieldsOnly)
                 return !IsAttributedAsDontSerialize && IsAttributedAsSerializable;
             if (serializationFields == YAXSerializationFields.PublicPropertiesOnly)
-                return !IsAttributedAsDontSerialize && m_isProperty &&
-                       ReflectionUtils.IsPublicProperty(m_propertyInfoInstance);
+                return !IsAttributedAsDontSerialize && _isProperty &&
+                       ReflectionUtils.IsPublicProperty(_propertyInfoInstance);
             throw new Exception("Unknown serialization field option");
         }
 
@@ -551,7 +551,7 @@ namespace YAXLib
         /// </returns>
         public override string ToString()
         {
-            return m_memberInfo.ToString();
+            return _memberInfo.ToString();
         }
 
         // Private Methods 
@@ -609,7 +609,7 @@ namespace YAXLib
             {
                 // it is required that YAXCustomSerializerAttribute is processed earlier
                 if (ReflectionUtils.IsBasicType(MemberType) || CustomSerializerType != null ||
-                    m_collectionAttributeInstance != null && m_collectionAttributeInstance.SerializationType ==
+                    _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
                 {
                     IsSerializedAsAttribute = true;
@@ -620,7 +620,7 @@ namespace YAXLib
             {
                 // it is required that YAXCustomSerializerAttribute is processed earlier
                 if (ReflectionUtils.IsBasicType(MemberType) || CustomSerializerType != null ||
-                    m_collectionAttributeInstance != null && m_collectionAttributeInstance.SerializationType ==
+                    _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
                 {
                     IsSerializedAsValue = true;
@@ -631,7 +631,7 @@ namespace YAXLib
             {
                 // it is required that YAXCustomSerializerAttribute is processed earlier
                 if (ReflectionUtils.IsBasicType(MemberType) || CustomSerializerType != null ||
-                    m_collectionAttributeInstance != null && m_collectionAttributeInstance.SerializationType ==
+                    _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
                 {
                     IsSerializedAsAttribute = true;
@@ -660,7 +660,7 @@ namespace YAXLib
             {
                 // it is required that YAXCustomSerializerAttribute is processed earlier
                 if (ReflectionUtils.IsBasicType(MemberType) || CustomSerializerType != null ||
-                    m_collectionAttributeInstance != null && m_collectionAttributeInstance.SerializationType ==
+                    _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
                 {
                     IsSerializedAsValue = true;
@@ -684,11 +684,11 @@ namespace YAXLib
             }
             else if (attr is YAXCollectionAttribute)
             {
-                m_collectionAttributeInstance = attr as YAXCollectionAttribute;
+                _collectionAttributeInstance = attr as YAXCollectionAttribute;
             }
             else if (attr is YAXDictionaryAttribute)
             {
-                m_dictionaryAttributeInstance = attr as YAXDictionaryAttribute;
+                _dictionaryAttributeInstance = attr as YAXDictionaryAttribute;
             }
             else if (attr is YAXErrorIfMissedAttribute)
             {
@@ -748,17 +748,17 @@ namespace YAXLib
                         alias = null;
                 }
 
-                if (m_possibleRealTypes.Any(x => x.Type == yaxTypeAttr.Type))
+                if (_possibleRealTypes.Any(x => x.Type == yaxTypeAttr.Type))
                     throw new YAXPolymorphicException(string.Format(
                         "The type \"{0}\" for field/property \"{1}\" has already been defined through another attribute.",
-                        yaxTypeAttr.Type.Name, m_memberInfo));
+                        yaxTypeAttr.Type.Name, _memberInfo));
 
-                if (alias != null && m_possibleRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
+                if (alias != null && _possibleRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
                     throw new YAXPolymorphicException(string.Format(
                         "The alias \"{0}\" given to type \"{1}\" for field/property \"{2}\" has already been given to another type through another attribute.",
-                        alias, yaxTypeAttr.Type.Name, m_memberInfo));
+                        alias, yaxTypeAttr.Type.Name, _memberInfo));
 
-                m_possibleRealTypes.Add(yaxTypeAttr);
+                _possibleRealTypes.Add(yaxTypeAttr);
             }
             else if (attr is YAXCollectionItemTypeAttribute)
             {
@@ -771,18 +771,18 @@ namespace YAXLib
                         alias = null;
                 }
 
-                if (m_possibleCollectionItemRealTypes.Any(x => x.Type == yaxColletionItemTypeAttr.Type))
+                if (_possibleCollectionItemRealTypes.Any(x => x.Type == yaxColletionItemTypeAttr.Type))
                     throw new YAXPolymorphicException(string.Format(
                         "The collection-item type \"{0}\" for collection \"{1}\" has already been defined through another attribute.",
-                        yaxColletionItemTypeAttr.Type.Name, m_memberInfo));
+                        yaxColletionItemTypeAttr.Type.Name, _memberInfo));
 
                 if (alias != null &&
-                    m_possibleCollectionItemRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
+                    _possibleCollectionItemRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
                     throw new YAXPolymorphicException(string.Format(
                         "The alias \"{0}\" given to collection-item type \"{1}\" for field/property \"{2}\" has already been given to another type through another attribute.",
-                        alias, yaxColletionItemTypeAttr.Type.Name, m_memberInfo));
+                        alias, yaxColletionItemTypeAttr.Type.Name, _memberInfo));
 
-                m_possibleCollectionItemRealTypes.Add(yaxColletionItemTypeAttr);
+                _possibleCollectionItemRealTypes.Add(yaxColletionItemTypeAttr);
             }
             else if (attr is YAXDontSerializeIfNullAttribute)
             {

--- a/YAXLib/TypeWrappersPool.cs
+++ b/YAXLib/TypeWrappersPool.cs
@@ -15,17 +15,17 @@ namespace YAXLib
         /// <summary>
         ///     The instance to the pool, to implement the singleton
         /// </summary>
-        private static TypeWrappersPool s_instance;
+        private static TypeWrappersPool _instance;
 
         /// <summary>
         ///     A dictionary from types to their corresponding wrappers
         /// </summary>
-        private readonly Dictionary<Type, UdtWrapper> m_dicTypes = new Dictionary<Type, UdtWrapper>();
+        private readonly Dictionary<Type, UdtWrapper> _dicTypes = new Dictionary<Type, UdtWrapper>();
 
         /// <summary>
         ///     An object to lock type-wrapper dictionary to make it thread-safe
         /// </summary>
-        private readonly object m_lockDic = new object();
+        private readonly object _lockDic = new object();
 
         /// <summary>
         ///     Prevents a default instance of the <c>TypeWrappersPool</c> class from being created, from
@@ -43,9 +43,9 @@ namespace YAXLib
         {
             get
             {
-                if (s_instance == null)
-                    s_instance = new TypeWrappersPool();
-                return s_instance;
+                if (_instance == null)
+                    _instance = new TypeWrappersPool();
+                return _instance;
             }
         }
 
@@ -54,9 +54,9 @@ namespace YAXLib
         /// </summary>
         public static void CleanUp()
         {
-            if (s_instance != null)
+            if (_instance != null)
             {
-                s_instance = null;
+                _instance = null;
                 // TODO: not sure if it's good work to do
                 GC.Collect();
             }
@@ -70,13 +70,13 @@ namespace YAXLib
         /// <returns>the type wrapper corresponding to the specified type</returns>
         public UdtWrapper GetTypeWrapper(Type t, YAXSerializer caller)
         {
-            lock (m_lockDic)
+            lock (_lockDic)
             {
                 UdtWrapper result;
-                if (!m_dicTypes.TryGetValue(t, out result))
+                if (!_dicTypes.TryGetValue(t, out result))
                 {
                     result = new UdtWrapper(t, caller);
-                    m_dicTypes.Add(t, result);
+                    _dicTypes.Add(t, result);
                 }
                 else
                 {

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -14,48 +14,48 @@ namespace YAXLib
         /// <summary>
         ///     boolean value indicating whether this instance is a wrapper around a collection type
         /// </summary>
-        private readonly bool m_isTypeCollection;
+        private readonly bool _isTypeCollection;
 
         /// <summary>
         ///     boolean value indicating whether this instance is a wrapper around a dictionary type
         /// </summary>
-        private readonly bool m_isTypeDictionary;
+        private readonly bool _isTypeDictionary;
 
         /// <summary>
         ///     the underlying type for this instance of <c>TypeWrapper</c>
         /// </summary>
-        private readonly Type m_udtType = typeof(object);
+        private readonly Type _udtType = typeof(object);
 
         /// <summary>
         ///     Alias for the type
         /// </summary>
-        private XName m_alias;
+        private XName _alias;
 
         /// <summary>
         ///     The collection attribute instance
         /// </summary>
-        private YAXCollectionAttribute m_collectionAttributeInstance;
+        private YAXCollectionAttribute _collectionAttributeInstance;
 
         /// <summary>
         ///     the dictionary attribute instance
         /// </summary>
-        private YAXDictionaryAttribute m_dictionaryAttributeInstance;
+        private YAXDictionaryAttribute _dictionaryAttributeInstance;
 
         /// <summary>
         ///     reference to an instance of <c>EnumWrapper</c> in case that the current instance is an enum.
         /// </summary>
-        private EnumWrapper m_enumWrapper;
+        private EnumWrapper _enumWrapper;
 
         /// <summary>
         ///     value indicating whether the serialization options has been explicitly adjusted
         ///     using attributes for the class
         /// </summary>
-        private bool m_isSerializationOptionSetByAttribute;
+        private bool _isSerializationOptionSetByAttribute;
 
         /// <summary>
         ///     the namespace associated with this element
         /// </summary>
-        private XNamespace m_namespace = XNamespace.None;
+        private XNamespace _namespace = XNamespace.None;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="UdtWrapper" /> class.
@@ -67,19 +67,19 @@ namespace YAXLib
         /// </param>
         public UdtWrapper(Type udtType, YAXSerializer callerSerializer)
         {
-            m_isTypeDictionary = false;
-            m_udtType = udtType;
-            m_isTypeCollection = ReflectionUtils.IsCollectionType(m_udtType);
-            m_isTypeDictionary = ReflectionUtils.IsIDictionary(m_udtType);
+            _isTypeDictionary = false;
+            _udtType = udtType;
+            _isTypeCollection = ReflectionUtils.IsCollectionType(_udtType);
+            _isTypeDictionary = ReflectionUtils.IsIDictionary(_udtType);
 
-            Alias = StringUtils.RefineSingleElement(ReflectionUtils.GetTypeFriendlyName(m_udtType));
+            Alias = StringUtils.RefineSingleElement(ReflectionUtils.GetTypeFriendlyName(_udtType));
             Comment = null;
             FieldsToSerialize = YAXSerializationFields.PublicPropertiesOnly;
             IsAttributedAsNotCollection = false;
 
             SetYAXSerializerOptions(callerSerializer);
             
-            foreach (var attr in m_udtType.GetCustomAttributes(true))
+            foreach (var attr in _udtType.GetCustomAttributes(true))
                 if (attr is YAXBaseAttribute)
                     ProcessYAXAttribute(attr);
         }
@@ -90,19 +90,19 @@ namespace YAXLib
         /// <value>The alias of the type.</value>
         public XName Alias
         {
-            get { return m_alias; }
+            get { return _alias; }
 
             private set
             {
                 if (Namespace.IsEmpty())
                 {
-                    m_alias = Namespace + value.LocalName;
+                    _alias = Namespace + value.LocalName;
                 }
                 else
                 {
-                    m_alias = value;
-                    if (m_alias.Namespace.IsEmpty())
-                        m_namespace = m_alias.Namespace;
+                    _alias = value;
+                    if (_alias.Namespace.IsEmpty())
+                        _namespace = _alias.Namespace;
                 }
             }
         }
@@ -145,18 +145,18 @@ namespace YAXLib
         ///     Gets the underlying type corresponding to this wrapper.
         /// </summary>
         /// <value>The underlying type corresponding to this wrapper.</value>
-        public Type UnderlyingType => m_udtType;
+        public Type UnderlyingType => _udtType;
 
         /// <summary>
         ///     Gets a value indicating whether the underlying type is a known-type
         /// </summary>
-        public bool IsKnownType => KnownTypes.IsKnowType(m_udtType);
+        public bool IsKnownType => KnownTypes.IsKnowType(_udtType);
 
         /// <summary>
         ///     Gets a value indicating whether this instance wraps around an enum.
         /// </summary>
         /// <value><c>true</c> if this instance wraps around an enum; otherwise, <c>false</c>.</value>
-        public bool IsEnum => m_udtType.IsEnum;
+        public bool IsEnum => _udtType.IsEnum;
 
         /// <summary>
         ///     Gets the enum wrapper, provided that this instance wraps around an enum.
@@ -168,10 +168,10 @@ namespace YAXLib
             {
                 if (IsEnum)
                 {
-                    if (m_enumWrapper == null)
-                        m_enumWrapper = new EnumWrapper(m_udtType);
+                    if (_enumWrapper == null)
+                        _enumWrapper = new EnumWrapper(_udtType);
 
-                    return m_enumWrapper;
+                    return _enumWrapper;
                 }
 
                 return null;
@@ -217,7 +217,7 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance wraps around a collection type; otherwise, <c>false</c>.
         /// </value>
-        public bool IsCollectionType => m_isTypeCollection;
+        public bool IsCollectionType => _isTypeCollection;
 
         /// <summary>
         ///     Gets a value indicating whether this instance wraps around a dictionary type.
@@ -225,7 +225,7 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance wraps around a dictionary type; otherwise, <c>false</c>.
         /// </value>
-        public bool IsDictionaryType => m_isTypeDictionary;
+        public bool IsDictionaryType => _isTypeDictionary;
 
         /// <summary>
         ///     Gets a value indicating whether this instance is treated as collection.
@@ -247,13 +247,13 @@ namespace YAXLib
         ///     Gets the collection attribute instance.
         /// </summary>
         /// <value>The collection attribute instance.</value>
-        public YAXCollectionAttribute CollectionAttributeInstance => m_collectionAttributeInstance;
+        public YAXCollectionAttribute CollectionAttributeInstance => _collectionAttributeInstance;
 
         /// <summary>
         ///     Gets the dictionary attribute instance.
         /// </summary>
         /// <value>The dictionary attribute instance.</value>
-        public YAXDictionaryAttribute DictionaryAttributeInstance => m_dictionaryAttributeInstance;
+        public YAXDictionaryAttribute DictionaryAttributeInstance => _dictionaryAttributeInstance;
 
         /// <summary>
         ///     Gets or sets the type of the custom serializer.
@@ -286,13 +286,13 @@ namespace YAXLib
         /// </remarks>
         public XNamespace Namespace
         {
-            get { return m_namespace; }
+            get { return _namespace; }
 
             private set
             {
-                m_namespace = value;
+                _namespace = value;
                 // explicit namespace definition overrides namespace definitions in SerializeAs attributes.
-                m_alias = m_namespace + m_alias.LocalName;
+                _alias = _namespace + _alias.LocalName;
             }
         }
 
@@ -319,7 +319,7 @@ namespace YAXLib
         /// <param name="caller">The caller serializer.</param>
         public void SetYAXSerializerOptions(YAXSerializer caller)
         {
-            if (!m_isSerializationOptionSetByAttribute)
+            if (!_isSerializationOptionSetByAttribute)
                 SerializationOption = caller != null
                     ? caller.SerializationOption
                     : YAXSerializationOptions.SerializeNullObjects;
@@ -333,7 +333,7 @@ namespace YAXLib
         /// </returns>
         public override string ToString()
         {
-            return m_udtType.ToString();
+            return _udtType.ToString();
         }
 
         /// <summary>
@@ -353,7 +353,7 @@ namespace YAXLib
             if (obj is UdtWrapper)
             {
                 var other = obj as UdtWrapper;
-                return m_udtType == other.m_udtType;
+                return _udtType == other._udtType;
             }
 
             return false;
@@ -367,7 +367,7 @@ namespace YAXLib
         /// </returns>
         public override int GetHashCode()
         {
-            return m_udtType.GetHashCode();
+            return _udtType.GetHashCode();
         }
 
         /// <summary>
@@ -394,7 +394,7 @@ namespace YAXLib
                 if (theAttr.IsSerializationOptionSet())
                 {
                     SerializationOption = theAttr.Options;
-                    m_isSerializationOptionSetByAttribute = true;
+                    _isSerializationOptionSetByAttribute = true;
                 }
             }
             else if (attr is YAXSerializeAsAttribute)
@@ -403,7 +403,7 @@ namespace YAXLib
             }
             else if (attr is YAXNotCollectionAttribute)
             {
-                if (!ReflectionUtils.IsArray(m_udtType))
+                if (!ReflectionUtils.IsArray(_udtType))
                     IsAttributedAsNotCollection = true;
             }
             else if (attr is YAXCustomSerializerAttribute)
@@ -436,11 +436,11 @@ namespace YAXLib
             }
             else if (attr is YAXCollectionAttribute)
             {
-                m_collectionAttributeInstance = attr as YAXCollectionAttribute;
+                _collectionAttributeInstance = attr as YAXCollectionAttribute;
             }
             else if (attr is YAXDictionaryAttribute)
             {
-                m_dictionaryAttributeInstance = attr as YAXDictionaryAttribute;
+                _dictionaryAttributeInstance = attr as YAXDictionaryAttribute;
             }
             else
             {

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -27,42 +27,42 @@ namespace YAXLib
         /// <summary>
         ///     The exception error behaviour enumeration to be used by the YAX library.
         /// </summary>
-        private readonly YAXExceptionTypes m_defaultExceptionType = YAXExceptionTypes.Warning;
+        private readonly YAXExceptionTypes _defaultExceptionType = YAXExceptionTypes.Warning;
 
         /// <summary>
         ///     The handling policy enumeration to be used by the YAX library.
         /// </summary>
-        private readonly YAXExceptionHandlingPolicies m_exceptionPolicy = YAXExceptionHandlingPolicies.ThrowErrorsOnly;
+        private readonly YAXExceptionHandlingPolicies _exceptionPolicy = YAXExceptionHandlingPolicies.ThrowErrorsOnly;
 
         /// <summary>
         ///     a map of namespaces to their prefixes (if any) to be added utlimately to the xml result
         /// </summary>
-        private readonly Dictionary<XNamespace, string> m_namespaceToPrefix = new Dictionary<XNamespace, string>();
+        private readonly Dictionary<XNamespace, string> _namespaceToPrefix = new Dictionary<XNamespace, string>();
 
         /// <summary>
         ///     The list of all errors that have occured.
         /// </summary>
-        private readonly YAXParsingErrors m_parsingErrors = new YAXParsingErrors();
+        private readonly YAXParsingErrors _parsingErrors = new YAXParsingErrors();
 
         /// <summary>
         ///     The serialization option enumeration which can be set during initialization.
         /// </summary>
-        private readonly YAXSerializationOptions m_serializationOption = YAXSerializationOptions.SerializeNullObjects;
+        private readonly YAXSerializationOptions _serializationOption = YAXSerializationOptions.SerializeNullObjects;
 
         /// <summary>
         ///     a reference to the base xml element used during serialization.
         /// </summary>
-        private XElement m_baseElement;
+        private XElement _baseElement;
 
         /// <summary>
         ///     reference to a pre assigned deserialization base object
         /// </summary>
-        private object m_desObject;
+        private object _desObject;
 
         /// <summary>
         ///     the attribute name used to deserialize meta-data for multi-dimensional arrays.
         /// </summary>
-        private string m_dimsAttrName = "dims";
+        private string _dimsAttrName = "dims";
 
         /// <summary>
         ///     The main document's default namespace. This is stored so that if an attribute has the default namespace,
@@ -70,54 +70,54 @@ namespace YAXLib
         ///     and attributes without any namespace must adapt this namespace. It is just for comparison and control
         ///     purposes.
         /// </summary>
-        private XNamespace m_documentDefaultNamespace;
+        private XNamespace _documentDefaultNamespace;
 
         /// <summary>
         ///     Specifies whether an exception is occurred during the deserialization of the current member
         /// </summary>
-        private bool m_exceptionOccurredDuringMemberDeserialization;
+        private bool _exceptionOccurredDuringMemberDeserialization;
 
         /// <summary>
         ///     <c>true</c> if this instance is busy serializing objects, <c>false</c> otherwise.
         /// </summary>
-        private bool m_isSerializing;
+        private bool _isSerializing;
 
         /// <summary>
         ///     XML document object which will hold the resulting serialization
         /// </summary>
-        private XDocument m_mainDocument;
+        private XDocument _mainDocument;
 
         /// <summary>
         ///     a collection of already serialized objects, kept for the sake of loop detection and preventing stack overflow
         ///     exception
         /// </summary>
-        private Stack<object> m_serializedStack;
+        private Stack<object> _serializedStack;
 
         /// <summary>
         ///     the attribute name used to deserialize meta-data for real types of objects serialized through
         ///     a reference to their base class or interface.
         /// </summary>
-        private string m_trueTypeAttrName = "realtype";
+        private string _trueTypeAttrName = "realtype";
 
         /// <summary>
         ///     The class or structure that is to be serialized/deserialized.
         /// </summary>
-        private Type m_type;
+        private Type _type;
 
         /// <summary>
         ///     The type wrapper for the underlying type used in the serializer
         /// </summary>
-        private UdtWrapper m_udtWrapper;
+        private UdtWrapper _udtWrapper;
 
         /// <summary>
         ///     The initials used for the xml namespace
         /// </summary>
-        private string m_yaxLibNamespacePrefix = "yaxlib";
+        private string _yaxLibNamespacePrefix = "yaxlib";
 
         /// <summary>
         ///     The URI address which holds the xmlns:yaxlib definition.
         /// </summary>
-        private XNamespace m_yaxLibNamespaceUri = XNamespace.Get("http://www.sinairv.com/yaxlib/");
+        private XNamespace _yaxLibNamespaceUri = XNamespace.Get("http://www.sinairv.com/yaxlib/");
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXSerializer" /> class.
@@ -172,14 +172,14 @@ namespace YAXLib
         public YAXSerializer(Type t, YAXExceptionHandlingPolicies exceptionPolicy, YAXExceptionTypes defaultExType,
             YAXSerializationOptions option)
         {
-            m_type = t;
-            m_exceptionPolicy = exceptionPolicy;
-            m_defaultExceptionType = defaultExType;
-            m_serializationOption = option;
+            _type = t;
+            _exceptionPolicy = exceptionPolicy;
+            _defaultExceptionType = defaultExType;
+            _serializationOption = option;
             // this must be the last call
-            m_udtWrapper = TypeWrappersPool.Pool.GetTypeWrapper(m_type, this);
-            if (m_udtWrapper.HasNamespace)
-                TypeNamespace = m_udtWrapper.Namespace;
+            _udtWrapper = TypeWrappersPool.Pool.GetTypeWrapper(_type, this);
+            if (_udtWrapper.HasNamespace)
+                TypeNamespace = _udtWrapper.Namespace;
             MaxRecursion = DefaultMaxRecursion;
         }
 
@@ -191,25 +191,25 @@ namespace YAXLib
         ///     Gets the default type of the exception.
         /// </summary>
         /// <value>The default type of the exception.</value>
-        public YAXExceptionTypes DefaultExceptionType => m_defaultExceptionType;
+        public YAXExceptionTypes DefaultExceptionType => _defaultExceptionType;
 
         /// <summary>
         ///     Gets the serialization option.
         /// </summary>
         /// <value>The serialization option.</value>
-        public YAXSerializationOptions SerializationOption => m_serializationOption;
+        public YAXSerializationOptions SerializationOption => _serializationOption;
 
         /// <summary>
         ///     Gets the exception handling policy.
         /// </summary>
         /// <value>The exception handling policy.</value>
-        public YAXExceptionHandlingPolicies ExceptionHandlingPolicy => m_exceptionPolicy;
+        public YAXExceptionHandlingPolicies ExceptionHandlingPolicy => _exceptionPolicy;
 
         /// <summary>
         ///     Gets the parsing errors.
         /// </summary>
         /// <value>The parsing errors.</value>
-        public YAXParsingErrors ParsingErrors => m_parsingErrors;
+        public YAXParsingErrors ParsingErrors => _parsingErrors;
 
         /// <summary>
         ///     Gets or sets a value indicating whether this instance is created to deserialize a non collection member of another
@@ -231,8 +231,8 @@ namespace YAXLib
         /// </summary>
         public XNamespace YaxLibNamespaceUri
         {
-            get { return m_yaxLibNamespaceUri; }
-            set { m_yaxLibNamespaceUri = value; }
+            get { return _yaxLibNamespaceUri; }
+            set { _yaxLibNamespaceUri = value; }
         }
 
         /// <summary>
@@ -240,9 +240,9 @@ namespace YAXLib
         /// </summary>
         public string YaxLibNamespacePrefix
         {
-            get { return m_yaxLibNamespacePrefix; }
+            get { return _yaxLibNamespacePrefix; }
 
-            set { m_yaxLibNamespacePrefix = value; }
+            set { _yaxLibNamespacePrefix = value; }
         }
 
         /// <summary>
@@ -250,9 +250,9 @@ namespace YAXLib
         /// </summary>
         public string DimentionsAttributeName
         {
-            get { return m_dimsAttrName; }
+            get { return _dimsAttrName; }
 
-            set { m_dimsAttrName = value; }
+            set { _dimsAttrName = value; }
         }
 
         /// <summary>
@@ -261,9 +261,9 @@ namespace YAXLib
         /// </summary>
         public string RealTypeAttributeName
         {
-            get { return m_trueTypeAttrName; }
+            get { return _trueTypeAttrName; }
 
-            set { m_trueTypeAttrName = value; }
+            set { _trueTypeAttrName = value; }
         }
 
         /// <summary>
@@ -357,7 +357,7 @@ namespace YAXLib
             }
             catch (XmlException ex)
             {
-                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), m_defaultExceptionType);
+                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), _defaultExceptionType);
                 return null;
             }
         }
@@ -378,7 +378,7 @@ namespace YAXLib
             }
             catch (XmlException ex)
             {
-                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), m_defaultExceptionType);
+                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), _defaultExceptionType);
                 return null;
             }
         }
@@ -399,7 +399,7 @@ namespace YAXLib
             }
             catch (XmlException ex)
             {
-                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), m_defaultExceptionType);
+                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), _defaultExceptionType);
                 return null;
             }
         }
@@ -420,7 +420,7 @@ namespace YAXLib
             }
             catch (XmlException ex)
             {
-                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), m_defaultExceptionType);
+                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), _defaultExceptionType);
                 return null;
             }
         }
@@ -438,7 +438,7 @@ namespace YAXLib
             }
             catch (XmlException ex)
             {
-                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), m_defaultExceptionType);
+                OnExceptionOccurred(new YAXBadlyFormedXML(ex, ex.LineNumber, ex.LinePosition), _defaultExceptionType);
                 return null;
             }
         }
@@ -450,9 +450,9 @@ namespace YAXLib
         /// <param name="obj">The object used as the base object in the next stage of deserialization.</param>
         public void SetDeserializationBaseObject(object obj)
         {
-            if (obj != null && !m_type.IsInstanceOfType(obj)) throw new YAXObjectTypeMismatch(m_type, obj.GetType());
+            if (obj != null && !_type.IsInstanceOfType(obj)) throw new YAXObjectTypeMismatch(_type, obj.GetType());
 
-            m_desObject = obj;
+            _desObject = obj;
         }
 
         /// <summary>
@@ -471,12 +471,12 @@ namespace YAXLib
         private XDocument SerializeXDocument(object obj)
         {
             // This method must be called by any public Serialize method
-            m_isSerializing = true;
-            if (m_serializedStack == null)
-                m_serializedStack = new Stack<object>();
-            m_mainDocument = new XDocument();
-            m_mainDocument.Add(SerializeBase(obj));
-            return m_mainDocument;
+            _isSerializing = true;
+            if (_serializedStack == null)
+                _serializedStack = new Stack<object>();
+            _mainDocument = new XDocument();
+            _mainDocument.Add(SerializeBase(obj));
+            return _mainDocument;
         }
 
         /// <summary>
@@ -490,48 +490,48 @@ namespace YAXLib
         private XElement SerializeBase(object obj)
         {
             if (obj == null)
-                return new XElement(m_udtWrapper.Alias);
+                return new XElement(_udtWrapper.Alias);
 
-            if (!m_type.IsInstanceOfType(obj))
-                throw new YAXObjectTypeMismatch(m_type, obj.GetType());
+            if (!_type.IsInstanceOfType(obj))
+                throw new YAXObjectTypeMismatch(_type, obj.GetType());
 
             FindDocumentDefaultNamespace();
 
             // to serialize stand-alone collection or dictionary objects
-            if (m_udtWrapper.IsTreatedAsDictionary)
+            if (_udtWrapper.IsTreatedAsDictionary)
             {
-                var elemResult = MakeDictionaryElement(null, m_udtWrapper.Alias, obj,
-                    m_udtWrapper.DictionaryAttributeInstance, m_udtWrapper.CollectionAttributeInstance,
-                    m_udtWrapper.IsNotAllowdNullObjectSerialization);
-                if (m_udtWrapper.PreservesWhitespace)
+                var elemResult = MakeDictionaryElement(null, _udtWrapper.Alias, obj,
+                    _udtWrapper.DictionaryAttributeInstance, _udtWrapper.CollectionAttributeInstance,
+                    _udtWrapper.IsNotAllowdNullObjectSerialization);
+                if (_udtWrapper.PreservesWhitespace)
                     XMLUtils.AddPreserveSpaceAttribute(elemResult);
                 if (elemResult.Parent == null)
                     AddNamespacesToElement(elemResult);
                 return elemResult;
             }
 
-            if (m_udtWrapper.IsTreatedAsCollection)
+            if (_udtWrapper.IsTreatedAsCollection)
             {
-                var elemResult = MakeCollectionElement(null, m_udtWrapper.Alias, obj, null, null);
-                if (m_udtWrapper.PreservesWhitespace)
+                var elemResult = MakeCollectionElement(null, _udtWrapper.Alias, obj, null, null);
+                if (_udtWrapper.PreservesWhitespace)
                     XMLUtils.AddPreserveSpaceAttribute(elemResult);
                 if (elemResult.Parent == null)
                     AddNamespacesToElement(elemResult);
                 return elemResult;
             }
 
-            if (ReflectionUtils.IsBasicType(m_udtWrapper.UnderlyingType))
+            if (ReflectionUtils.IsBasicType(_udtWrapper.UnderlyingType))
             {
                 bool dummyAlreadyAdded;
-                var elemResult = MakeBaseElement(null, m_udtWrapper.Alias, obj, out dummyAlreadyAdded);
-                if (m_udtWrapper.PreservesWhitespace)
+                var elemResult = MakeBaseElement(null, _udtWrapper.Alias, obj, out dummyAlreadyAdded);
+                if (_udtWrapper.PreservesWhitespace)
                     XMLUtils.AddPreserveSpaceAttribute(elemResult);
                 if (elemResult.Parent == null)
                     AddNamespacesToElement(elemResult);
                 return elemResult;
             }
 
-            if (!m_udtWrapper.UnderlyingType.EqualsOrIsNullableOf(obj.GetType()))
+            if (!_udtWrapper.UnderlyingType.EqualsOrIsNullableOf(obj.GetType()))
             {
                 // this block of code runs if the serializer is instantiated with a
                 // another base value such as System.Object but is provided with an
@@ -543,10 +543,10 @@ namespace YAXLib
                 // do not pop from stack because the new internal serializer was sufficient for the whole serialization 
                 // and this instance of serializer did not do anything extra
                 FinalizeNewSerializer(ser, true, false);
-                elem.Name = m_udtWrapper.Alias;
+                elem.Name = _udtWrapper.Alias;
 
-                AddMetadataAttribute(elem, m_yaxLibNamespaceUri + m_trueTypeAttrName, obj.GetType().FullName,
-                    m_documentDefaultNamespace);
+                AddMetadataAttribute(elem, _yaxLibNamespaceUri + _trueTypeAttrName, obj.GetType().FullName,
+                    _documentDefaultNamespace);
                 AddNamespacesToElement(elem);
 
                 return elem;
@@ -554,10 +554,10 @@ namespace YAXLib
             else
             {
                 // SerializeBase will add the object to the stack
-                var elem = SerializeBase(obj, m_udtWrapper.Alias);
-                if (!m_type.IsValueType)
-                    m_serializedStack.Pop();
-                Debug.Assert(m_serializedStack.Count == 0,
+                var elem = SerializeBase(obj, _udtWrapper.Alias);
+                if (!_type.IsValueType)
+                    _serializedStack.Pop();
+                Debug.Assert(_serializedStack.Count == 0,
                     "Serialization stack is not empty at the end of serialization");
                 return elem;
             }
@@ -566,14 +566,14 @@ namespace YAXLib
         private void PushObjectToSerializationStack(object obj)
         {
             if (!obj.GetType().IsValueType)
-                m_serializedStack.Push(obj);
+                _serializedStack.Push(obj);
         }
 
         private void FindDocumentDefaultNamespace()
         {
-            if (m_udtWrapper.HasNamespace && string.IsNullOrEmpty(m_udtWrapper.NamespacePrefix))
+            if (_udtWrapper.HasNamespace && string.IsNullOrEmpty(_udtWrapper.NamespacePrefix))
                 // it has a default namespace defined (one without a prefix)
-                m_documentDefaultNamespace = m_udtWrapper.Namespace; // set the default namespace
+                _documentDefaultNamespace = _udtWrapper.Namespace; // set the default namespace
         }
 
         /// <summary>
@@ -585,7 +585,7 @@ namespace YAXLib
         /// <param name="baseElement">The base XML element.</param>
         private void SetBaseElement(XElement baseElement)
         {
-            m_baseElement = baseElement;
+            _baseElement = baseElement;
         }
 
         /// <summary>
@@ -600,61 +600,61 @@ namespace YAXLib
         /// </returns>
         private XElement SerializeBase(object obj, XName className)
         {
-            m_isSerializing =
+            _isSerializing =
                 true; // this is set once again here since internal serializers may not call public Serialize methods
 
-            if (m_baseElement == null)
+            if (_baseElement == null)
             {
-                m_baseElement = CreateElementWithNamespace(m_udtWrapper, className);
+                _baseElement = CreateElementWithNamespace(_udtWrapper, className);
             }
             else
             {
                 var baseElem = new XElement(className, null);
-                m_baseElement.Add(baseElem);
-                m_baseElement = baseElem;
+                _baseElement.Add(baseElem);
+                _baseElement = baseElem;
             }
 
             if (MaxRecursion == 1)
             {
                 PushObjectToSerializationStack(obj);
-                return m_baseElement;
+                return _baseElement;
             }
 
-            if (!m_type.IsValueType)
+            if (!_type.IsValueType)
             {
-                var alreadySerializedObject = m_serializedStack.FirstOrDefault(x => ReferenceEquals(x, obj));
+                var alreadySerializedObject = _serializedStack.FirstOrDefault(x => ReferenceEquals(x, obj));
                 if (alreadySerializedObject != null)
                 {
-                    if (!m_udtWrapper.ThrowUponSerializingCyclingReferences)
+                    if (!_udtWrapper.ThrowUponSerializingCyclingReferences)
                     {
                         // although we are not going to serialize anything, push the object to be picked up
                         // by the pop statement right after serialization
                         PushObjectToSerializationStack(obj);
-                        return m_baseElement;
+                        return _baseElement;
                     }
 
-                    throw new YAXCannotSerializeSelfReferentialTypes(m_type);
+                    throw new YAXCannotSerializeSelfReferentialTypes(_type);
                 }
 
                 PushObjectToSerializationStack(obj);
             }
 
-            if (m_udtWrapper.HasComment && m_baseElement.Parent == null && m_mainDocument != null)
-                foreach (var comment in m_udtWrapper.Comment)
-                    m_mainDocument.Add(new XComment(comment));
+            if (_udtWrapper.HasComment && _baseElement.Parent == null && _mainDocument != null)
+                foreach (var comment in _udtWrapper.Comment)
+                    _mainDocument.Add(new XComment(comment));
 
             // if the containing element is set to preserve spaces, then emit the 
             // required attribute
-            if (m_udtWrapper.PreservesWhitespace) XMLUtils.AddPreserveSpaceAttribute(m_baseElement);
+            if (_udtWrapper.PreservesWhitespace) XMLUtils.AddPreserveSpaceAttribute(_baseElement);
 
             // check if the main class/type has defined custom serializers
-            if (m_udtWrapper.HasCustomSerializer)
+            if (_udtWrapper.HasCustomSerializer)
             {
-                InvokeCustomSerializerToElement(m_udtWrapper.CustomSerializerType, obj, m_baseElement);
+                InvokeCustomSerializerToElement(_udtWrapper.CustomSerializerType, obj, _baseElement);
             }
-            else if (KnownTypes.IsKnowType(m_type))
+            else if (KnownTypes.IsKnowType(_type))
             {
-                KnownTypes.Serialize(obj, m_baseElement, TypeNamespace);
+                KnownTypes.Serialize(obj, _baseElement, TypeNamespace);
             }
             else // if it has no custom serializers
             {
@@ -682,7 +682,7 @@ namespace YAXLib
 
                     // ignore this member if it is null and we are not about to serialize null objects
                     if (elementValue == null &&
-                        m_udtWrapper.IsNotAllowdNullObjectSerialization)
+                        _udtWrapper.IsNotAllowdNullObjectSerialization)
                         continue;
 
                     if (elementValue == null &&
@@ -707,15 +707,15 @@ namespace YAXLib
                     if (member.IsSerializedAsAttribute &&
                         (areOfSameType || hasCustomSerializer || isCollectionSerially || isKnownType))
                     {
-                        if (!XMLUtils.AttributeExists(m_baseElement, serializationLocation,
+                        if (!XMLUtils.AttributeExists(_baseElement, serializationLocation,
                             member.Alias.OverrideNsIfEmpty(TypeNamespace)))
                         {
-                            var attrToCreate = XMLUtils.CreateAttribute(m_baseElement,
+                            var attrToCreate = XMLUtils.CreateAttribute(_baseElement,
                                 serializationLocation, member.Alias.OverrideNsIfEmpty(TypeNamespace),
                                 hasCustomSerializer || isCollectionSerially || isKnownType
                                     ? string.Empty
                                     : elementValue,
-                                m_documentDefaultNamespace);
+                                _documentDefaultNamespace);
 
                             RegisterNamespace(member.Alias.OverrideNsIfEmpty(TypeNamespace).Namespace, null);
 
@@ -755,14 +755,14 @@ namespace YAXLib
                              (areOfSameType || hasCustomSerializer || isCollectionSerially || isKnownType))
                     {
                         // find the parent element from its location
-                        var parElem = XMLUtils.FindLocation(m_baseElement, serializationLocation);
+                        var parElem = XMLUtils.FindLocation(_baseElement, serializationLocation);
                         if (parElem == null) // if the parent element does not exist
                         {
                             // see if the location can be created
-                            if (!XMLUtils.CanCreateLocation(m_baseElement, serializationLocation))
+                            if (!XMLUtils.CanCreateLocation(_baseElement, serializationLocation))
                                 throw new YAXBadLocationException(serializationLocation);
                             // try to create the location
-                            parElem = XMLUtils.CreateLocation(m_baseElement, serializationLocation);
+                            parElem = XMLUtils.CreateLocation(_baseElement, serializationLocation);
                             if (parElem == null)
                                 throw new YAXBadLocationException(serializationLocation);
                         }
@@ -805,14 +805,14 @@ namespace YAXLib
                     else // if the data is going to be serialized as an element
                     {
                         // find the parent element from its location
-                        var parElem = XMLUtils.FindLocation(m_baseElement, serializationLocation);
+                        var parElem = XMLUtils.FindLocation(_baseElement, serializationLocation);
                         if (parElem == null) // if the parent element does not exist
                         {
                             // see if the location can be created
-                            if (!XMLUtils.CanCreateLocation(m_baseElement, serializationLocation))
+                            if (!XMLUtils.CanCreateLocation(_baseElement, serializationLocation))
                                 throw new YAXBadLocationException(serializationLocation);
                             // try to create the location
-                            parElem = XMLUtils.CreateLocation(m_baseElement, serializationLocation);
+                            parElem = XMLUtils.CreateLocation(_baseElement, serializationLocation);
                             if (parElem == null)
                                 throw new YAXBadLocationException(serializationLocation);
                         }
@@ -873,8 +873,8 @@ namespace YAXLib
                                 }
                                 else
                                 {
-                                    AddMetadataAttribute(elemToAdd, m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                                        realType.FullName, m_documentDefaultNamespace);
+                                    AddMetadataAttribute(elemToAdd, _yaxLibNamespaceUri + _trueTypeAttrName,
+                                        realType.FullName, _documentDefaultNamespace);
                                 }
                             }
 
@@ -911,15 +911,15 @@ namespace YAXLib
                 // remove that element by itself. However if the element is empty, because the 
                 // corresponding object did not have any fields to serialize (e.g., DBNull, Random)
                 // then keep that element
-                if (m_baseElement.Parent != null &&
-                    XMLUtils.IsElementCompletelyEmpty(m_baseElement) &&
+                if (_baseElement.Parent != null &&
+                    XMLUtils.IsElementCompletelyEmpty(_baseElement) &&
                     isAnythingFoundToSerialize)
-                    m_baseElement.Remove();
+                    _baseElement.Remove();
             } // end of else if it has no custom serializers
 
-            if (m_baseElement.Parent == null) AddNamespacesToElement(m_baseElement);
+            if (_baseElement.Parent == null) AddNamespacesToElement(_baseElement);
 
-            return m_baseElement;
+            return _baseElement;
         }
 
         /// <summary>
@@ -949,30 +949,30 @@ namespace YAXLib
             if (!ns.IsEmpty())
                 return;
 
-            if (m_namespaceToPrefix.ContainsKey(ns))
+            if (_namespaceToPrefix.ContainsKey(ns))
             {
-                var existingPrefix = m_namespaceToPrefix[ns];
+                var existingPrefix = _namespaceToPrefix[ns];
                 // override the prefix only if already existing namespace has no prefix assigned
                 if (string.IsNullOrEmpty(existingPrefix))
-                    m_namespaceToPrefix[ns] = prefix;
+                    _namespaceToPrefix[ns] = prefix;
             }
             else
             {
-                m_namespaceToPrefix.Add(ns, prefix);
+                _namespaceToPrefix.Add(ns, prefix);
             }
         }
 
         private void ImportNamespaces(YAXSerializer otherSerializer)
         {
-            foreach (var pair in otherSerializer.m_namespaceToPrefix) RegisterNamespace(pair.Key, pair.Value);
+            foreach (var pair in otherSerializer._namespaceToPrefix) RegisterNamespace(pair.Key, pair.Value);
         }
 
         private void AddNamespacesToElement(XElement rootNode)
         {
             var nsNoPrefix = new List<XNamespace>();
-            foreach (var ns in m_namespaceToPrefix.Keys)
+            foreach (var ns in _namespaceToPrefix.Keys)
             {
-                var prefix = m_namespaceToPrefix[ns];
+                var prefix = _namespaceToPrefix[ns];
                 if (string.IsNullOrEmpty(prefix))
                 {
                     nsNoPrefix.Add(ns);
@@ -982,7 +982,7 @@ namespace YAXLib
                     // if no namespace with this prefix already exists
                     if (rootNode.GetNamespaceOfPrefix(prefix) == null)
                     {
-                        rootNode.AddAttributeNamespaceSafe(XNamespace.Xmlns + prefix, ns, m_documentDefaultNamespace);
+                        rootNode.AddAttributeNamespaceSafe(XNamespace.Xmlns + prefix, ns, _documentDefaultNamespace);
                     }
                     else // if this prefix is already added
                     {
@@ -999,14 +999,14 @@ namespace YAXLib
             }
 
             // if the main type wrapper has a default (no prefix) namespace
-            if (m_udtWrapper.Namespace.IsEmpty() && string.IsNullOrEmpty(m_udtWrapper.NamespacePrefix))
+            if (_udtWrapper.Namespace.IsEmpty() && string.IsNullOrEmpty(_udtWrapper.NamespacePrefix))
                 // it will be added automatically
-                nsNoPrefix.Remove(m_udtWrapper.Namespace);
+                nsNoPrefix.Remove(_udtWrapper.Namespace);
 
             // now generate namespaces for those without prefix
             foreach (var ns in nsNoPrefix)
                 rootNode.AddAttributeNamespaceSafe(XNamespace.Xmlns + rootNode.GetRandomPrefix(), ns,
-                    m_documentDefaultNamespace);
+                    _documentDefaultNamespace);
         }
 
         /// <summary>
@@ -1188,7 +1188,7 @@ namespace YAXLib
 
                 if (isKeyAttrib && areKeyOfSameType)
                 {
-                    elemChild.AddAttributeNamespaceSafe(keyAlias, keyObj, m_documentDefaultNamespace);
+                    elemChild.AddAttributeNamespaceSafe(keyAlias, keyObj, _documentDefaultNamespace);
                 }
                 else if (isKeyContent && areKeyOfSameType)
                 {
@@ -1204,14 +1204,14 @@ namespace YAXLib
                             // other elements, therefore we need to make sure to re-add the element.
                             elemChild.Add(addedElem);
 
-                        AddMetadataAttribute(addedElem, m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                            keyObj.GetType().FullName, m_documentDefaultNamespace);
+                        AddMetadataAttribute(addedElem, _yaxLibNamespaceUri + _trueTypeAttrName,
+                            keyObj.GetType().FullName, _documentDefaultNamespace);
                     }
                 }
 
                 if (isValueAttrib && areValueOfSameType)
                 {
-                    elemChild.AddAttributeNamespaceSafe(valueAlias, valueObj, m_documentDefaultNamespace);
+                    elemChild.AddAttributeNamespaceSafe(valueAlias, valueObj, _documentDefaultNamespace);
                 }
                 else if (isValueContent && areValueOfSameType)
                 {
@@ -1227,8 +1227,8 @@ namespace YAXLib
                             // other elements, therefore we need to make sure to re-add the element.
                             elemChild.Add(addedElem);
 
-                        AddMetadataAttribute(addedElem, m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                            valueObj.GetType().FullName, m_documentDefaultNamespace);
+                        AddMetadataAttribute(addedElem, _yaxLibNamespaceUri + _trueTypeAttrName,
+                            valueObj.GetType().FullName, _documentDefaultNamespace);
                     }
                 }
 
@@ -1394,16 +1394,16 @@ namespace YAXLib
                         ) // i.e., it has been removed, e.g., because all its members have been serialized outside the element
                             elemToAdd.Add(itemElem); // return it back, or undelete this item
 
-                        AddMetadataAttribute(itemElem, m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                            obj.GetType().FullName, m_documentDefaultNamespace);
+                        AddMetadataAttribute(itemElem, _yaxLibNamespaceUri + _trueTypeAttrName,
+                            obj.GetType().FullName, _documentDefaultNamespace);
                     }
                 }
             }
 
             var arrayDims = ReflectionUtils.GetArrayDimensions(elementValue);
             if (arrayDims != null && arrayDims.Length > 1)
-                AddMetadataAttribute(elemToAdd, m_yaxLibNamespaceUri + m_dimsAttrName,
-                    StringUtils.GetArrayDimsString(arrayDims), m_documentDefaultNamespace);
+                AddMetadataAttribute(elemToAdd, _yaxLibNamespaceUri + _dimsAttrName,
+                    StringUtils.GetArrayDimsString(arrayDims), _documentDefaultNamespace);
 
             return elemToAdd;
         }
@@ -1454,44 +1454,44 @@ namespace YAXLib
         /// <returns>object containing the deserialized data</returns>
         private object DeserializeBase(XElement baseElement)
         {
-            m_isSerializing = false;
+            _isSerializing = false;
 
-            if (baseElement == null) return m_desObject;
+            if (baseElement == null) return _desObject;
 
-            if (m_udtWrapper.HasCustomSerializer)
-                return InvokeCustomDeserializerFromElement(m_udtWrapper.CustomSerializerType, baseElement);
+            if (_udtWrapper.HasCustomSerializer)
+                return InvokeCustomDeserializerFromElement(_udtWrapper.CustomSerializerType, baseElement);
 
-            var realTypeAttr = baseElement.Attribute_NamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                m_documentDefaultNamespace);
+            var realTypeAttr = baseElement.Attribute_NamespaceSafe(_yaxLibNamespaceUri + _trueTypeAttrName,
+                _documentDefaultNamespace);
             if (realTypeAttr != null)
             {
                 var theRealType = ReflectionUtils.GetTypeByName(realTypeAttr.Value);
                 if (theRealType != null)
                 {
-                    m_type = theRealType;
-                    m_udtWrapper = TypeWrappersPool.Pool.GetTypeWrapper(m_type, this);
+                    _type = theRealType;
+                    _udtWrapper = TypeWrappersPool.Pool.GetTypeWrapper(_type, this);
                 }
             }
 
-            if (m_type.IsGenericType && m_type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+            if (_type.IsGenericType && _type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
                 return DeserializeKeyValuePair(baseElement);
 
-            if (KnownTypes.IsKnowType(m_type)) return KnownTypes.Deserialize(baseElement, m_type, TypeNamespace);
+            if (KnownTypes.IsKnowType(_type)) return KnownTypes.Deserialize(baseElement, _type, TypeNamespace);
 
-            if ((m_udtWrapper.IsTreatedAsCollection || m_udtWrapper.IsTreatedAsDictionary) &&
+            if ((_udtWrapper.IsTreatedAsCollection || _udtWrapper.IsTreatedAsDictionary) &&
                 !IsCraetedToDeserializeANonCollectionMember)
             {
-                if (m_udtWrapper.DictionaryAttributeInstance != null)
-                    return DeserializeTaggedDictionaryValue(baseElement, m_udtWrapper.Alias, m_type,
-                        m_udtWrapper.CollectionAttributeInstance, m_udtWrapper.DictionaryAttributeInstance);
-                return DeserializeCollectionValue(m_type, baseElement, m_udtWrapper.Alias,
-                    m_udtWrapper.CollectionAttributeInstance);
+                if (_udtWrapper.DictionaryAttributeInstance != null)
+                    return DeserializeTaggedDictionaryValue(baseElement, _udtWrapper.Alias, _type,
+                        _udtWrapper.CollectionAttributeInstance, _udtWrapper.DictionaryAttributeInstance);
+                return DeserializeCollectionValue(_type, baseElement, _udtWrapper.Alias,
+                    _udtWrapper.CollectionAttributeInstance);
             }
 
-            if (ReflectionUtils.IsBasicType(m_type)) return ReflectionUtils.ConvertBasicType(baseElement.Value, m_type);
+            if (ReflectionUtils.IsBasicType(_type)) return ReflectionUtils.ConvertBasicType(baseElement.Value, _type);
 
             object o;
-            o = m_desObject ?? Activator.CreateInstance(m_type, new object[0]);
+            o = _desObject ?? Activator.CreateInstance(_type, new object[0]);
             // o = m_desObject ?? m_type.InvokeMember(string.Empty, BindingFlags.CreateInstance, null, null, new object[0]);
 
             foreach (var member in GetFieldsToBeSerialized())
@@ -1503,7 +1503,7 @@ namespace YAXLib
                     continue;
 
                 // reset handled exceptions status
-                m_exceptionOccurredDuringMemberDeserialization = false;
+                _exceptionOccurredDuringMemberDeserialization = false;
 
                 var elemValue = string.Empty; // the element value gathered at the first phase
                 XElement xelemValue = null; // the XElement instance gathered at the first phase
@@ -1524,8 +1524,8 @@ namespace YAXLib
                         // loook for an element with the same name AND a yaxlib:realtype attribute
                         var elem = XMLUtils.FindElement(baseElement, serializationLocation,
                             member.Alias.OverrideNsIfEmpty(TypeNamespace));
-                        if (elem != null && elem.Attribute_NamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                            m_documentDefaultNamespace) != null)
+                        if (elem != null && elem.Attribute_NamespaceSafe(_yaxLibNamespaceUri + _trueTypeAttrName,
+                            _documentDefaultNamespace) != null)
                         {
                             elemValue = elem.Value;
                             xelemValue = elem;
@@ -1535,7 +1535,7 @@ namespace YAXLib
                             OnExceptionOccurred(new YAXAttributeMissingException(
                                     StringUtils.CombineLocationAndElementName(serializationLocation, member.Alias),
                                     elem ?? baseElement),
-                                !member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization
+                                !member.MemberType.IsValueType && _udtWrapper.IsNotAllowdNullObjectSerialization
                                     ? YAXExceptionTypes.Ignore
                                     : member.TreatErrorsAs);
                         }
@@ -1553,7 +1553,7 @@ namespace YAXLib
                     {
                         OnExceptionOccurred(new YAXElementMissingException(
                                 serializationLocation, baseElement),
-                            !member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization
+                            !member.MemberType.IsValueType && _udtWrapper.IsNotAllowdNullObjectSerialization
                                 ? YAXExceptionTypes.Ignore
                                 : member.TreatErrorsAs);
                     }
@@ -1566,8 +1566,8 @@ namespace YAXLib
                             var innerelem = XMLUtils.FindElement(baseElement, serializationLocation,
                                 member.Alias.OverrideNsIfEmpty(TypeNamespace));
                             if (innerelem != null &&
-                                innerelem.Attribute_NamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                                    m_documentDefaultNamespace) != null)
+                                innerelem.Attribute_NamespaceSafe(_yaxLibNamespaceUri + _trueTypeAttrName,
+                                    _documentDefaultNamespace) != null)
                             {
                                 elemValue = innerelem.Value;
                                 xelemValue = innerelem;
@@ -1577,7 +1577,7 @@ namespace YAXLib
                                 OnExceptionOccurred(
                                     new YAXElementValueMissingException(serializationLocation,
                                         innerelem ?? baseElement),
-                                    !member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization
+                                    !member.MemberType.IsValueType && _udtWrapper.IsNotAllowdNullObjectSerialization
                                         ? YAXExceptionTypes.Ignore
                                         : member.TreatErrorsAs);
                             }
@@ -1634,7 +1634,7 @@ namespace YAXLib
                             OnExceptionOccurred(new YAXElementMissingException(
                                     StringUtils.CombineLocationAndElementName(serializationLocation,
                                         member.Alias.OverrideNsIfEmpty(TypeNamespace)), baseElement),
-                                !member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization
+                                !member.MemberType.IsValueType && _udtWrapper.IsNotAllowdNullObjectSerialization
                                     ? YAXExceptionTypes.Ignore
                                     : member.TreatErrorsAs);
                     }
@@ -1647,12 +1647,12 @@ namespace YAXLib
                 }
 
                 // Phase2: Now try to retrieve elemValue's value, based on values gathered in xelemValue, xattrValue, and elemValue
-                if (m_exceptionOccurredDuringMemberDeserialization)
+                if (_exceptionOccurredDuringMemberDeserialization)
                 {
-                    if (m_desObject == null
+                    if (_desObject == null
                     ) // i.e. if it was NOT resuming deserialization, set default value, otherwise existing value for the member is kept
                     {
-                        if (!member.MemberType.IsValueType && m_udtWrapper.IsNotAllowdNullObjectSerialization)
+                        if (!member.MemberType.IsValueType && _udtWrapper.IsNotAllowdNullObjectSerialization)
                         {
                             try
                             {
@@ -1663,7 +1663,7 @@ namespace YAXLib
                                 OnExceptionOccurred(
                                     new YAXDefaultValueCannotBeAssigned(member.Alias.LocalName, member.DefaultValue,
                                         xattrValue ?? xelemValue ?? baseElement as IXmlLineInfo),
-                                    m_defaultExceptionType);
+                                    _defaultExceptionType);
                             }
                         }
                         else if (member.DefaultValue != null)
@@ -1677,7 +1677,7 @@ namespace YAXLib
                                 OnExceptionOccurred(
                                     new YAXDefaultValueCannotBeAssigned(member.Alias.LocalName, member.DefaultValue,
                                         xattrValue ?? xelemValue ?? baseElement as IXmlLineInfo),
-                                    m_defaultExceptionType);
+                                    _defaultExceptionType);
                             }
                         }
                         else
@@ -1711,7 +1711,7 @@ namespace YAXLib
                     {
                         OnExceptionOccurred(
                             new YAXPropertyCannotBeAssignedTo(member.Alias.LocalName,
-                                xattrValue ?? xelemValue ?? baseElement as IXmlLineInfo), m_defaultExceptionType);
+                                xattrValue ?? xelemValue ?? baseElement as IXmlLineInfo), _defaultExceptionType);
                     }
                 }
                 else if (elemValue != null)
@@ -1808,8 +1808,8 @@ namespace YAXLib
                         // maybe it has got a realtype attribute and hence have turned into an element
                         var theElem = XMLUtils.FindElement(elem, member.SerializationLocation, member.Alias);
                         if (theElem != null &&
-                            theElem.Attribute_NamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                                m_documentDefaultNamespace) != null)
+                            theElem.Attribute_NamespaceSafe(_yaxLibNamespaceUri + _trueTypeAttrName,
+                                _documentDefaultNamespace) != null)
                             return true;
                     }
                     else
@@ -1825,7 +1825,7 @@ namespace YAXLib
                         if (!ReflectionUtils.IsBasicType(member.MemberType)
                             && !member.IsTreatedAsCollection
                             && !member.IsTreatedAsDictionary
-                            && member.MemberType != m_type
+                            && member.MemberType != _type
                         ) // searching for same type objects will lead to infinite loops
                         {
                             // try to create a fake element 
@@ -1873,8 +1873,8 @@ namespace YAXLib
             // try to retrieve the real-type if specified
             if (xelemValue != null && !isRealTypeAttributeNotRelevant)
             {
-                var realTypeAttribute = xelemValue.Attribute_NamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                    m_documentDefaultNamespace);
+                var realTypeAttribute = xelemValue.Attribute_NamespaceSafe(_yaxLibNamespaceUri + _trueTypeAttrName,
+                    _documentDefaultNamespace);
                 if (realTypeAttribute != null)
                 {
                     var realType = ReflectionUtils.GetTypeByName(realTypeAttribute.Value);
@@ -1910,7 +1910,7 @@ namespace YAXLib
                 catch
                 {
                     OnExceptionOccurred(new YAXPropertyCannotBeAssignedTo(member.Alias.LocalName, xelemValue),
-                        m_defaultExceptionType);
+                        _defaultExceptionType);
                 }
             }
             else if (ReflectionUtils.IsBasicType(memberType))
@@ -1931,7 +1931,7 @@ namespace YAXLib
                     catch
                     {
                         OnExceptionOccurred(new YAXPropertyCannotBeAssignedTo(member.Alias.LocalName, xelemValue),
-                            m_defaultExceptionType);
+                            _defaultExceptionType);
                     }
                 }
                 catch (Exception ex)
@@ -1949,7 +1949,7 @@ namespace YAXLib
                     {
                         OnExceptionOccurred(
                             new YAXDefaultValueCannotBeAssigned(member.Alias.LocalName, member.DefaultValue,
-                                xelemValue), m_defaultExceptionType);
+                                xelemValue), _defaultExceptionType);
                     }
                 }
             }
@@ -1969,7 +1969,7 @@ namespace YAXLib
                 ser.IsCraetedToDeserializeANonCollectionMember =
                     !(member.IsTreatedAsDictionary || member.IsTreatedAsCollection);
 
-                if (m_desObject != null) // i.e. it is in resuming mode
+                if (_desObject != null) // i.e. it is in resuming mode
                     ser.SetDeserializationBaseObject(member.GetValue(o));
 
                 var convertedObj = ser.DeserializeBase(xelemValue);
@@ -1982,7 +1982,7 @@ namespace YAXLib
                 catch
                 {
                     OnExceptionOccurred(new YAXPropertyCannotBeAssignedTo(member.Alias.LocalName, xelemValue),
-                        m_defaultExceptionType);
+                        _defaultExceptionType);
                 }
             }
         }
@@ -2035,7 +2035,7 @@ namespace YAXLib
                     catch
                     {
                         OnExceptionOccurred(new YAXBadlyFormedInput(memberAlias.ToString(), elemValue, xelemValue),
-                            m_defaultExceptionType);
+                            _defaultExceptionType);
                     }
             }
             else //if the collection was serialized recursively
@@ -2058,8 +2058,8 @@ namespace YAXLib
                     var curElementType = itemType;
                     var curElementIsPrimitive = isPrimitive;
 
-                    var realTypeAttribute = childElem.Attribute_NamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                        m_documentDefaultNamespace);
+                    var realTypeAttribute = childElem.Attribute_NamespaceSafe(_yaxLibNamespaceUri + _trueTypeAttrName,
+                        _documentDefaultNamespace);
                     if (realTypeAttribute != null)
                     {
                         var theRealType = ReflectionUtils.GetTypeByName(realTypeAttribute.Value);
@@ -2086,7 +2086,7 @@ namespace YAXLib
                         {
                             OnExceptionOccurred(
                                 new YAXBadlyFormedInput(childElem.Name.ToString(), childElem.Value, childElem),
-                                m_defaultExceptionType);
+                                _defaultExceptionType);
                         }
                     }
                     else
@@ -2103,8 +2103,8 @@ namespace YAXLib
             Type dicKeyType, dicValueType;
             if (ReflectionUtils.IsArray(colType))
             {
-                var dimsAttr = xelemValue.Attribute_NamespaceSafe(m_yaxLibNamespaceUri + m_dimsAttrName,
-                    m_documentDefaultNamespace);
+                var dimsAttr = xelemValue.Attribute_NamespaceSafe(_yaxLibNamespaceUri + _dimsAttrName,
+                    _documentDefaultNamespace);
                 var dims = new int[0];
                 if (dimsAttr != null) dims = StringUtils.ParseArrayDimsString(dimsAttr.Value);
 
@@ -2127,7 +2127,7 @@ namespace YAXLib
                         {
                             OnExceptionOccurred(
                                 new YAXCannotAddObjectToCollection(memberAlias.ToString(), lst[i], xelemValue),
-                                m_defaultExceptionType);
+                                _defaultExceptionType);
                         }
                     }
                 }
@@ -2146,7 +2146,7 @@ namespace YAXLib
                         {
                             OnExceptionOccurred(
                                 new YAXCannotAddObjectToCollection(memberAlias.ToString(), lst[i], xelemValue),
-                                m_defaultExceptionType);
+                                _defaultExceptionType);
                         }
                 }
 
@@ -2171,7 +2171,7 @@ namespace YAXLib
                     {
                         OnExceptionOccurred(
                             new YAXCannotAddObjectToCollection(memberAlias.ToString(), lstItem, xelemValue),
-                            m_defaultExceptionType);
+                            _defaultExceptionType);
                     }
                 }
 
@@ -2197,7 +2197,7 @@ namespace YAXLib
                     {
                         OnExceptionOccurred(
                             new YAXCannotAddObjectToCollection(memberAlias.ToString(), lstItem, xelemValue),
-                            m_defaultExceptionType);
+                            _defaultExceptionType);
                     }
                 }
 
@@ -2240,7 +2240,7 @@ namespace YAXLib
                     {
                         OnExceptionOccurred(
                             new YAXCannotAddObjectToCollection(memberAlias.ToString(), lst[i], xelemValue),
-                            m_defaultExceptionType);
+                            _defaultExceptionType);
                     }
 
                 return col;
@@ -2270,7 +2270,7 @@ namespace YAXLib
                     {
                         OnExceptionOccurred(
                             new YAXCannotAddObjectToCollection(memberAlias.ToString(), lstItem, xelemValue),
-                            m_defaultExceptionType);
+                            _defaultExceptionType);
                     }
 
                 return col;
@@ -2316,7 +2316,7 @@ namespace YAXLib
             catch
             {
                 OnExceptionOccurred(new YAXPropertyCannotBeAssignedTo(member.Alias.LocalName, xelemValue),
-                    m_defaultExceptionType);
+                    _defaultExceptionType);
             }
         }
 
@@ -2428,7 +2428,7 @@ namespace YAXLib
                     if (isKeyAttrib)
                     {
                         key = ReflectionUtils.ConvertBasicType(
-                            childElem.Attribute_NamespaceSafe(keyAlias, m_documentDefaultNamespace).Value, keyType);
+                            childElem.Attribute_NamespaceSafe(keyAlias, _documentDefaultNamespace).Value, keyType);
                     }
                     else if (isKeyContent)
                     {
@@ -2453,7 +2453,7 @@ namespace YAXLib
                     if (isValueAttrib)
                     {
                         value = ReflectionUtils.ConvertBasicType(
-                            childElem.Attribute_NamespaceSafe(valueAlias, m_documentDefaultNamespace).Value, valueType);
+                            childElem.Attribute_NamespaceSafe(valueAlias, _documentDefaultNamespace).Value, valueType);
                     }
                     else if (isValueContent)
                     {
@@ -2483,7 +2483,7 @@ namespace YAXLib
                     OnExceptionOccurred(
                         new YAXCannotAddObjectToCollection(alias.LocalName,
                             new KeyValuePair<object, object>(key, value), childElem),
-                        m_defaultExceptionType);
+                        _defaultExceptionType);
                 }
             }
 
@@ -2493,10 +2493,10 @@ namespace YAXLib
         private YAXSerializer NewInternalSerializer(Type type, XNamespace namespaceToOverride,
             XElement insertionLocation)
         {
-            var serializer = new YAXSerializer(type, m_exceptionPolicy, m_defaultExceptionType, m_serializationOption);
+            var serializer = new YAXSerializer(type, _exceptionPolicy, _defaultExceptionType, _serializationOption);
             serializer.MaxRecursion = MaxRecursion == 0 ? 0 : MaxRecursion - 1;
-            serializer.m_serializedStack = m_serializedStack;
-            serializer.m_documentDefaultNamespace = m_documentDefaultNamespace;
+            serializer._serializedStack = _serializedStack;
+            serializer._documentDefaultNamespace = _documentDefaultNamespace;
             if (namespaceToOverride != null)
                 serializer.SetNamespaceToOverrideEmptyNamespace(namespaceToOverride);
 
@@ -2512,13 +2512,13 @@ namespace YAXLib
             if (serializer == null)
                 return;
 
-            if (popFromSerializationStack && m_isSerializing && serializer.m_type != null &&
-                !serializer.m_type.IsValueType)
-                m_serializedStack.Pop();
+            if (popFromSerializationStack && _isSerializing && serializer._type != null &&
+                !serializer._type.IsValueType)
+                _serializedStack.Pop();
 
             if (importNamespaces)
                 ImportNamespaces(serializer);
-            m_parsingErrors.AddRange(serializer.ParsingErrors);
+            _parsingErrors.AddRange(serializer.ParsingErrors);
         }
 
         /// <summary>
@@ -2539,7 +2539,7 @@ namespace YAXLib
             catch
             {
                 OnExceptionOccurred(new YAXPropertyCannotBeAssignedTo(member.Alias.LocalName, xelemValue),
-                    m_defaultExceptionType);
+                    _defaultExceptionType);
             }
         }
 
@@ -2557,7 +2557,7 @@ namespace YAXLib
         {
             var isKeyFound = false;
 
-            if (isKeyAttrib && childElem.Attribute_NamespaceSafe(keyAlias, m_documentDefaultNamespace) != null)
+            if (isKeyAttrib && childElem.Attribute_NamespaceSafe(keyAlias, _documentDefaultNamespace) != null)
             {
                 isKeyFound = true;
             }
@@ -2571,8 +2571,8 @@ namespace YAXLib
                 var elem = childElem.Element(keyAlias);
                 if (elem != null)
                 {
-                    var realTypeAttr = elem.Attribute_NamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                        m_documentDefaultNamespace);
+                    var realTypeAttr = elem.Attribute_NamespaceSafe(_yaxLibNamespaceUri + _trueTypeAttrName,
+                        _documentDefaultNamespace);
                     if (realTypeAttr != null)
                     {
                         var theRealType = ReflectionUtils.GetTypeByName(realTypeAttr.Value);
@@ -2593,8 +2593,8 @@ namespace YAXLib
                 {
                     isKeyFound = true;
 
-                    var realTypeAttr = elem.Attribute_NamespaceSafe(m_yaxLibNamespaceUri + m_trueTypeAttrName,
-                        m_documentDefaultNamespace);
+                    var realTypeAttr = elem.Attribute_NamespaceSafe(_yaxLibNamespaceUri + _trueTypeAttrName,
+                        _documentDefaultNamespace);
                     if (realTypeAttr != null)
                     {
                         var theRealType = ReflectionUtils.GetTypeByName(realTypeAttr.Value);
@@ -2614,7 +2614,7 @@ namespace YAXLib
         /// <returns>a <c>KeyValuePair</c> instance containing the deserialized data</returns>
         private object DeserializeKeyValuePair(XElement baseElement)
         {
-            var genArgs = m_type.GetGenericArguments();
+            var genArgs = _type.GetGenericArguments();
             var keyType = genArgs[0];
             var valueType = genArgs[1];
 
@@ -2677,7 +2677,7 @@ namespace YAXLib
                 FinalizeNewSerializer(ser, false);
             }
 
-            var pair = Activator.CreateInstance(m_type, keyValue, valueValue);
+            var pair = Activator.CreateInstance(_type, keyValue, valueValue);
             return pair;
         }
 
@@ -2760,7 +2760,7 @@ namespace YAXLib
 
                     var memInfo = new MemberWrapper(member, this);
                     if (memInfo.IsAllowedToBeSerialized(typeWrapper.FieldsToSerialize,
-                        m_udtWrapper.DontSerializePropertiesWithNoSetter)) yield return memInfo;
+                        _udtWrapper.DontSerializePropertiesWithNoSetter)) yield return memInfo;
                 }
             }
         }
@@ -2772,16 +2772,16 @@ namespace YAXLib
         /// <returns>the sequence of fields to be serialized for the serializer's underlying type.</returns>
         private IEnumerable<MemberWrapper> GetFieldsToBeSerialized()
         {
-            return GetFieldsToBeSerialized(m_udtWrapper).OrderBy(t => t.Order);
+            return GetFieldsToBeSerialized(_udtWrapper).OrderBy(t => t.Order);
         }
 
         private void AddMetadataAttribute(XElement parent, XName attrName, object attrValue,
             XNamespace documentDefaultNamespace)
         {
-            if (!m_udtWrapper.SuppressMetadataAttributes)
+            if (!_udtWrapper.SuppressMetadataAttributes)
             {
                 parent.AddAttributeNamespaceSafe(attrName, attrValue, documentDefaultNamespace);
-                RegisterNamespace(m_yaxLibNamespaceUri, m_yaxLibNamespacePrefix);
+                RegisterNamespace(_yaxLibNamespaceUri, _yaxLibNamespacePrefix);
             }
         }
 
@@ -2791,7 +2791,7 @@ namespace YAXLib
         private LoadOptions GetXmlLoadOptions()
         {
             var options = LoadOptions.None;
-            if (m_serializationOption.HasFlag(YAXSerializationOptions.DisplayLineInfoInExceptions))
+            if (_serializationOption.HasFlag(YAXSerializationOptions.DisplayLineInfoInExceptions))
                 options |= LoadOptions.SetLineInfo;
             return options;
         }
@@ -2804,12 +2804,12 @@ namespace YAXLib
         /// <param name="exceptionType">Type of the exception.</param>
         private void OnExceptionOccurred(YAXException ex, YAXExceptionTypes exceptionType)
         {
-            m_exceptionOccurredDuringMemberDeserialization = true;
+            _exceptionOccurredDuringMemberDeserialization = true;
             if (exceptionType == YAXExceptionTypes.Ignore) return;
 
-            m_parsingErrors.AddException(ex, exceptionType);
-            if (m_exceptionPolicy == YAXExceptionHandlingPolicies.ThrowWarningsAndErrors ||
-                m_exceptionPolicy == YAXExceptionHandlingPolicies.ThrowErrorsOnly &&
+            _parsingErrors.AddException(ex, exceptionType);
+            if (_exceptionPolicy == YAXExceptionHandlingPolicies.ThrowWarningsAndErrors ||
+                _exceptionPolicy == YAXExceptionHandlingPolicies.ThrowErrorsOnly &&
                 exceptionType == YAXExceptionTypes.Error)
                 throw ex;
         }

--- a/YAXLibTests/SampleClasses/ColorExample.cs
+++ b/YAXLibTests/SampleClasses/ColorExample.cs
@@ -11,29 +11,29 @@ namespace YAXLibTests.SampleClasses
     [YAXComment("This example shows a technique for serializing classes without a default constructor")]
     public class ColorExample
     {
-        private Color m_color = Color.Blue;
+        private Color _color = Color.Blue;
 
         public string TheColor
         {
-            get { return string.Format("#{0:X}", m_color.ToArgb()); }
+            get { return string.Format("#{0:X}", _color.ToArgb()); }
 
             set
             {
-                m_color = Color.White;
+                _color = Color.White;
 
                 value = value.Trim();
                 if (value.StartsWith("#")) // remove leading # if any
                     value = value.Substring(1);
 
                 int n;
-                if (int.TryParse(value, NumberStyles.HexNumber, null, out n)) m_color = Color.FromArgb(n);
+                if (int.TryParse(value, NumberStyles.HexNumber, null, out n)) _color = Color.FromArgb(n);
             }
         }
 
         public override string ToString()
         {
             //return GeneralToStringProvider.GeneralToString(this);
-            return string.Format("TheColor: {0}", m_color.ToString());
+            return string.Format("TheColor: {0}", _color.ToString());
         }
 
         public static ColorExample GetSampleInstance()

--- a/YAXLibTests/SampleClasses/FieldSerializationExample.cs
+++ b/YAXLibTests/SampleClasses/FieldSerializationExample.cs
@@ -11,14 +11,14 @@ namespace YAXLibTests.SampleClasses
     [YAXSerializableType(FieldsToSerialize = YAXSerializationFields.AttributedFieldsOnly)]
     public class FieldSerializationExample
     {
-        [YAXSerializableField] private readonly int m_someInt;
+        [YAXSerializableField] private readonly int _someInt;
         
-        [YAXSerializableField] private readonly double m_someDouble;
+        [YAXSerializableField] private readonly double _someDouble;
 
         public FieldSerializationExample()
         {
-            m_someInt = 8;
-            m_someDouble = 3.14;
+            _someInt = 8;
+            _someDouble = 3.14;
             SomePrivateStringProperty = "Hi";
             SomePublicPropertyThatIsNotSerialized = "Public";
         }
@@ -31,8 +31,8 @@ namespace YAXLibTests.SampleClasses
         {
             var sb = new StringBuilder();
 
-            sb.AppendLine("m_someInt: " + m_someInt);
-            sb.AppendLine("m_someDouble: " + m_someDouble);
+            sb.AppendLine("_someInt: " + _someInt);
+            sb.AppendLine("_someDouble: " + _someDouble);
             sb.AppendLine("SomePrivateStringProperty: " + SomePrivateStringProperty);
             sb.AppendLine("SomePublicPropertyThatIsNotSerialized: " + SomePublicPropertyThatIsNotSerialized);
 

--- a/YAXLibTests/SampleClasses/MoreComplexExample.cs
+++ b/YAXLibTests/SampleClasses/MoreComplexExample.cs
@@ -16,7 +16,7 @@ namespace YAXLibTests.SampleClasses
       Students - shows the usage of YAXNotCollection attribute")]
     public class MoreComplexExample
     {
-        private List<int> m_lst = new List<int>();
+        private List<int> _lst = new List<int>();
 
         [YAXDictionary(EachPairName = "PointInfo", KeyName = "PName",
             ValueName = "ThePoint", SerializeKeyAs = YAXNodeTypes.Attribute,
@@ -25,9 +25,9 @@ namespace YAXLibTests.SampleClasses
 
         public IEnumerable<int> IntEnumerable
         {
-            get { return m_lst; }
+            get { return _lst; }
 
-            set { m_lst = value.ToList(); }
+            set { _lst = value.ToList(); }
         }
 
         [YAXNotCollection] public Students Students { get; set; }
@@ -127,18 +127,18 @@ namespace YAXLibTests.SampleClasses
 
     public class StudentsEnumerator : IEnumerator<string>
     {
-        private readonly Students m_students;
+        private readonly Students _students;
         private int counter = -1;
 
         public StudentsEnumerator(Students studentsInstance)
         {
-            m_students = studentsInstance;
+            _students = studentsInstance;
             counter = -1;
         }
 
         #region IEnumerator<string> Members
 
-        public string Current => m_students.GetAt(counter);
+        public string Current => _students.GetAt(counter);
 
         #endregion
 
@@ -152,12 +152,12 @@ namespace YAXLibTests.SampleClasses
 
         #region IEnumerator Members
 
-        object IEnumerator.Current => m_students.GetAt(counter);
+        object IEnumerator.Current => _students.GetAt(counter);
 
         public bool MoveNext()
         {
             counter++;
-            if (counter >= m_students.Count)
+            if (counter >= _students.Count)
                 return false;
             return true;
         }

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -799,8 +799,8 @@ namespace YAXLibTests
                 @"<!-- This example shows how to choose the fields to be serialized -->
 <FieldSerializationExample>
   <SomePrivateStringProperty>Hi</SomePrivateStringProperty>
-  <m_someInt>8</m_someInt>
-  <m_someDouble>3.14</m_someDouble>
+  <_someInt>8</_someInt>
+  <_someDouble>3.14</_someDouble>
 </FieldSerializationExample>";
             var serializer = new YAXSerializer(typeof(FieldSerializationExample),
                 YAXExceptionHandlingPolicies.DoNotThrow, YAXExceptionTypes.Warning,


### PR DESCRIPTION
> ❌ DO NOT use Hungarian notation.

https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/general-naming-conventions

- no replace all used, but Reshaper (one by one)
- no public has been renamed
- no other renaming than removing the `m_` and `s_`. 1 test needed a change as it serialized the fields
- no code changes, no other renames

Hungarian notation is also mentioned here: https://github.com/YAXLib/YAXLib/issues/14