### PR TITLE
Exception de/serialization 

### DIFF
--- a/YAXLib/KnownTypes/ColorDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/ColorDynamicKnownType.cs
@@ -8,8 +8,10 @@ namespace YAXLib
 {
     internal class ColorDynamicKnownType : DynamicKnownType
     {
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
         public override string TypeName => "System.Drawing.Color";
-
+        
         public override void Serialize(object obj, XElement elem, XNamespace overridingNamespace)
         {
             var objectType = obj.GetType();

--- a/YAXLib/KnownTypes/DataSetDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/DataSetDynamicKnownType.cs
@@ -9,6 +9,8 @@ namespace YAXLib
 {
     internal class DataSetDynamicKnownType : DynamicKnownType
     {
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
         public override string TypeName => "System.Data.DataSet";
 
         public override void Serialize(object obj, XElement elem, XNamespace overridingNamespace)

--- a/YAXLib/KnownTypes/DataTableDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/DataTableDynamicKnownType.cs
@@ -9,6 +9,8 @@ namespace YAXLib
 {
     internal class DataTableDynamicKnownType : DynamicKnownType
     {
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
         public override string TypeName => "System.Data.DataTable";
 
         public override void Serialize(object obj, XElement elem, XNamespace overridingNamespace)

--- a/YAXLib/KnownTypes/DbNullKnownType.cs
+++ b/YAXLib/KnownTypes/DbNullKnownType.cs
@@ -8,6 +8,9 @@ namespace YAXLib
 {
     internal class DbNullKnownType : KnownType<DBNull>
     {
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
+
         public override void Serialize(DBNull obj, XElement elem, XNamespace overridingNamespace)
         {
             if (obj != null)

--- a/YAXLib/KnownTypes/DynamicKnownType.cs
+++ b/YAXLib/KnownTypes/DynamicKnownType.cs
@@ -3,13 +3,16 @@
 
 using System;
 using System.Xml.Linq;
+using YAXLib.Options;
 
 namespace YAXLib
 {
     internal abstract class DynamicKnownType : IKnownType
     {
         private Type _type;
-
+        public abstract bool CanSerialize { get; }
+        public abstract bool CanDeserialize { get; }
+        public SerializerOptions Options { get; set; }
         public abstract string TypeName { get; }
 
         public Type Type

--- a/YAXLib/KnownTypes/ExceptionKnownBaseType.cs
+++ b/YAXLib/KnownTypes/ExceptionKnownBaseType.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Xml.Linq;
+using YAXLib.Options;
+
+namespace YAXLib
+{
+    internal class ExceptionKnownBaseType : KnownType<Exception>
+    {
+        internal const string ObjectGraphElementName = "Exception-Graph";
+        private int _recursion;
+
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
+        internal bool SerializeObjectGraph { get; set; } = true;
+
+        public override void Serialize(Exception obj, XElement elem, XNamespace overridingNamespace)
+        {
+            if (obj == null) return;
+
+            if (_recursion >= Options.MaxRecursion)
+                return;
+
+            // We serialize the whole object graph
+            if (_recursion == 0)
+            {
+                elem.Name = nameof(Exception);
+                // Unprefixed attributes use the default namespace, i.e. mostly from the element
+                elem.Add(new XAttribute("type", obj.GetType().AssemblyQualifiedName ?? string.Empty));
+
+                if (SerializeObjectGraph && TrySerializeObjectGraph(obj, out var value))
+                {
+                    var objElement = new XElement(ObjectGraphElementName, overridingNamespace, value);
+                    elem.Add(new XComment("Base64 encoded result from " + typeof(System.Runtime.Serialization.Formatters.Binary.BinaryFormatter).FullName));
+                    elem.Add(objElement);
+                }
+            }
+
+            foreach (var member in new YAXSerializer(obj.GetType(), new SerializerOptions{MaxRecursion = 1}).GetFieldsToBeSerialized())
+            {
+                // We MUST NOT use a custom serializer for Exception types, as this known type class is expected
+                // to process this type. Doing different will lead to an infinite loop.
+                if (!ReflectionUtils.IsBaseClassOrSubclassOf(member.MemberType, "System.Exception"))
+                {
+                    var value = member.GetValue(obj);
+                    if (value == null || ReflectionUtils.IsBasicType(value.GetType()))
+                    {
+                        elem.Add(new XElement(member.Alias, overridingNamespace, value));
+                    }
+                    else if (member.OriginalName == nameof(Exception.TargetSite))
+                    {
+                        elem.Add(new XElement(member.Alias, overridingNamespace, value));
+                    }
+                    else
+                    {
+                        // Without a recursion limit it could happen
+                        // that this is instance gets called from the memberSerializer
+                        var memberSerializer = new YAXSerializer(member.MemberType, new SerializerOptions {MaxRecursion = 1});
+                        var parent = new XElement(member.Alias, overridingNamespace);
+                        var element = memberSerializer.SerializeToXDocument(value).Root;
+                        if (!XMLUtils.IsElementCompletelyEmpty(element)) parent.Add(element);
+                        elem.Add(parent);
+                    }
+                } 
+                else
+                {
+                    var exElement =
+                        new XElement(member.OriginalName == "InnerException" ? member.OriginalName : "Exception",
+                            overridingNamespace); // Alias not used
+                    var ex = member.GetValue(obj) as Exception;
+                    if (ex != null)
+                    {
+                        exElement.Add(new XAttribute("type", ex.GetType().FullName ?? string.Empty)); // Alias not used
+                    }
+                    elem.Add(exElement);
+                    _recursion++;
+                    Serialize(ex, exElement, overridingNamespace);
+                    _recursion--;
+                }
+            }
+        }
+
+        public override Exception? Deserialize(XElement elem, XNamespace overridingNamespace)
+        {
+            // Only the Exception can be deserialized
+            if (SerializeObjectGraph && TryDeserializeObjectGraph(elem, out var exception))
+            {
+                return exception;
+            }
+
+            var exType = Type.GetType(elem.Attribute("type")?.Value ?? string.Empty);
+            if (exType != null)
+            {
+                var exInstance = Activator.CreateInstance(exType, Array.Empty<object>()) as Exception;
+                return exInstance;
+            }
+
+            return null;
+        }
+
+        private static bool TrySerializeObjectGraph(object obj, out string? value)
+        {
+            try
+            {
+                using var stream = new System.IO.MemoryStream();
+                var formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                formatter.Serialize(stream, obj);
+                stream.Flush();
+                value = Convert.ToBase64String(stream.GetBuffer(), 0, (int) stream.Length);
+                return true;
+            }
+            catch
+            {
+                // Not marked as Serializable
+                // Nothing to do
+            }
+            
+            value = null;
+            return false;
+        }
+
+        private static bool TryDeserializeObjectGraph(XElement elem, out Exception? exception)
+        {
+            try
+            {
+                var oGraph = XMLUtils.FindElement(elem, ".", ObjectGraphElementName);
+                if (oGraph != null)
+                {
+                    using var stream = new System.IO.MemoryStream(Convert.FromBase64String(oGraph.Value));
+                    stream.Seek(0, System.IO.SeekOrigin.Begin);
+                    var formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                    exception = formatter.Deserialize(stream) as Exception;
+                    stream.Close();
+                    return true;
+                }
+            }
+            catch
+            {
+                // Nothing to do
+            }
+
+            exception = null;
+            return false;
+        }
+    }
+}

--- a/YAXLib/KnownTypes/IKnownType.cs
+++ b/YAXLib/KnownTypes/IKnownType.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Xml.Linq;
+using YAXLib.Options;
 
 namespace YAXLib
 {
@@ -12,6 +13,21 @@ namespace YAXLib
         ///     Gets the underlying known type.
         /// </summary>
         Type Type { get; }
+
+        /// <summary>
+        ///     Returns <see langword="true"/>, if <see cref="IKnownType.Serialize"/> is implemented.
+        /// </summary>
+        bool CanSerialize { get; }
+
+        /// <summary>
+        ///     Returns <see langword="true"/>, if <see cref="IKnownType.Deserialize"/> is implemented.
+        /// </summary>
+        bool CanDeserialize { get; }
+
+        /// <summary>
+        ///    Gets or sets the <see cref="SerializerOptions"/>.
+        /// </summary>
+        SerializerOptions Options { get; set; }
 
         /// <summary>
         ///     Serializes the specified object int the specified XML element.

--- a/YAXLib/KnownTypes/KnownType.cs
+++ b/YAXLib/KnownTypes/KnownType.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Xml.Linq;
+using YAXLib.Options;
 
 namespace YAXLib
 {
@@ -17,11 +18,23 @@ namespace YAXLib
         /// </summary>
         public Type Type => typeof(T);
 
+        /// <summary>
+        ///     Returns <see langword="true"/>, if <see cref="IKnownType.Serialize"/> is implemented.
+        /// </summary>
+        public abstract bool CanSerialize { get; }
+
+        /// <summary>
+        ///     Returns <see langword="true"/>, if <see cref="IKnownType.Deserialize"/> is implemented.
+        /// </summary>
+        public abstract bool CanDeserialize { get; }
+
+        public SerializerOptions Options { get; set; }
+
         void IKnownType.Serialize(object obj, XElement elem, XNamespace overridingNamespace)
         {
             Serialize((T) obj, elem, overridingNamespace);
         }
-
+        
         object IKnownType.Deserialize(XElement baseElement, XNamespace overridingNamespace)
         {
             return Deserialize(baseElement, overridingNamespace);

--- a/YAXLib/KnownTypes/RectangleDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/RectangleDynamicKnownType.cs
@@ -8,6 +8,8 @@ namespace YAXLib
 {
     internal class RectangleDynamicKnownType : DynamicKnownType
     {
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
         public override string TypeName => "System.Drawing.Rectangle";
 
         public override void Serialize(object obj, XElement elem, XNamespace overridingNamespace)

--- a/YAXLib/KnownTypes/RuntimeTypeDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/RuntimeTypeDynamicKnownType.cs
@@ -8,6 +8,8 @@ namespace YAXLib
 {
     internal class RuntimeTypeDynamicKnownType : DynamicKnownType
     {
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
         public override string TypeName => "System.RuntimeType";
 
         public override void Serialize(object obj, XElement elem, XNamespace overridingNamespace)

--- a/YAXLib/KnownTypes/TimeSpanKnownType.cs
+++ b/YAXLib/KnownTypes/TimeSpanKnownType.cs
@@ -8,6 +8,9 @@ namespace YAXLib
 {
     internal class TimeSpanKnownType : KnownType<TimeSpan>
     {
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
+
         public override void Serialize(TimeSpan timeSpan, XElement elem, XNamespace overridingNamespace)
         {
             elem.Value = timeSpan.ToString();

--- a/YAXLib/KnownTypes/TypeKnownType.cs
+++ b/YAXLib/KnownTypes/TypeKnownType.cs
@@ -8,6 +8,9 @@ namespace YAXLib
 {
     internal class TypeKnownType : KnownType<Type>
     {
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
+
         public override void Serialize(Type obj, XElement elem, XNamespace overridingNamespace)
         {
             if (obj != null)

--- a/YAXLib/KnownTypes/XAttributeKnownType.cs
+++ b/YAXLib/KnownTypes/XAttributeKnownType.cs
@@ -8,6 +8,9 @@ namespace YAXLib
 {
     internal class XAttributeKnownType : KnownType<XAttribute>
     {
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
+
         public override void Serialize(XAttribute obj, XElement elem, XNamespace overridingNamespace)
         {
             if (obj != null) elem.Add(obj);

--- a/YAXLib/KnownTypes/XElementKnownType.cs
+++ b/YAXLib/KnownTypes/XElementKnownType.cs
@@ -8,6 +8,9 @@ namespace YAXLib
 {
     internal class XElementKnownType : KnownType<XElement>
     {
+        public override bool CanSerialize => true;
+        public override bool CanDeserialize => true;
+
         public override void Serialize(XElement obj, XElement elem, XNamespace overridingNamespace)
         {
             if (obj != null) elem.Add(obj);

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -773,7 +773,6 @@ namespace YAXLib
         {
             return (T) srcObj.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance)
                 ?.GetValue(srcObj, null);
-            //return (T)srcObj.GetType().InvokeMember(propertyName, BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, srcObj, null);
         }
 
         public static T InvokeIntIndexer<T>(object srcObj, string propertyName, int index)
@@ -796,6 +795,13 @@ namespace YAXLib
             var method = srcObj.GetType().GetMethod(methodName, argTypes);
             var result = method?.Invoke(srcObj, args);
             return result;
+        }
+
+        public static bool IsBaseClassOrSubclassOf(Type subType, string baseName)
+        {
+            if (baseName == null || subType == null) return false;
+            var baseType = Type.GetType(baseName);
+            return baseType != null && (subType.FullName == baseName || subType.IsSubclassOf(baseType));
         }
     }
 }

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -12,6 +12,11 @@ namespace YAXLib
     internal class UdtWrapper
     {
         /// <summary>
+        ///     The serializer that creates this instance.
+        /// </summary>
+        private readonly YAXSerializer _callerSerializer;
+
+        /// <summary>
         ///     boolean value indicating whether this instance is a wrapper around a collection type
         /// </summary>
         private readonly bool _isTypeCollection;
@@ -76,8 +81,9 @@ namespace YAXLib
             Comment = null;
             FieldsToSerialize = YAXSerializationFields.PublicPropertiesOnly;
             IsAttributedAsNotCollection = false;
-
+            
             SetYAXSerializerOptions(callerSerializer);
+            _callerSerializer = callerSerializer;
             
             foreach (var attr in _udtType.GetCustomAttributes(true))
                 if (attr is YAXBaseAttribute)
@@ -150,7 +156,7 @@ namespace YAXLib
         /// <summary>
         ///     Gets a value indicating whether the underlying type is a known-type
         /// </summary>
-        public bool IsKnownType => KnownTypes.IsKnowType(_udtType);
+        public bool IsKnownType => KnownTypes.TryGetKnownType(_udtType, _callerSerializer.Options, out _);
 
         /// <summary>
         ///     Gets a value indicating whether this instance wraps around an enum.

--- a/YAXLibTests/SampleClasses/ExceptionTestSample.cs
+++ b/YAXLibTests/SampleClasses/ExceptionTestSample.cs
@@ -6,14 +6,13 @@ using System.Threading;
 
 namespace YAXLibTests.SampleClasses
 {
-    // No [Serializable] attribute
-    public class ExceptionNotSerializable : Exception
+    public class CustomException : Exception
     {
-        public ExceptionNotSerializable(string message) : this()
+        public CustomException(string message) : this()
         {
             Info = message;
         }
-        public ExceptionNotSerializable()
+        public CustomException()
         {
             Info = "Parameterless constructor";
             DivideByZeroException = new DivideByZeroException("1/0", new AbandonedMutexException());
@@ -40,7 +39,7 @@ namespace YAXLibTests.SampleClasses
 
         public void CreateNotSerializableException()
         {
-            var ex = new ExceptionNotSerializable("Exception has no Serializable attribute");
+            var ex = new CustomException("This is a custom exception");
             ex.Data.Add("TheKey", "TheValue");
             throw ex;
         }

--- a/YAXLibTests/SampleClasses/ExceptionTestSample.cs
+++ b/YAXLibTests/SampleClasses/ExceptionTestSample.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Threading;
+
+namespace YAXLibTests.SampleClasses
+{
+    // No [Serializable] attribute
+    public class ExceptionNotSerializable : Exception
+    {
+        public ExceptionNotSerializable(string message) : this()
+        {
+            Info = message;
+        }
+        public ExceptionNotSerializable()
+        {
+            Info = "Parameterless constructor";
+            DivideByZeroException = new DivideByZeroException("1/0", new AbandonedMutexException());
+        }
+
+        public string Info { get; set; }
+
+        public DivideByZeroException DivideByZeroException { get; set; }
+    }
+
+    public class ExceptionTestSample
+    {
+        public void CreateInnerSystemExceptions()
+        {
+            try
+            {
+                var c = "dummy".ToCharArray()[int.MaxValue];
+            }
+            catch (IndexOutOfRangeException e1)
+            {
+                throw new ArgumentOutOfRangeException("x-axis", e1);
+            }
+        }
+
+        public void CreateNotSerializableException()
+        {
+            var ex = new ExceptionNotSerializable("Exception has no Serializable attribute");
+            ex.Data.Add("TheKey", "TheValue");
+            throw ex;
+        }
+    }
+}

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -2295,38 +2295,7 @@ namespace YAXLibTests
         /// <see cref="Exception"/>s are serialized using the <see cref="ExceptionKnownBaseType"/>.
         /// </summary>
         [Test]
-        public void Exception_Serializable()
-        {
-            try
-            {
-                // throws System exceptions which are all ISerializable
-                new ExceptionTestSample().CreateInnerSystemExceptions();
-            }
-            catch (Exception ex)
-            {
-                // Use serializer with default MaxRecursion
-                var ser = new YAXSerializer(ex.GetType());
-                
-                var exceptionSerialized = ser.Serialize(ex);
-                var deserialized = (Exception) ser.Deserialize(exceptionSerialized);
-                Assert.That(exceptionSerialized, Does.Contain("<InnerException type=\"System.IndexOutOfRangeException\">"));
-                Assert.That(exceptionSerialized, Does.Contain(ExceptionKnownBaseType.ObjectGraphElementName));
-                
-                // InnerExceptions are serialized for ISerializable Exceptions
-                Assert.That(deserialized, Is.TypeOf(typeof(ArgumentOutOfRangeException)));
-                Assert.That(deserialized.InnerException, Is.TypeOf(typeof(IndexOutOfRangeException)));
-                // Exception messages are deserialized, too:
-                Assert.That(deserialized.Message, Does.Contain("x-axis"));
-            }
-        }
-
-        /// <summary>
-        /// All subclasses of <see cref="Exception"/>s are considered as
-        /// <see cref="IKnownType"/>, specifically a known "base type".
-        /// <see cref="Exception"/>s are serialized using the <see cref="ExceptionKnownBaseType"/>.
-        /// </summary>
-        [Test]
-        public void Exception_not_Serializable()
+        public void Serialize_Exception()
         {
             try
             {
@@ -2338,9 +2307,9 @@ namespace YAXLibTests
                 var ser = new YAXSerializer(ex.GetType());
                 
                 var exceptionSerialized = ser.Serialize(ex);
-                var deserialized = (ExceptionNotSerializable) ser.Deserialize(exceptionSerialized);
+                var deserialized = (CustomException) ser.Deserialize(exceptionSerialized);
                 Assert.That(exceptionSerialized, Does.Contain("<Exception type=\"" + ex.GetType().AssemblyQualifiedName + "\""));
-                Assert.That(exceptionSerialized, Does.Contain(((ExceptionNotSerializable)ex).Info));
+                Assert.That(exceptionSerialized, Does.Contain(((CustomException)ex).Info));
                 // InnerExceptions cannot be deserialized
                 Assert.That(deserialized.InnerException, Is.Null);
                 Assert.That(ser.Deserialize("<dummy></dummy>"), Is.Null);


### PR DESCRIPTION
Closes #62 
~~This initial implementation is meant as an offer for discussion.~~
Final implementation:
1. `IKnownType`
   * Extended by `CanSerialize`, `CanDeserialize` to prevent from unnecessary implementations
   * Extended by `SerializerOptions` because settings also matter for known types.
2. `KnownTypes`
   * Added `KnownBaseTypes` as a new dictionary
   * Removed property `IsKnowType(Type type)` and its expensive, repetive querying dictionaries and reflection calls.
   * A "known base type" is registered for lowest useful point in the class hierarchy. It handles the base class itsself (e.g. `Exception`) and its subclass (e.g. `NullReferenceException`. See `ReflectionUtils.IsBaseClassOrSubclassOf`.
   * Specific implementation for known base type `Exception` added.
3. `UdpWrapper`
   * Now initalizes known types including `SerializerOptions`
4. `YAXSerializer`
   * Buffers "is known type" in a boolean
   * Invokes de/serialization depending on `IKnownType.CanSerialize` and `IKnownType.CanDeserialize`
5. `ExceptionKnownBaseType`
   * Implemented serialization and deserialization
   * ~~If the `Exception` subclass is flagged with `Serializable` attribute, the `Serialization.Formatters.Binary.BinaryFormatter` will deserialize the `Exception` and the result is written to an `Exception-Graph` element `Base64` encoded.~~
   * Addionally, other `Exception` properties are serialized for better "human readability".
   * `Exception.TargetSite` only contains the member throwing the exception. In the former version, the complete object graph was serialized, causing megabytes of space even with low recursion setting.
   * ~~If an `Exception-Graph` element is found during deserialization, it is used to deserialize the exception. This brings better details quality than the fallback option, which is returning an exception instance using a parameterless constructor.~~
