### PR TITLE
Fix handling of nullable enums

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 [3.01] August 19, 2021
 
-  * Nullable `Enum` will now serialize `YaxEnum` alias
+  * Nullable `Enum` will now serialize `YaxEnum` alias ([#161](https://github.com/YAXLib/YAXLib/pull/161))
 
 [3.00] Commits until June 5, 2021
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+[3.01] August 19, 2021
+
+  * Nullable `Enum` will now serialize `YaxEnum` alias
+
 [3.00] Commits until June 5, 2021
 
    **Changes:**

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -104,13 +104,16 @@ namespace YAXLib
             _isProperty = memberInfo.MemberType == MemberTypes.Property;
 
             Alias = StringUtils.RefineSingleElement(_memberInfo.Name);
-
             if (_isProperty)
+            {
                 _propertyInfoInstance = (PropertyInfo) memberInfo;
+                _memberType = _propertyInfoInstance.PropertyType;
+            }
             else
+            {
                 _fieldInfoInstance = (FieldInfo) memberInfo;
-
-            _memberType = _isProperty ? _propertyInfoInstance.PropertyType : _fieldInfoInstance.FieldType;
+                _memberType = _fieldInfoInstance.FieldType;
+            }
 
             _memberTypeWrapper = TypeWrappersPool.Pool.GetTypeWrapper(MemberType, callerSerializer);
             if (_memberTypeWrapper.HasNamespace)
@@ -147,8 +150,7 @@ namespace YAXLib
             // then use those of the member-type
             if (_collectionAttributeInstance == null && _memberTypeWrapper.CollectionAttributeInstance != null)
                 _collectionAttributeInstance = _memberTypeWrapper.CollectionAttributeInstance;
-            _memberInfo.GetCustomAttributes(true);
-
+            
             if (_dictionaryAttributeInstance == null && _memberTypeWrapper.DictionaryAttributeInstance != null)
                 _dictionaryAttributeInstance = _memberTypeWrapper.DictionaryAttributeInstance;
         }

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -27,7 +27,7 @@ namespace YAXLib
         /// <summary>
         ///     the underlying type for this instance of <c>TypeWrapper</c>
         /// </summary>
-        private readonly Type _udtType = typeof(object);
+        private readonly Type _udtType;
 
         /// <summary>
         ///     Alias for the type
@@ -63,7 +63,10 @@ namespace YAXLib
         /// <summary>
         ///     Initializes a new instance of the <see cref="UdtWrapper" /> class.
         /// </summary>
-        /// <param name="udtType">The underlying type to create the wrapper around.</param>
+        /// <param name="udtType">
+        /// The underlying type to create the wrapper around.
+        /// If the the type is <see cref="Nullable"/>, the underlying type of the <see cref="Nullable"/> is used.
+        /// </param>
         /// <param name="callerSerializer">
         ///     reference to the serializer
         ///     instance which is building this instance.
@@ -71,7 +74,9 @@ namespace YAXLib
         public UdtWrapper(Type udtType, YAXSerializer callerSerializer)
         {
             _isTypeDictionary = false;
-            _udtType = udtType;
+            _udtType = ReflectionUtils.IsNullable(udtType, out var nullableUnderlyingType)
+                ? nullableUnderlyingType
+                : udtType;
             _isTypeCollection = ReflectionUtils.IsCollectionType(_udtType);
             _isTypeDictionary = ReflectionUtils.IsIDictionary(_udtType);
 
@@ -171,10 +176,7 @@ namespace YAXLib
             {
                 if (IsEnum)
                 {
-                    if (_enumWrapper == null)
-                        _enumWrapper = new EnumWrapper(_udtType);
-
-                    return _enumWrapper;
+                    return _enumWrapper ??= new EnumWrapper(_udtType);
                 }
 
                 return null;

--- a/YAXLibTests/DeserializationTest.cs
+++ b/YAXLibTests/DeserializationTest.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using NUnit.Framework;
 using YAXLib;
 using YAXLib.Enums;
+using YAXLib.Options;
 using YAXLibTests.SampleClasses;
 using YAXLibTests.SampleClasses.PolymorphicSerialization;
 using YAXLibTests.SampleClasses.SelfReferencingObjects;
@@ -185,7 +186,11 @@ namespace YAXLibTests
         public void DesEmptyNullableTest()
         {
             const string xml = @"<NullableSample2 />";
-            var serializer = new YAXSerializer(typeof(NullableSample2), YAXExceptionHandlingPolicies.DoNotThrow);
+            var serializer = new YAXSerializer(typeof(NullableSample2),
+                new SerializerOptions {
+                    ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.DoNotThrow,
+                    SerializationOptions = YAXSerializationOptions.DontSerializeNullObjects
+                });
             var got = (NullableSample2) serializer.Deserialize(xml);
 
             Assert.That(got, Is.Not.Null);

--- a/YAXLibTests/SampleClasses/NullableSample1.cs
+++ b/YAXLibTests/SampleClasses/NullableSample1.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
+
+namespace YAXLibTests.SampleClasses
+{
+    [YAXSerializableType(FieldsToSerialize = YAXSerializationFields.AllFields)]
+    public class NullableSample1
+    {
+        public string Text { get; set; }
+        public Sample1Enum TestEnumProperty { get; set; }
+        public Sample1Enum? TestEnumNullableProperty { get; set; }
+        public Sample1Enum TestEnumField;
+        public Sample1Enum? TestEnumNullableField;
+
+        public static NullableSample1 GetSampleInstance()
+        {
+            return new()
+            {
+                Text = "Hello World", 
+                TestEnumProperty = Sample1Enum.EnumOne,
+                TestEnumNullableProperty = Sample1Enum.EnumTwo,
+                TestEnumField = Sample1Enum.EnumOne,
+                TestEnumNullableField = Sample1Enum.EnumThree
+            };
+        }
+    }
+
+    public enum Sample1Enum
+    {
+        [YAXEnum("yax-enum-for-EnumOne")]
+        EnumOne,
+        [YAXEnum("yax-enum-for-EnumTwo")]
+        EnumTwo,
+        [YAXEnum("yax-enum-for-EnumThree")]
+        EnumThree
+    }
+}

--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -702,41 +702,136 @@ namespace YAXLibTests
         }
 
         [Test]
-        public void NullableSample2Test()
+        public void NullableSample2_Serialize()
         {
-            const string result =
+            const string expected =
                 @"<NullableSample2 Number=""10"">
   <DateTime>1980-04-11T13:37:01.2345678Z</DateTime>
   <Decimal>1234.56789</Decimal>
   <Boolean>true</Boolean>
-  <Enum>Third</Enum>
+  <Enum>Autumn or fall</Enum>
 </NullableSample2>";
-            var serializer = new YAXSerializer(typeof(NullableSample2), YAXExceptionHandlingPolicies.DoNotThrow,
-                YAXExceptionTypes.Warning, YAXSerializationOptions.SerializeNullObjects);
-            var got = serializer.Serialize(NullableSample2.GetSampleInstance());
+            var serializer = new YAXSerializer(typeof(NullableSample2),
+                new SerializerOptions {
+                    ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.DoNotThrow,
+                    ExceptionBehavior = YAXExceptionTypes.Warning,
+                    SerializationOptions = YAXSerializationOptions.SerializeNullObjects
+                });
+            var original = NullableSample2.GetSampleInstance();
+            var got = serializer.Serialize(original);
 
-            Console.WriteLine(got);
-            Assert.That(got, Is.EqualTo(result));
+            // Assert
+            got.Should().BeEquivalentTo(expected);
         }
 
         [Test]
-        public void NullableSample2WithNullAttributeTest()
+        public void NullableSample2_Deserialize()
         {
-            const string result =
-                @"<NullableSample2>
+            const string xml =
+                @"<NullableSample2 Number=""10"">
   <DateTime>1980-04-11T13:37:01.2345678Z</DateTime>
   <Decimal>1234.56789</Decimal>
   <Boolean>true</Boolean>
-  <Enum>Third</Enum>
+  <Enum>Autumn or fall</Enum>
 </NullableSample2>";
-            var serializer = new YAXSerializer(typeof(NullableSample2), YAXExceptionHandlingPolicies.DoNotThrow,
-                YAXExceptionTypes.Warning, YAXSerializationOptions.DontSerializeNullObjects);
-            var sample = NullableSample2.GetSampleInstance();
-            sample.Number = null;
-            var got = serializer.Serialize(sample);
+            var serializer = new YAXSerializer(typeof(NullableSample2),
+                new SerializerOptions {
+                    ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.DoNotThrow,
+                    ExceptionBehavior = YAXExceptionTypes.Warning,
+                    SerializationOptions = YAXSerializationOptions.SerializeNullObjects
+                });
+            var original = NullableSample2.GetSampleInstance();
+            var des = (NullableSample2) serializer.Deserialize(xml);
 
-            Console.WriteLine(got);
-            Assert.That(got, Is.EqualTo(result));
+            // Assert
+            des.Should().BeEquivalentTo(original);
+        }
+
+        [Test]
+        public void NullableSample2WithNullAttribute_Serialize()
+        {
+            const string expected =
+                @"<NullableSample2 Number=""10"">
+  <DateTime>1980-04-11T13:37:01.2345678Z</DateTime>
+  <Decimal>1234.56789</Decimal>
+  <Boolean>true</Boolean>
+  <Enum>Autumn or fall</Enum>
+</NullableSample2>";
+            var serializer = new YAXSerializer(typeof(NullableSample2),
+                new SerializerOptions {
+                    ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.DoNotThrow,
+                    ExceptionBehavior = YAXExceptionTypes.Warning,
+                    SerializationOptions = YAXSerializationOptions.DontSerializeNullObjects
+                });
+
+            var original = NullableSample2.GetSampleInstance();
+            
+            var got = serializer.Serialize(original);
+
+            // Assert
+            got.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void NullableSample2WithNullAttribute_Deserialize()
+        {
+            const string xml =
+                @"<NullableSample2 Number=""10"">
+  <DateTime>1980-04-11T13:37:01.2345678Z</DateTime>
+  <Decimal>1234.56789</Decimal>
+  <Boolean>true</Boolean>
+  <Enum>Autumn or fall</Enum>
+</NullableSample2>";
+            var serializer = new YAXSerializer(typeof(NullableSample2),
+                new SerializerOptions {
+                    ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.DoNotThrow,
+                    ExceptionBehavior = YAXExceptionTypes.Warning,
+                    SerializationOptions = YAXSerializationOptions.DontSerializeNullObjects
+                });
+
+            var original = NullableSample2.GetSampleInstance();
+            var des = (NullableSample2) serializer.Deserialize(xml);
+
+            // Assert
+            des.Should().BeEquivalentTo(original);
+        }
+
+        [Test]
+        public void NullableSample1WithNullAttribute_Serialize()
+        {
+            const string expected =
+                @"<NullableSample1>
+  <Text>Hello World</Text>
+  <TestEnumProperty>yax-enum-for-EnumOne</TestEnumProperty>
+  <TestEnumNullableProperty>yax-enum-for-EnumTwo</TestEnumNullableProperty>
+  <TestEnumField>yax-enum-for-EnumOne</TestEnumField>
+  <TestEnumNullableField>yax-enum-for-EnumThree</TestEnumNullableField>
+</NullableSample1>";
+            var original = NullableSample1.GetSampleInstance();
+            var serializer = new YAXSerializer(typeof(NullableSample1));
+            var got = serializer.Serialize(original);
+
+            // Assert
+            got.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void NullableSample1WithNullAttribute_Deserialize()
+        {
+            const string xml =
+                @"<NullableSample1>
+  <Text>Hello World</Text>
+  <TestEnumProperty>yax-enum-for-EnumOne</TestEnumProperty>
+  <TestEnumNullableProperty>yax-enum-for-EnumTwo</TestEnumNullableProperty>
+  <TestEnumField>yax-enum-for-EnumOne</TestEnumField>
+  <TestEnumNullableField>yax-enum-for-EnumThree</TestEnumNullableField>
+</NullableSample1>";
+            var original = NullableSample1.GetSampleInstance();
+            var serializer = new YAXSerializer(typeof(NullableSample1));
+            var des = (NullableSample1) serializer.Deserialize(xml);
+
+            // Assert
+            des.Should().BeEquivalentTo(original);
         }
 
         [Test]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ for:
     build_script:
       - ps: dotnet restore --verbosity quiet
       - ps: |
-          $version = "3.0.0"
+          $version = "3.0.1"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {


### PR DESCRIPTION
The `UdtWrapper` now initializes the `UnderlyingType` property with the underlying type of the udtType, if it is `nullable`.

Corrected unit tests in *YAXLibTests/SerializationTest.cs*:
* NullableSample2Test()
* NullableSample2WithNullAttributeTest()

Added De/Serialilzation test for fields.