### PR TITLE
Type handling and related exceptions

### DIFF
--- a/DemoApplication/DemoApplication.csproj
+++ b/DemoApplication/DemoApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>NET5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/YAXLib/EnumWrapper.cs
+++ b/YAXLib/EnumWrapper.cs
@@ -15,7 +15,7 @@ namespace YAXLib
     internal class EnumWrapper
     {
         /// <summary>
-        ///     maps real enum names to their corresponding user defined aliases
+        ///     Maps real enum names to their corresponding user defined aliases
         /// </summary>
         private readonly Dictionary<string, string> _enumMembers = new Dictionary<string, string>();
 
@@ -41,18 +41,15 @@ namespace YAXLib
                     var originalName = m.Name;
                     var alias = originalName;
                     foreach (var attr in m.GetCustomAttributes(false))
-                        if (attr is YAXEnumAttribute)
-                            alias = (attr as YAXEnumAttribute).Alias;
+                        if (attr is YAXEnumAttribute enumAttr)
+                            alias = enumAttr.Alias;
 
-                    if (alias != originalName)
-                    {
-                        if (!_enumMembers.ContainsKey(alias))
-                            _enumMembers.Add(m.Name, alias);
-                        else if (!_enumMembers.ContainsKey(originalName))
-                            _enumMembers.Add(m.Name, originalName);
-                        else
-                            throw new YAXException("Enum alias already exists");
-                    }
+                    if (alias == originalName) continue;
+                    
+                    if (!_enumMembers.ContainsKey(originalName) && !_enumMembers.ContainsValue(alias))
+                        _enumMembers.Add(m.Name, alias);
+                    else
+                        throw new YAXEnumAliasException($"Enum alias '{alias}' for original name '{originalName}' already exists.");
                 }
         }
 

--- a/YAXLib/Exceptions/YAXEnumAliasException.cs
+++ b/YAXLib/Exceptions/YAXEnumAliasException.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+
+namespace YAXLib.Exceptions
+{
+    /// <summary>
+    ///     The exception throws when trying to register an already existing <see cref="Enum"/> alias.
+    ///     This exception is raised during serialization and deserialization.
+    /// </summary>
+    [Serializable]
+    public class YAXEnumAliasException : YAXException
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="YAXEnumAliasException" /> class.
+        /// </summary>
+        public YAXEnumAliasException()
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="YAXEnumAliasException" /> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public YAXEnumAliasException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/YAXLib/Exceptions/YAXException.cs
+++ b/YAXLib/Exceptions/YAXException.cs
@@ -8,7 +8,7 @@ namespace YAXLib.Exceptions
     /// <summary>
     ///     The base for all exception classes of YAXLib
     /// </summary>
-    public class YAXException : Exception
+    public abstract class YAXException : Exception
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXException" /> class.

--- a/YAXLib/Exceptions/YAXObjectTypeMismatch.cs
+++ b/YAXLib/Exceptions/YAXObjectTypeMismatch.cs
@@ -13,8 +13,6 @@ namespace YAXLib.Exceptions
     /// </summary>
     public class YAXObjectTypeMismatch : YAXException
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXObjectTypeMismatch" /> class.
         /// </summary>
@@ -25,10 +23,6 @@ namespace YAXLib.Exceptions
             ExpectedType = expectedType;
             ReceivedType = receivedType;
         }
-
-        #endregion
-
-        #region Properties
 
         /// <summary>
         ///     Gets the expected type.
@@ -54,7 +48,5 @@ namespace YAXLib.Exceptions
                 "Expected an object of type '{0}' but received an object of type '{1}'.",
                 ExpectedType.Name,
                 ReceivedType.Name);
-
-        #endregion
     }
 }

--- a/YAXLib/KnownTypes/KnownTypes.cs
+++ b/YAXLib/KnownTypes/KnownTypes.cs
@@ -18,20 +18,20 @@ namespace YAXLib
     /// </summary>
     internal class KnownTypes
     {
-        private static readonly Dictionary<Type, IKnownType> _dictKnownTypes = new Dictionary<Type, IKnownType>();
+        private static readonly Dictionary<Type, IKnownType> _dictKnownTypes = new();
 
-        private static readonly Dictionary<string, IKnownType> _dictDynamicKnownTypes =
-            new Dictionary<string, IKnownType>();
+        private static readonly Dictionary<string, IKnownType> _dictDynamicKnownTypes = new();
 
         static KnownTypes()
         {
-            // NOTE: known-types MUST be registered here
+            // Register all known types
+
             Add(new TimeSpanKnownType());
             Add(new XElementKnownType());
             Add(new XAttributeKnownType());
             Add(new DbNullKnownType());
-
             Add(new TypeKnownType());
+
             AddDynamicKnownType(new RectangleDynamicKnownType());
             AddDynamicKnownType(new ColorDynamicKnownType());
             AddDynamicKnownType(new RuntimeTypeDynamicKnownType());
@@ -74,25 +74,4 @@ namespace YAXLib
             return null;
         }
     }
-
-    #region XElement
-
-    // Thanks go to CodePlex user tg73: 
-    // http://www.codeplex.com/site/users/view/tg73
-    // for providing this implementation in the following issue:
-    // http://yaxlib.codeplex.com/workitem/17676
-
-    #endregion
-
-    #region XAttribute
-
-    #endregion
-
-    #region TimeSpan
-
-    #endregion
-
-    #region DBNull
-
-    #endregion
 }

--- a/YAXLib/KnownTypes/TimeSpanKnownType.cs
+++ b/YAXLib/KnownTypes/TimeSpanKnownType.cs
@@ -20,15 +20,12 @@ namespace YAXLib
             if (elemTicks == null)
             {
                 var strTimeSpanString = elem.Value;
-                TimeSpan timeSpanResult;
-                if (!TimeSpan.TryParse(strTimeSpanString, out timeSpanResult))
+                if (!TimeSpan.TryParse(strTimeSpanString, out var timeSpanResult))
                     throw new YAXBadlyFormedInput(elem.Name.ToString(), elem.Value, elem);
                 return timeSpanResult;
             }
 
-            var strTicks = elemTicks.Value;
-            long ticks;
-            if (!long.TryParse(strTicks, out ticks)) throw new YAXBadlyFormedInput("Ticks", elemTicks.Value, elemTicks);
+            if (!long.TryParse(elemTicks.Value, out var ticks)) throw new YAXBadlyFormedInput("Ticks", elemTicks.Value, elemTicks);
             return new TimeSpan(ticks);
         }
     }

--- a/YAXLib/KnownTypes/TypeKnownType.cs
+++ b/YAXLib/KnownTypes/TypeKnownType.cs
@@ -11,7 +11,7 @@ namespace YAXLib
         public override void Serialize(Type obj, XElement elem, XNamespace overridingNamespace)
         {
             if (obj != null)
-                elem.Value = obj.FullName;
+                elem.Value = obj.FullName ?? string.Empty;
         }
 
         public override Type Deserialize(XElement elem, XNamespace overridingNamespace)

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -720,12 +720,10 @@ namespace YAXLib
                         out var genTypeArg);
 
                 if (!isDesiredInterface)
-                    throw new YAXException(
-                        $"The provided custom serialization type '{serType.AssemblyQualifiedName}' is not derived from the proper interface.");
+                    throw new YAXObjectTypeMismatch(typeof(ICustomSerializer<>), serType);
 
                 if (!genTypeArg.IsAssignableFrom(MemberType))
-                    throw new YAXException(
-                        $"The generic argument of the class '{MemberType.AssemblyQualifiedName}' is not assignable from '{genTypeArg.AssemblyQualifiedName}'.");
+                    throw new YAXObjectTypeMismatch(MemberType, genTypeArg);
 
                 CustomSerializerType = serType;
             }

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -381,9 +381,9 @@ namespace YAXLib
         /// <param name="attr">The attribute to process.</param>
         private void ProcessYAXAttribute(object attr)
         {
-            if (attr is YAXCommentAttribute)
+            if (attr is YAXCommentAttribute commentAttribute)
             {
-                var comment = (attr as YAXCommentAttribute).Comment;
+                var comment = commentAttribute.Comment;
                 if (!string.IsNullOrEmpty(comment))
                 {
                     var comments = comment.Split(new[] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
@@ -392,9 +392,8 @@ namespace YAXLib
                     Comment = comments;
                 }
             }
-            else if (attr is YAXSerializableTypeAttribute)
+            else if (attr is YAXSerializableTypeAttribute theAttr)
             {
-                var theAttr = attr as YAXSerializableTypeAttribute;
                 FieldsToSerialize = theAttr.FieldsToSerialize;
                 if (theAttr.IsSerializationOptionSet())
                 {
@@ -402,9 +401,9 @@ namespace YAXLib
                     _isSerializationOptionSetByAttribute = true;
                 }
             }
-            else if (attr is YAXSerializeAsAttribute)
+            else if (attr is YAXSerializeAsAttribute attribute)
             {
-                Alias = StringUtils.RefineSingleElement((attr as YAXSerializeAsAttribute).SerializeAs);
+                Alias = StringUtils.RefineSingleElement(attribute.SerializeAs);
             }
             else if (attr is YAXNotCollectionAttribute)
             {
@@ -420,12 +419,12 @@ namespace YAXLib
                         out var genTypeArg);
 
                 if (!isDesiredSerializerInterface)
-                    throw new YAXException(
-                        $"The provided custom serialization type '{serType.AssemblyQualifiedName}' is not derived from the proper Interface.");
+                    throw new YAXObjectTypeMismatch(typeof(ICustomSerializer<>), serType);
                 
+                // Reason for missing unit test coverage (?):
+                // Usually this case throws before
                 if (!genTypeArg.IsAssignableFrom(UnderlyingType))
-                    throw new YAXException(
-                        $"The generic argument of the class '{UnderlyingType.AssemblyQualifiedName}' is not assignable from '{genTypeArg.AssemblyQualifiedName}'.");
+                    throw new YAXObjectTypeMismatch(UnderlyingType, genTypeArg);
 
                 CustomSerializerType = serType;
             }
@@ -433,9 +432,8 @@ namespace YAXLib
             {
                 PreservesWhitespace = true;
             }
-            else if (attr is YAXNamespaceAttribute)
+            else if (attr is YAXNamespaceAttribute nsAttrib)
             {
-                var nsAttrib = attr as YAXNamespaceAttribute;
                 Namespace = nsAttrib.Namespace;
                 NamespacePrefix = nsAttrib.Prefix;
             }

--- a/YAXLib/YAXLib.csproj.DotSettings
+++ b/YAXLib/YAXLib.csproj.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=knowntypes/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/YAXLibTests/CustomSerializerTests.cs
+++ b/YAXLibTests/CustomSerializerTests.cs
@@ -16,7 +16,20 @@ namespace YAXLibTests
         {
             var s = new YAXSerializer(typeof(ISampleInterface));
             var original = new IllegalTypeOfClassSerializer();
-            Assert.Throws<YAXException>(()=> s.Serialize(original));
+            Assert.That(code: ()=> s.Serialize(original), Throws.TypeOf<YAXObjectTypeMismatch>());
+        }
+
+        [Test]
+        public void Custom_Interface_Serializer_Should_Throw_If_Missing_Interface()
+        {
+            var s = new YAXSerializer(typeof(ISampleInterface));
+            var original = new GenericClassWithoutInterface<int>
+            { 
+                Something = 9876,
+                Id = 12345,
+                Name = "The " + nameof(ISampleInterface.Name)
+            };
+            Assert.That(code: ()=> s.Serialize(original), Throws.TypeOf<YAXObjectTypeMismatch>());
         }
 
         [Test]
@@ -144,7 +157,7 @@ namespace YAXLibTests
             // Use an interface as type to serialize a generic class
 
             var s = new YAXSerializer(typeof(ISampleInterface));
-            var original = (ISampleInterface) new GenericClassWithInterface<int>
+            var original = new GenericClassWithInterface<int>
             { 
                 Something = 9876,
                 Id = 12345,

--- a/YAXLibTests/KnownTypeTests.cs
+++ b/YAXLibTests/KnownTypeTests.cs
@@ -25,6 +25,22 @@ namespace YAXLibTests
         }
 
         [Test]
+        public void TypeKnowTypeSerialization()
+        {
+            var typeExample = TypeKnownTypeSample.GetSampleInstance();
+            var serializer = new YAXSerializer(typeof(TypeKnownTypeSample));
+            var xml = @"<TypeKnownTypeSample>
+  <TheType>YAXLibTests.KnownTypeTests</TheType>
+</TypeKnownTypeSample>";
+            
+            var serialized = serializer.Serialize(typeExample);
+            var deserialized = (TypeKnownTypeSample) serializer.Deserialize(serialized);
+
+            Assert.That(serialized, Is.EqualTo(xml));
+            Assert.That(deserialized.TheType.UnderlyingSystemType, Is.EqualTo(typeExample.TheType.UnderlyingSystemType));
+        }
+
+        [Test]
         public void TestSingleKnownTypeSerialization()
         {
             var typeToTest = typeof(Color);

--- a/YAXLibTests/SampleClasses/CustomSerialization/InterfaceSample.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/InterfaceSample.cs
@@ -33,6 +33,19 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
         }
     }
 
+    [YAXCustomSerializer(typeof(InterfaceSerializer))]
+    public class GenericClassWithoutInterface<T>
+    {
+        [YAXErrorIfMissed(YAXExceptionTypes.Ignore)]
+        public T Something { get; set; }
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public override string ToString()
+        {
+            return Id + Name;
+        }
+    }
+
     [YAXCustomSerializer(typeof(string))]
     public class IllegalTypeOfClassSerializer : ISampleInterface
     {

--- a/YAXLibTests/SampleClasses/NullableSample3.cs
+++ b/YAXLibTests/SampleClasses/NullableSample3.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using YAXLib;
+using YAXLib.Attributes;
+using YAXLib.Enums;
+
+namespace YAXLibTests.SampleClasses
+{
+    [YAXSerializableType(FieldsToSerialize = YAXSerializationFields.AllFields)]
+    public class NullableSample3
+    {
+        public string Text { get; set; }
+        public Sample3Enum TestEnumProperty { get; set; }
+        public Sample3Enum? TestEnumNullableProperty { get; set; }
+        public Sample3Enum TestEnumField;
+        public Sample3Enum? TestEnumNullableField;
+
+        public static NullableSample3 GetSampleInstance()
+        {
+            return new()
+            {
+                Text = "Hello World", 
+                TestEnumProperty = Sample3Enum.EnumOne,
+                TestEnumNullableProperty = Sample3Enum.EnumTwo,
+                TestEnumField = Sample3Enum.EnumThree,
+                TestEnumNullableField = Sample3Enum.EnumFour
+            };
+        }
+    }
+
+    public enum Sample3Enum
+    {
+        [YAXEnum("yax-enum-for-EnumOne")]
+        EnumOne,
+        [YAXEnum("yax-enum-for-EnumTwo")]
+        EnumTwo,
+        [YAXEnum("yax-enum-for-EnumThree")]
+        EnumThree,
+        [YAXEnum("yax-enum-for-EnumThree")] // duplicate alias
+        EnumFour
+    }
+}

--- a/YAXLibTests/SampleClasses/TimeSpanSample.cs
+++ b/YAXLibTests/SampleClasses/TimeSpanSample.cs
@@ -9,7 +9,7 @@ using YAXLib.Attributes;
 namespace YAXLibTests.SampleClasses
 {
     [ShowInDemoApplication]
-    [YAXComment("This example shows serialization and deserialization of TimeSpan obejcts")]
+    [YAXComment("This example shows serialization and deserialization of TimeSpan objects")]
     public class TimeSpanSample
     {
         public TimeSpan TheTimeSpan { get; set; }
@@ -24,9 +24,10 @@ namespace YAXLibTests.SampleClasses
 
         public static TimeSpanSample GetSampleInstance()
         {
-            var dic = new Dictionary<TimeSpan, int>();
-            dic.Add(new TimeSpan(2, 3, 45, 2, 300), 1);
-            dic.Add(new TimeSpan(3, 1, 40, 1, 200), 2);
+            var dic = new Dictionary<TimeSpan, int> {
+                { new TimeSpan(2, 3, 45, 2, 300), 1 },
+                { new TimeSpan(3, 1, 40, 1, 200), 2 }
+            };
 
             return new TimeSpanSample
             {

--- a/YAXLibTests/SampleClasses/TypeKnownTypeSample.cs
+++ b/YAXLibTests/SampleClasses/TypeKnownTypeSample.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+
+namespace YAXLibTests.SampleClasses
+{
+    public class TypeKnownTypeSample
+    {
+        public Type TheType { get; set; }
+
+        public static TypeKnownTypeSample GetSampleInstance()
+        {
+            return new TypeKnownTypeSample { TheType = typeof(KnownTypeTests)};
+        }
+    }
+}

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -4,15 +4,15 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../Key/YAXLib.Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <TargetFrameworks>net462;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ for:
     test_script:
       - dotnet test YAXLibTests
       - nuget.exe install OpenCover -ExcludeVersion
-      - OpenCover\tools\OpenCover.Console.exe -register:appveyor -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:"test -f net5.0  -c debug YAXLibTests" -filter:"+[YAXLib]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml -oldstyle
+      - OpenCover\tools\OpenCover.Console.exe -register:appveyor -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:"test -f net6.0  -c debug YAXLibTests" -filter:"+[YAXLib]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml -oldstyle
       - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
       - pip install codecov
       - codecov -f "coverage.xml"
@@ -56,5 +56,5 @@ for:
       - dotnet build YAXLib -f netstandard2.0 
     test_script:
       - dotnet restore YAXLibTests --verbosity quiet
-      - dotnet build YAXLibTests -f net5.0
-      - dotnet test YAXLibTests -f net5.0
+      - dotnet build YAXLibTests -f net6.0
+      - dotnet test YAXLibTests -f net6.0

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<repositories>
-  <repository path="..\YAXLibTests\packages.config" />
-</repositories>


### PR DESCRIPTION
### YAXLib
* Added `YAXEnumAliasException`
* `YAXLibException` is now an abstract base class in favor of more specific exceptions
* Replaced usage of `YAXLibException` with `YAXObjectTypeMismatch` in `MemberWrapper`and `UdtWrapper`
* Fix for `EnumWrapper`: Did not detect adding duplicate aliases for `Enum`s. Now throws `YAXEnumAliasException` instead of `YAXLibException` when this happens.

### Unit Tests
* TargetFramework net6.0 
* Update to latest dependencies

#### Custom Serializer
* Added test for cases where interface implementation is missing (should throw)

#### Known Types
* Added missing test for known type `Type` (`TypeKnownType`)
* Added missing test for duplicate Enum aliases: should throw
* Added missing tests for `TimeSpan` serialization

### DemoApplication
* TargetFramework net6.0

### Removed unused files
* packages/repositories.config
* YAXLib.csproj.Dotsettings
