### PR TITLE
ICustomSerializers may have an interface as the generic argument

### DIFF
--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -711,20 +711,22 @@ namespace YAXLib
                 if (!ReflectionUtils.IsArray(MemberType))
                     IsAttributedAsNotCollection = true;
             }
-            else if (attr is YAXCustomSerializerAttribute)
+            else if (attr is YAXCustomSerializerAttribute customSerializerAttribute)
             {
-                var serType = (attr as YAXCustomSerializerAttribute).CustomSerializerType;
+                var serType = customSerializerAttribute.CustomSerializerType;
 
-                Type genTypeArg;
                 var isDesiredInterface =
                     ReflectionUtils.IsDerivedFromGenericInterfaceType(serType, typeof(ICustomSerializer<>),
-                        out genTypeArg);
+                        out var genTypeArg);
 
                 if (!isDesiredInterface)
                     throw new YAXException(
-                        "The provided custom serialization type is not derived from the proper interface");
-                if (genTypeArg != MemberType)
-                    throw new YAXException("The generic argument of the class and the member type do not match");
+                        $"The provided custom serialization type '{serType.AssemblyQualifiedName}' is not derived from the proper interface.");
+
+                if (!genTypeArg.IsAssignableFrom(MemberType))
+                    throw new YAXException(
+                        $"The generic argument of the class '{MemberType.AssemblyQualifiedName}' is not assignable from '{genTypeArg.AssemblyQualifiedName}'.");
+
                 CustomSerializerType = serType;
             }
             else if (attr is YAXPreserveWhitespaceAttribute)

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -411,21 +411,21 @@ namespace YAXLib
                 if (!ReflectionUtils.IsArray(_udtType))
                     IsAttributedAsNotCollection = true;
             }
-            else if (attr is YAXCustomSerializerAttribute)
+            else if (attr is YAXCustomSerializerAttribute customSerializerAttribute)
             {
-                var serType = (attr as YAXCustomSerializerAttribute).CustomSerializerType;
+                var serType = customSerializerAttribute.CustomSerializerType;
 
-                Type genTypeArg;
-                var isDesiredInterface =
+                var isDesiredSerializerInterface =
                     ReflectionUtils.IsDerivedFromGenericInterfaceType(serType, typeof(ICustomSerializer<>),
-                        out genTypeArg);
+                        out var genTypeArg);
 
-                if (!isDesiredInterface)
+                if (!isDesiredSerializerInterface)
                     throw new YAXException(
-                        "The provided custom serialization type is not derived from the proper interface");
-
-                if (genTypeArg != UnderlyingType)
-                    throw new YAXException("The generic argument of the class and the type of the class do not match");
+                        $"The provided custom serialization type '{serType.AssemblyQualifiedName}' is not derived from the proper Interface.");
+                
+                if (!genTypeArg.IsAssignableFrom(UnderlyingType))
+                    throw new YAXException(
+                        $"The generic argument of the class '{UnderlyingType.AssemblyQualifiedName}' is not assignable from '{genTypeArg.AssemblyQualifiedName}'.");
 
                 CustomSerializerType = serType;
             }

--- a/YAXLibTests/SampleClasses/CustomSerialization/InterfaceSample.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/InterfaceSample.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
+
+namespace YAXLibTests.SampleClasses.CustomSerialization
+{
+    public interface ISampleInterface
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    [YAXCustomSerializer(typeof(InterfaceSerializer))]
+    public class NonGenericClassWithInterface : ISampleInterface
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    [YAXCustomSerializer(typeof(InterfaceSerializer))]
+    public class GenericClassWithInterface<T> : ISampleInterface
+    {
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
+        public T Something { get; set; }
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public override string ToString()
+        {
+            return Id + Name;
+        }
+    }
+
+    [YAXCustomSerializer(typeof(string))]
+    public class IllegalTypeOfClassSerializer : ISampleInterface
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public override string ToString()
+        {
+            return Id + Name;
+        }
+    }
+}

--- a/YAXLibTests/SampleClasses/CustomSerialization/InterfaceSerializer.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/InterfaceSerializer.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Xml.Linq;
+using YAXLib;
+
+namespace YAXLibTests.SampleClasses.CustomSerialization
+{
+    public class InterfaceSerializer : ICustomSerializer<ISampleInterface>
+    {
+        public void SerializeToAttribute(ISampleInterface objectToSerialize, XAttribute attrToFill)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SerializeToElement(ISampleInterface objectToSerialize, XElement elemToFill)
+        {
+            elemToFill.Add(new XElement("Id", objectToSerialize.Id));
+            elemToFill.Add(new XElement("Name", objectToSerialize.Name));
+        }
+
+        public string SerializeToValue(ISampleInterface objectToSerialize)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ISampleInterface DeserializeFromAttribute(XAttribute attrib)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ISampleInterface DeserializeFromElement(XElement element)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ISampleInterface DeserializeFromValue(string value)
+        {
+            throw new NotImplementedException();
+        }
+    }}


### PR DESCRIPTION
ICustomSerializers may have an interface or a base type as the generic argument
Fixes #166
e.g. 
```CSharp
public class SomeSerializer : ICustomSerializer<ISomeInterface> {
   //...
}
```