### PR TITLE
Fix YAXAttributeForClass and YAXValueForClass attributes are ignored when a YAXCustomSerializer is not defined on the property's type 

### DIFF
--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -608,7 +608,7 @@ namespace YAXLib
             else if (attr is YAXAttributeForClassAttribute)
             {
                 // it is required that YAXCustomSerializerAttribute is processed earlier
-                if (ReflectionUtils.IsBasicType(MemberType) || CustomSerializerType != null ||
+                if (ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer || MemberTypeWrapper.HasCustomSerializer ||
                     _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
                 {
@@ -619,7 +619,7 @@ namespace YAXLib
             else if (attr is YAXValueForClassAttribute)
             {
                 // it is required that YAXCustomSerializerAttribute is processed earlier
-                if (ReflectionUtils.IsBasicType(MemberType) || CustomSerializerType != null ||
+                if (ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer || MemberTypeWrapper.HasCustomSerializer ||
                     _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
                 {
@@ -630,7 +630,7 @@ namespace YAXLib
             else if (attr is YAXAttributeForAttribute)
             {
                 // it is required that YAXCustomSerializerAttribute is processed earlier
-                if (ReflectionUtils.IsBasicType(MemberType) || CustomSerializerType != null ||
+                if (ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer ||
                     _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
                 {
@@ -659,7 +659,7 @@ namespace YAXLib
             else if (attr is YAXValueForAttribute)
             {
                 // it is required that YAXCustomSerializerAttribute is processed earlier
-                if (ReflectionUtils.IsBasicType(MemberType) || CustomSerializerType != null ||
+                if (ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer ||
                     _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
                 {

--- a/YAXLibTests/CustomSerializerTests.cs
+++ b/YAXLibTests/CustomSerializerTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using NUnit.Framework;
+using YAXLib;
+using YAXLibTests.SampleClasses.CustomSerialization;
+
+namespace YAXLibTests
+{
+    [TestFixture]
+    public class CustomSerializerTests
+    {
+        [Test]
+        public void Custom_Class_Level_Serializer()
+        {
+            // The custom serializer handles the whole class instance
+            
+            var original = new ClassLevelSample { Title = "The Title", MessageBody = "The Message"};
+            var s = new YAXSerializer(typeof(ClassLevelSample));
+            var xml = s.Serialize(original);
+            var deserialized = (ClassLevelSample) s.Deserialize(xml);
+            
+            Assert.That(xml, Is.EqualTo("<ClassLevelSample Title=\"The Title\">The Message</ClassLevelSample>"));
+            Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()));
+        }
+        
+        [Test]
+        public void Custom_Field_Serializer()
+        {
+            // The custom serializer handles Body property
+            
+            var original = new FieldLevelSample
+            {
+                Id = "1234", // default serializer
+                Title = "This is the title", // default serializer
+                Body = "Just a short message body" // use custom serializer
+            };
+            var s = new YAXSerializer(typeof(FieldLevelSample));
+            var xml = s.Serialize(original);
+            var deserialized = (FieldLevelSample) s.Deserialize(xml);
+            var expectedXml = 
+                @"<FieldLevelSample>
+  <Id>1234</Id>
+  <Title>This is the title</Title>
+  <Body>ELE__Just a short message body</Body>
+</FieldLevelSample>";
+            
+            Assert.That(xml, Is.EqualTo(expectedXml));
+            Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()));
+        }
+        
+        [Test]
+        public void Custom_Field_Serializer_Combined()
+        {
+            // All properties will use the same serializer
+            // in combination with YAXAttributeForClass and YAXValueForClass
+            
+            var original = new FieldLevelCombinedSample
+                {
+                    Id = "1234", // serialize as class attribute
+                    Title = "This is the title", // serialize as element
+                    Body = "Just a short message body" // serialize as value
+                };
+            var s = new YAXSerializer(typeof(FieldLevelCombinedSample));
+            var xml = s.Serialize(original);
+            var deserialized = (FieldLevelCombinedSample) s.Deserialize(xml);
+            var expectedXml = 
+@"<FieldLevelCombinedSample Id=""ATTR_1234"">
+  <Title>ELE__This is the title</Title>VAL__Just a short message body</FieldLevelCombinedSample>";
+            
+            Assert.That(xml, Is.EqualTo(expectedXml));
+            Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()));
+        }
+    }
+}

--- a/YAXLibTests/CustomSerializerTests.cs
+++ b/YAXLibTests/CustomSerializerTests.cs
@@ -11,16 +11,51 @@ namespace YAXLibTests
     public class CustomSerializerTests
     {
         [Test]
-        public void Custom_Class_Level_Serializer()
+        public void Custom_Class_Level_Serializer_Element()
         {
-            // The custom serializer handles the whole class instance
-            
-            var original = new ClassLevelSample { Title = "The Title", MessageBody = "The Message"};
-            var s = new YAXSerializer(typeof(ClassLevelSample));
+            // The custom serializer for ClassLevelSample handles serialization options
+
+            var original = new ClassLevelSampleAsElement
+                {ClassLevelSample = new ClassLevelSample {Title = "The Title", MessageBody = "The Message"}};
+            var s = new YAXSerializer(typeof(ClassLevelSampleAsElement));
             var xml = s.Serialize(original);
-            var deserialized = (ClassLevelSample) s.Deserialize(xml);
+            var deserialized = (ClassLevelSampleAsElement) s.Deserialize(xml);
             
-            Assert.That(xml, Is.EqualTo("<ClassLevelSample Title=\"The Title\">The Message</ClassLevelSample>"));
+            Assert.That(xml, Is.EqualTo(@"<ClassLevelSampleAsElement>
+  <ClassLevelSample>
+    <Title>The Title</Title>
+    <MessageBody>The Message</MessageBody>
+  </ClassLevelSample>
+</ClassLevelSampleAsElement>"));
+            Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()));
+        }
+        
+        [Test]
+        public void Custom_Class_Level_Serializer_Attribute()
+        {
+            // The custom serializer for ClassLevelSample handles serialization options
+
+            var original = new ClassLevelSampleAsAttribute
+                {ClassLevelSample = new ClassLevelSample {Title = "The Title", MessageBody = "The Message"}};
+            var s = new YAXSerializer(typeof(ClassLevelSampleAsAttribute));
+            var xml = s.Serialize(original);
+            var deserialized = (ClassLevelSampleAsAttribute) s.Deserialize(xml);
+            
+            Assert.That(xml, Is.EqualTo("<ClassLevelSampleAsAttribute ClassLevelSample=\"ATTR|The Title|The Message\" />"));
+            Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()));
+        }
+        
+        [Test]
+        public void Custom_Class_Level_Serializer_Value()
+        {
+            // The custom serializer for ClassLevelSample handles serialization options
+            
+            var original = new ClassLevelSampleAsValue { ClassLevelSample = new ClassLevelSample { Title = "The Title", MessageBody = "The Message"}};
+            var s = new YAXSerializer(typeof(ClassLevelSampleAsValue));
+            var xml = s.Serialize(original);
+            var deserialized = (ClassLevelSampleAsValue) s.Deserialize(xml);
+            
+            Assert.That(xml, Is.EqualTo("<ClassLevelSampleAsValue>VAL|The Title|The Message</ClassLevelSampleAsValue>"));
             Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()));
         }
         

--- a/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelSample.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelSample.cs
@@ -15,7 +15,31 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
         public string MessageBody { get; set; }
         
         public string Title { get; set; }
-        
+    }
+
+    public class ClassLevelSampleAsElement
+    {
+        public ClassLevelSample ClassLevelSample { get; set; }
+        public override string ToString()
+        {
+            return GeneralToStringProvider.GeneralToString(this);
+        }
+    }
+    
+    public class ClassLevelSampleAsAttribute
+    {
+        [YAXAttributeForClass]
+        public ClassLevelSample ClassLevelSample { get; set; }
+        public override string ToString()
+        {
+            return GeneralToStringProvider.GeneralToString(this);
+        }
+    }
+    
+    public class ClassLevelSampleAsValue
+    {
+        [YAXValueForClass]
+        public ClassLevelSample ClassLevelSample { get; set; }
         public override string ToString()
         {
             return GeneralToStringProvider.GeneralToString(this);

--- a/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelSample.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelSample.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses.CustomSerialization
+{
+    [YAXCustomSerializer(typeof(ClassLevelSerializer))]
+    public class ClassLevelSample
+    {
+        public string MessageBody { get; set; }
+        
+        public string Title { get; set; }
+        
+        public override string ToString()
+        {
+            return GeneralToStringProvider.GeneralToString(this);
+        }
+    }
+}

--- a/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelSerializer.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelSerializer.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Xml.Linq;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses.CustomSerialization
+{
+    public class ClassLevelSerializer : ICustomSerializer<ClassLevelSample>
+    {
+        public void SerializeToAttribute(ClassLevelSample objectToSerialize, XAttribute attrToFill)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SerializeToElement(ClassLevelSample objectToSerialize, XElement elemToFill)
+        {
+            elemToFill.Add(new XText(objectToSerialize.MessageBody));
+            elemToFill.SetAttributeValue(nameof(objectToSerialize.Title), objectToSerialize.Title);
+        }
+
+        public string SerializeToValue(ClassLevelSample objectToSerialize)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ClassLevelSample DeserializeFromAttribute(XAttribute attrib)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ClassLevelSample DeserializeFromElement(XElement element)
+        {
+            return new ClassLevelSample
+                {MessageBody = element.Value, Title = element.Attribute(nameof(ClassLevelSample.Title))?.Value};
+        }
+
+        public ClassLevelSample DeserializeFromValue(string value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelSerializer.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelSerializer.cs
@@ -11,34 +11,39 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
     {
         public void SerializeToAttribute(ClassLevelSample objectToSerialize, XAttribute attrToFill)
         {
-            throw new NotImplementedException();
+            attrToFill.Value = string.Join("|", "ATTR", objectToSerialize.Title, objectToSerialize.MessageBody);
         }
 
         public void SerializeToElement(ClassLevelSample objectToSerialize, XElement elemToFill)
         {
-            elemToFill.Add(new XText(objectToSerialize.MessageBody));
-            elemToFill.SetAttributeValue(nameof(objectToSerialize.Title), objectToSerialize.Title);
+            elemToFill.Add(new XElement(nameof(objectToSerialize.Title), objectToSerialize.Title));
+            elemToFill.Add(new XElement(nameof(objectToSerialize.MessageBody), objectToSerialize.MessageBody));
         }
 
         public string SerializeToValue(ClassLevelSample objectToSerialize)
         {
-            throw new NotImplementedException();
+            return string.Join("|", "VAL", objectToSerialize.Title, objectToSerialize.MessageBody);
         }
 
         public ClassLevelSample DeserializeFromAttribute(XAttribute attrib)
         {
-            throw new NotImplementedException();
+            var split = attrib.Value.Split('|');
+            return new ClassLevelSample {Title = split[1], MessageBody = split[2]};
         }
 
         public ClassLevelSample DeserializeFromElement(XElement element)
         {
-            return new ClassLevelSample
-                {MessageBody = element.Value, Title = element.Attribute(nameof(ClassLevelSample.Title))?.Value};
+            return new ClassLevelSample {
+                Title = element.Element(nameof(ClassLevelSample.Title))?.Value,
+                MessageBody = element.Element(nameof(ClassLevelSample.MessageBody))?.Value
+            };
         }
 
         public ClassLevelSample DeserializeFromValue(string value)
         {
-            throw new NotImplementedException();
+            var split = value.Split('|');
+            return new ClassLevelSample {Title = split[1], MessageBody = split[2]};
+
         }
     }
 }

--- a/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelCombinedSample.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelCombinedSample.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses.CustomSerialization
+{
+    /// <summary>
+    /// Combines the universal <see cref="FieldLevelCombinedSerializer"/> for each field
+    /// with more attributes that determine how properties will be serialized.
+    /// </summary>
+    public class FieldLevelCombinedSample
+    {
+        [YAXCustomSerializer(typeof(FieldLevelCombinedSerializer))]
+        [YAXAttributeForClass]
+        public string Id { get; set; }
+        
+        /// <summary>
+        /// Serialize as element
+        /// </summary>
+        [YAXCustomSerializer(typeof(FieldLevelCombinedSerializer))]
+        public string Title { get; set; }
+        
+        [YAXCustomSerializer(typeof(FieldLevelCombinedSerializer))]
+        [YAXValueForClass]
+        public string Body { get; set; }
+
+        public override string ToString()
+        {
+            return GeneralToStringProvider.GeneralToString(this);
+        }
+    }
+}

--- a/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelCombinedSerializer.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelCombinedSerializer.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Xml.Linq;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses.CustomSerialization
+{
+    public class FieldLevelCombinedSerializer : ICustomSerializer<string>
+    {
+        public void SerializeToAttribute(string objectToSerialize, XAttribute attrToFill)
+        {
+            attrToFill.Value = "ATTR_" + objectToSerialize;
+        }
+
+        public void SerializeToElement(string objectToSerialize, XElement elemToFill)
+        {
+            elemToFill.Add(new XText("ELE__" + objectToSerialize));
+        }
+
+        public string SerializeToValue(string objectToSerialize)
+        {
+            return "VAL__" + objectToSerialize;
+        }
+
+        public string DeserializeFromAttribute(XAttribute attrib)
+        {
+            return attrib.Value.Substring(5);
+        }
+
+        public string DeserializeFromElement(XElement element)
+        {
+            return element.Value.Substring(5);
+        }
+
+        public string DeserializeFromValue(string value)
+        {
+            return value.Substring(5);
+        }
+    }
+}

--- a/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelSample.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelSample.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses.CustomSerialization
+{
+    public class FieldLevelSample
+    {
+        public string Id { get; set; }
+        
+        public string Title { get; set; }
+        
+        [YAXCustomSerializer(typeof(FieldLevelSerializer))]
+        public string Body { get; set; }
+
+        public override string ToString()
+        {
+            return GeneralToStringProvider.GeneralToString(this);
+        }
+    }
+}

--- a/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelSerializer.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelSerializer.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Xml.Linq;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses.CustomSerialization
+{
+    public class FieldLevelSerializer : ICustomSerializer<string>
+    {
+        public void SerializeToAttribute(string objectToSerialize, XAttribute attrToFill)
+        {
+            attrToFill.Value = "ATTR_" + objectToSerialize;
+        }
+
+        public void SerializeToElement(string objectToSerialize, XElement elemToFill)
+        {
+            elemToFill.Add(new XText("ELE__" + objectToSerialize));
+        }
+
+        public string SerializeToValue(string objectToSerialize)
+        {
+            return "VAL__" + objectToSerialize;
+        }
+
+        public string DeserializeFromAttribute(XAttribute attrib)
+        {
+            return attrib.Value.Substring(5);
+        }
+
+        public string DeserializeFromElement(XElement element)
+        {
+            return element.Value.Substring(5);
+        }
+
+        public string DeserializeFromValue(string value)
+        {
+            return value.Substring(5);
+        }
+    }
+}

--- a/YAXLibTests/SampleClasses/CustomSerializationDemoClasses.cs
+++ b/YAXLibTests/SampleClasses/CustomSerializationDemoClasses.cs
@@ -8,7 +8,7 @@ using YAXLib;
 
 namespace YAXLibTests.SampleClasses
 {
-    [YAXCustomSerializer(typeof(CustomMessageSerializer))]
+    [YAXCustomSerializer(typeof(CustomMessageClassSerializer))]
     public class Message
     {
         public string MessageText { get; set; }
@@ -23,7 +23,7 @@ namespace YAXLibTests.SampleClasses
     }
 
     [ShowInDemoApplication]
-    public class CustomSerializationTests
+    public class CustomSerializationDemoClasses
     {
         [YAXCustomSerializer(typeof(CustomTitleSerializer))]
         [YAXElementFor("SomeTitle")]
@@ -36,7 +36,7 @@ namespace YAXLibTests.SampleClasses
             return GeneralToStringProvider.GeneralToString(this);
         }
 
-        public static CustomSerializationTests GetSampleInstance()
+        public static CustomSerializationDemoClasses GetSampleInstance()
         {
             var message = new Message
             {
@@ -46,7 +46,7 @@ namespace YAXLibTests.SampleClasses
                 BoldLength = 3
             };
 
-            return new CustomSerializationTests
+            return new CustomSerializationDemoClasses
             {
                 Title = "Important Note",
                 Message = message
@@ -54,7 +54,7 @@ namespace YAXLibTests.SampleClasses
         }
     }
 
-    public class CustomMessageSerializer : ICustomSerializer<Message>
+    public class CustomMessageClassSerializer : ICustomSerializer<Message>
     {
         #region ICustomSerializer<Message> Members
 
@@ -135,20 +135,20 @@ namespace YAXLibTests.SampleClasses
 
         public string DeserializeFromAttribute(XAttribute attrib)
         {
-            return RetreiveValue(attrib.Value);
+            return RetrieveValue(attrib.Value);
         }
 
         public string DeserializeFromElement(XElement element)
         {
-            return RetreiveValue(element.Value);
+            return RetrieveValue(element.Value);
         }
 
         public string DeserializeFromValue(string value)
         {
-            return RetreiveValue(value);
+            return RetrieveValue(value);
         }
 
-        private string RetreiveValue(string str)
+        private string RetrieveValue(string str)
         {
             var sb = new StringBuilder();
 


### PR DESCRIPTION
- Modified `MemberWrapper` to fix #97 
- Added unit tests for `ICustomSerializer`s
- Renamed file `CustomSerializationTests.cs` to `CustomSerializationDemoClasses.cs`(only used for demo app)
