### PR TITLE
Serialize boolean as ToLowerInvariant()

### DIFF
--- a/YAXLib/XMLUtils.cs
+++ b/YAXLib/XMLUtils.cs
@@ -425,17 +425,19 @@ namespace YAXLib
         }
 
         /// <summary>
-        /// Gets the string representation of the object.
+        /// Gets the string representation of the object, or <see cref="string.Empty"/> if the object is <see langword="null"/>.
         /// </summary>
         /// <param name="self">The object to get as a string.</param>
         /// <param name="culture">The <see cref="CultureInfo"/> to use for culture-specific output.</param>
-        /// <returns>The <see cref="CultureInfo"/>-aware string representation of the object.</returns>
+        /// <returns>The <see cref="CultureInfo"/>-aware string representation of the object, or <see cref="string.Empty"/> if the object is <see langword="null"/>.</returns>
         public static string ToXmlValue(this object self, CultureInfo culture)
         {
-            var typeName = self == null ? string.Empty : self.GetType().Name;
-
-            switch (typeName)
+            if (self == null) return string.Empty;
+            
+            switch (self.GetType().Name)
             {
+                case "Boolean":
+                    return ((bool) self).ToString().ToLowerInvariant();
                 case "Double":
                     return ((double) self).ToString("R", culture);
                 case "Single":
@@ -444,7 +446,7 @@ namespace YAXLib
                     return ReflectionUtils.InvokeMethod(self, "ToString", "R", culture) as string;
             }
 
-            return Convert.ToString(self ?? string.Empty, culture);
+            return Convert.ToString(self, culture);
         }
 
         public static XAttribute AddAttributeNamespaceSafe(this XElement parent, XName attrName, object attrValue,

--- a/YAXLibTests/NamespaceTest.cs
+++ b/YAXLibTests/NamespaceTest.cs
@@ -32,7 +32,7 @@ namespace YAXLibTests
             const string result =
                 @"<!-- This example shows usage of a number of custom namespaces -->
 <ns1:MultipleNamespaceSample xmlns:ns1=""http://namespaces.org/ns1"" xmlns:ns2=""http://namespaces.org/ns2"" xmlns:ns3=""http://namespaces.org/ns3"">
-  <ns1:BoolItem>True</ns1:BoolItem>
+  <ns1:BoolItem>true</ns1:BoolItem>
   <ns2:StringItem>This is a test string</ns2:StringItem>
   <ns3:IntItem>10</ns3:IntItem>
 </ns1:MultipleNamespaceSample>";
@@ -493,14 +493,14 @@ namespace YAXLibTests
     <AssemblyName>$safeprojectname$</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <DebugSymbols>False</DebugSymbols>
-    <Optimize>False</Optimize>
+    <DebugSymbols>false</DebugSymbols>
+    <Optimize>false</Optimize>
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugSymbols>True</DebugSymbols>
+    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>False</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -508,9 +508,9 @@ namespace YAXLibTests
     <DocumentationFile>bin\Debug\$safeprojectname$.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugSymbols>False</DebugSymbols>
+    <DebugSymbols>false</DebugSymbols>
     <DebugType>pdbonly</DebugType>
-    <Optimize>True</Optimize>
+    <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -519,31 +519,31 @@ namespace YAXLibTests
   <ItemGroup>
     <Reference Include=""$generatedproject$.EFDAL.Interfaces"">
       <HintPath>..\bin\$generatedproject$.EFDAL.Interfaces.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include=""System"">
-      <SpecificVersion>False</SpecificVersion>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include=""System.Core"">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
-      <SpecificVersion>False</SpecificVersion>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include=""nHydrate.EFCore, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL"">
       <HintPath>..\bin\nHydrate.EFCore.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include=""$generatedproject$.EFDAL.Interfaces"">
       <HintPath>..\bin\$generatedproject$.EFDAL.Interfaces.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include=""System"">
-      <SpecificVersion>False</SpecificVersion>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include=""System.Core"">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
-      <SpecificVersion>False</SpecificVersion>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
   </ItemGroup>
   <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -384,7 +384,7 @@ namespace YAXLibTests
                 @"<!-- This example is used in the article to show YAXLib exception handling policies -->
 <ProgrammingLanguage>
   <LanguageName>C#</LanguageName>
-  <IsCaseSensitive>True</IsCaseSensitive>
+  <IsCaseSensitive>true</IsCaseSensitive>
 </ProgrammingLanguage>";
             var serializer = new YAXSerializer(typeof(ProgrammingLanguage), YAXExceptionHandlingPolicies.DoNotThrow,
                 YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
@@ -706,7 +706,7 @@ namespace YAXLibTests
                 @"<NullableSample2 Number=""10"">
   <DateTime>1980-04-11T13:37:01.2345678Z</DateTime>
   <Decimal>1234.56789</Decimal>
-  <Boolean>True</Boolean>
+  <Boolean>true</Boolean>
   <Enum>Third</Enum>
 </NullableSample2>";
             var serializer = new YAXSerializer(typeof(NullableSample2), YAXExceptionHandlingPolicies.DoNotThrow,
@@ -724,7 +724,7 @@ namespace YAXLibTests
                 @"<NullableSample2>
   <DateTime>1980-04-11T13:37:01.2345678Z</DateTime>
   <Decimal>1234.56789</Decimal>
-  <Boolean>True</Boolean>
+  <Boolean>true</Boolean>
   <Enum>Third</Enum>
 </NullableSample2>";
             var serializer = new YAXSerializer(typeof(NullableSample2), YAXExceptionHandlingPolicies.DoNotThrow,
@@ -1371,16 +1371,16 @@ namespace YAXLibTests
     </Object>
   </TheSortedList>
   <TheBitArray>
-    <Object yaxlib:realtype=""System.Boolean"">False</Object>
-    <Object yaxlib:realtype=""System.Boolean"">True</Object>
-    <Object yaxlib:realtype=""System.Boolean"">False</Object>
-    <Object yaxlib:realtype=""System.Boolean"">False</Object>
-    <Object yaxlib:realtype=""System.Boolean"">False</Object>
-    <Object yaxlib:realtype=""System.Boolean"">False</Object>
-    <Object yaxlib:realtype=""System.Boolean"">True</Object>
-    <Object yaxlib:realtype=""System.Boolean"">False</Object>
-    <Object yaxlib:realtype=""System.Boolean"">False</Object>
-    <Object yaxlib:realtype=""System.Boolean"">False</Object>
+    <Object yaxlib:realtype=""System.Boolean"">false</Object>
+    <Object yaxlib:realtype=""System.Boolean"">true</Object>
+    <Object yaxlib:realtype=""System.Boolean"">false</Object>
+    <Object yaxlib:realtype=""System.Boolean"">false</Object>
+    <Object yaxlib:realtype=""System.Boolean"">false</Object>
+    <Object yaxlib:realtype=""System.Boolean"">false</Object>
+    <Object yaxlib:realtype=""System.Boolean"">true</Object>
+    <Object yaxlib:realtype=""System.Boolean"">false</Object>
+    <Object yaxlib:realtype=""System.Boolean"">false</Object>
+    <Object yaxlib:realtype=""System.Boolean"">false</Object>
   </TheBitArray>
 </NonGenericCollectionsSample>";
 


### PR DESCRIPTION
Closes #78 
- **breaking change:** booleans are serialized as `ToLowerInvariant() `
- de-serialization normalizes the `xml` value before converting to boolean; no changes here, and v2.x backward compatibility ensured
- test are sufficient already - changed expected string literals (`True` -> `true`, `False` -> `false`)
