### PR TITLE
Custom Serialization

### DIFF
--- a/YAXLib/ICustomSerializer.cs
+++ b/YAXLib/ICustomSerializer.cs
@@ -21,7 +21,8 @@ namespace YAXLib
         /// </summary>
         /// <param name="objectToSerialize">The object to serialize.</param>
         /// <param name="attrToFill">The XML attribute to fill.</param>
-        void SerializeToAttribute(T objectToSerialize, XAttribute attrToFill);
+        /// <param name="serializationContext">Contains information about member/type that specified the custom serializer</param>
+        void SerializeToAttribute(T objectToSerialize, XAttribute attrToFill, ISerializationContext serializationContext);
 
 
         /// <summary>
@@ -30,23 +31,26 @@ namespace YAXLib
         /// </summary>
         /// <param name="objectToSerialize">The object to serialize.</param>
         /// <param name="elemToFill">The XML element to fill.</param>
-        void SerializeToElement(T objectToSerialize, XElement elemToFill);
+        /// <param name="serializationContext">Contains information about member/type that specified the custom serializer</param>
+        void SerializeToElement(T objectToSerialize, XElement elemToFill, ISerializationContext serializationContext);
 
         /// <summary>
         ///     Serializes the given object to an string to be used as a value for an
         ///     XML element.
         /// </summary>
         /// <param name="objectToSerialize">The object to serialize.</param>
+        /// <param name="serializationContext">type that specified the custom serializer></param>
         /// <returns></returns>
-        string SerializeToValue(T objectToSerialize);
+        string SerializeToValue(T objectToSerialize, ISerializationContext serializationContext);
 
         /// <summary>
         ///     Deserializes from an xml attribute, and returns the retrieved value.
         ///     You will normally need to use XAttribute.Value property only.
         /// </summary>
         /// <param name="attrib">The attribute to deserialize.</param>
+        /// <param name="serializationContext">Contains information about member/type that specified the custom serializer</param>
         /// <returns></returns>
-        T DeserializeFromAttribute(XAttribute attrib);
+        T DeserializeFromAttribute(XAttribute attrib, ISerializationContext serializationContext);
 
         /// <summary>
         ///     Deserializes from an xml element, and returns the retrieved value.
@@ -54,14 +58,16 @@ namespace YAXLib
         ///     XElement.Attributes(), and XElement.Elements() only.
         /// </summary>
         /// <param name="element">The element to deserialize.</param>
+        /// <param name="serializationContext"></param>
         /// <returns></returns>
-        T DeserializeFromElement(XElement element);
+        T DeserializeFromElement(XElement element, ISerializationContext serializationContext);
 
         /// <summary>
         ///     Deserializes from a string value which has been serialized as the content of an element
         /// </summary>
         /// <param name="value">The string value to deserialize.</param>
+        /// <param name="serializationContext">Contains information about member/type that specified the custom serializer</param>
         /// <returns></returns>
-        T DeserializeFromValue(string value);
+        T DeserializeFromValue(string value, ISerializationContext serializationContext);
     }
 }

--- a/YAXLib/ISerializationContext.cs
+++ b/YAXLib/ISerializationContext.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+#nullable enable
+using System;
+using System.Reflection;
+using YAXLib.Options;
+
+namespace YAXLib
+{
+    /// <summary>
+    /// Provides information about which <see cref="Type"/>s and/or members being serialized or deserialized.
+    /// </summary>
+    public interface ISerializationContext
+    {
+        /// <summary>
+        /// The member's <see cref="FieldInfo"/> for property serialization, else <see langref="null"/>.
+        /// </summary>
+        FieldInfo? FieldInfo { get; }
+
+        /// <summary>
+        /// The member's <see cref="MemberInfo"/> for member serialization, else <see langref="null"/>.
+        /// </summary>
+        MemberInfo? MemberInfo { get; }
+
+        /// <summary>
+        /// The member's <see cref="PropertyInfo"/> for property serialization, else <see langref="null"/>.
+        /// </summary>
+        PropertyInfo? PropertyInfo { get; }
+
+        /// <summary>
+        /// The member's <see cref="Type"/> for member serialization, else <see langref="null"/>.
+        /// </summary>
+        Type? MemberType { get; }
+
+        /// <summary>
+        /// The class' <see cref="Type"/> for class level serialization, else <see langref="null"/>.
+        /// </summary>
+        Type? ClassType { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Options.SerializerOptions"/> of the <see cref="YAXSerializer"/> instance.
+        /// </summary>
+        SerializerOptions SerializerOptions { get; }
+    }
+}

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,7 +21,7 @@ namespace YAXLib
         /// <summary>
         ///     the <c>FieldInfo</c> instance, if this member corresponds to a field, <c>null</c> otherwise
         /// </summary>
-        private readonly FieldInfo _fieldInfoInstance;
+        private readonly FieldInfo? _fieldInfoInstance;
 
         /// <summary>
         ///     <c>true</c> if this instance corresponds to a property, <c>false</c>
@@ -51,22 +52,22 @@ namespace YAXLib
         /// <summary>
         ///     the <c>PropertyInfo</c> instance, if this member corresponds to a property, <c>null</c> otherwise
         /// </summary>
-        private readonly PropertyInfo _propertyInfoInstance;
+        private readonly PropertyInfo? _propertyInfoInstance;
 
         /// <summary>
         ///     The alias specified by the user
         /// </summary>
-        private XName _alias;
+        private XName? _alias;
 
         /// <summary>
         ///     The collection attribute instance
         /// </summary>
-        private YAXCollectionAttribute _collectionAttributeInstance;
+        private YAXCollectionAttribute? _collectionAttributeInstance;
 
         /// <summary>
         ///     the dictionary attribute instance
         /// </summary>
-        private YAXDictionaryAttribute _dictionaryAttributeInstance;
+        private YAXDictionaryAttribute? _dictionaryAttributeInstance;
 
         /// <summary>
         ///     specifies whether this member is going to be serialized as an attribute
@@ -93,7 +94,7 @@ namespace YAXLib
         /// </summary>
         /// <param name="memberInfo">The member-info to build this instance from.</param>
         /// <param name="callerSerializer">The caller serializer.</param>
-        public MemberWrapper(MemberInfo memberInfo, YAXSerializer callerSerializer)
+        public MemberWrapper(MemberInfo memberInfo, YAXSerializer? callerSerializer)
         {
             Order = int.MaxValue;
 
@@ -124,7 +125,7 @@ namespace YAXLib
 
             InitInstance();
 
-            TreatErrorsAs = callerSerializer != null ? callerSerializer.DefaultExceptionType : YAXExceptionTypes.Error;
+            TreatErrorsAs = callerSerializer?.DefaultExceptionType ?? YAXExceptionTypes.Error;
 
             // discover YAXCustomSerializerAttributes earlier, because some other attributes depend on it
             var attrsToProcessEarlier = new HashSet<Type>
@@ -159,7 +160,7 @@ namespace YAXLib
         ///     Gets the alias specified for this member.
         /// </summary>
         /// <value>The alias specified for this member.</value>
-        public XName Alias
+        public XName? Alias
         {
             get { return _alias; }
 
@@ -167,12 +168,12 @@ namespace YAXLib
             {
                 if (Namespace.IsEmpty())
                 {
-                    _alias = Namespace + value.LocalName;
+                    _alias = Namespace + value?.LocalName;
                 }
                 else
                 {
                     _alias = value;
-                    if (_alias.Namespace.IsEmpty())
+                    if (_alias != null && _alias.Namespace.IsEmpty())
                         _namespace = _alias.Namespace;
                 }
             }
@@ -187,7 +188,7 @@ namespace YAXLib
             get
             {
                 if (_isProperty)
-                    return _propertyInfoInstance.CanRead;
+                    return _propertyInfoInstance != null && _propertyInfoInstance.CanRead;
                 return true;
             }
         }
@@ -201,7 +202,7 @@ namespace YAXLib
             get
             {
                 if (_isProperty)
-                    return _propertyInfoInstance.CanWrite;
+                    return _propertyInfoInstance != null && _propertyInfoInstance.CanWrite;
                 return true;
             }
         }
@@ -210,19 +211,19 @@ namespace YAXLib
         ///     Gets an array of comment lines.
         /// </summary>
         /// <value>The comment lines.</value>
-        public string[] Comment { get; private set; }
+        public string[]? Comment { get; private set; }
 
         /// <summary>
         ///     Gets the default value for this instance.
         /// </summary>
         /// <value>The default value for this instance.</value>
-        public object DefaultValue { get; private set; }
+        public object? DefaultValue { get; private set; }
 
         /// <summary>
         ///     Gets the format specified for this value; <c>null</c> if no format is specified.
         /// </summary>
         /// <value>the format specified for this value; <c>null</c> if no format is specified.</value>
-        public string Format { get; private set; }
+        public string? Format { get; private set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance has comments.
@@ -340,6 +341,21 @@ namespace YAXLib
         public Type MemberType => _memberType;
 
         /// <summary>
+        ///     Gets the <see cref="FieldInfo"/> of a field, if the member is a field.
+        /// </summary>
+        public FieldInfo? FieldInfo => _fieldInfoInstance;
+
+        /// <summary>
+        ///     Gets the <see cref="MemberInfo"/>.
+        /// </summary>
+        public MemberInfo MemberInfo => _memberInfo;
+
+        /// <summary>
+        ///     Gets the <see cref="PropertyInfo"/> of a field, if the member is a property.
+        /// </summary>
+        public PropertyInfo? PropertyInfo => _propertyInfoInstance;
+
+        /// <summary>
         ///     Gets the type wrapper instance corresponding to the member-type of this instance.
         /// </summary>
         /// <value>The type wrapper instance corresponding to the member-type of this instance.</value>
@@ -377,13 +393,13 @@ namespace YAXLib
         ///     Gets the collection attribute instance.
         /// </summary>
         /// <value>The collection attribute instance.</value>
-        public YAXCollectionAttribute CollectionAttributeInstance => _collectionAttributeInstance;
+        public YAXCollectionAttribute? CollectionAttributeInstance => _collectionAttributeInstance;
 
         /// <summary>
         ///     Gets the dictionary attribute instance.
         /// </summary>
         /// <value>The dictionary attribute instance.</value>
-        public YAXDictionaryAttribute DictionaryAttributeInstance => _dictionaryAttributeInstance;
+        public YAXDictionaryAttribute? DictionaryAttributeInstance => _dictionaryAttributeInstance;
 
         /// <summary>
         ///     Gets a value indicating whether this instance is treated as a collection.
@@ -405,7 +421,7 @@ namespace YAXLib
         ///     Gets or sets the type of the custom serializer.
         /// </summary>
         /// <value>The type of the custom serializer.</value>
-        public Type CustomSerializerType { get; private set; }
+        public Type? CustomSerializerType { get; private set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance has custom serializer.
@@ -440,7 +456,7 @@ namespace YAXLib
             {
                 _namespace = value;
                 // explicit namespace definition overrides namespace definitions in SerializeAs attributes.
-                _alias = _namespace + _alias.LocalName;
+                _alias = _namespace + _alias?.LocalName;
             }
         }
 
@@ -458,7 +474,7 @@ namespace YAXLib
         ///     setting a default namespace for that element would make it apply to
         ///     the whole document).
         /// </remarks>
-        public string NamespacePrefix { get; private set; }
+        public string? NamespacePrefix { get; private set; }
 
         public bool IsRealTypeDefined(Type type)
         {
@@ -467,7 +483,7 @@ namespace YAXLib
 
 
         // TODO: move to public methods section
-        public YAXTypeAttribute GetRealTypeDefinition(Type type)
+        public YAXTypeAttribute? GetRealTypeDefinition(Type type)
         {
             return _possibleRealTypes.FirstOrDefault(x => ReferenceEquals(x.Type, type));
         }
@@ -481,11 +497,11 @@ namespace YAXLib
         /// <param name="obj">The object whose value corresponding to this instance, must be retreived.</param>
         /// <param name="index">The array of indeces (usually <c>null</c>).</param>
         /// <returns>the original value of this member in the specified object</returns>
-        public object GetOriginalValue(object obj, object[] index)
+        public object? GetOriginalValue(object obj, object[]? index)
         {
             if (_isProperty)
-                return _propertyInfoInstance.GetValue(obj, index);
-            return _fieldInfoInstance.GetValue(obj);
+                return _propertyInfoInstance?.GetValue(obj, index);
+            return _fieldInfoInstance?.GetValue(obj);
         }
 
         /// <summary>
@@ -493,7 +509,7 @@ namespace YAXLib
         /// </summary>
         /// <param name="obj">The object whose value corresponding to this instance, must be retreived.</param>
         /// <returns>the processed value of this member in the specified object</returns>
-        public object GetValue(object obj)
+        public object? GetValue(object obj)
         {
             var elementValue = GetOriginalValue(obj, null);
 
@@ -516,12 +532,12 @@ namespace YAXLib
         /// </summary>
         /// <param name="obj">The object whose member corresponding to this instance, must be given value.</param>
         /// <param name="value">The value.</param>
-        public void SetValue(object obj, object value)
+        public void SetValue(object obj, object? value)
         {
             if (_isProperty)
-                _propertyInfoInstance.SetValue(obj, value, null);
+                _propertyInfoInstance?.SetValue(obj, value, null);
             else
-                _fieldInfoInstance.SetValue(obj, value);
+                _fieldInfoInstance?.SetValue(obj, value);
         }
 
         /// <summary>
@@ -535,7 +551,7 @@ namespace YAXLib
         public bool IsAllowedToBeSerialized(YAXSerializationFields serializationFields,
             bool dontSerializePropertiesWithNoSetter)
         {
-            if (dontSerializePropertiesWithNoSetter && _isProperty && !_propertyInfoInstance.CanWrite)
+            if (_propertyInfoInstance != null && dontSerializePropertiesWithNoSetter && _isProperty && !_propertyInfoInstance.CanWrite)
                 return false;
 
             if (serializationFields == YAXSerializationFields.AllFields)
@@ -597,10 +613,10 @@ namespace YAXLib
         {
             if (attr is YAXCommentAttribute)
             {
-                var comment = (attr as YAXCommentAttribute).Comment;
+                var comment = (attr as YAXCommentAttribute)?.Comment;
                 if (!string.IsNullOrEmpty(comment))
                 {
-                    var comments = comment.Split(new[] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
+                    var comments = comment!.Split(new[] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
                     for (var i = 0; i < comments.Length; i++) comments[i] = string.Format(" {0} ", comments[i].Trim());
 
                     Comment = comments;
@@ -632,7 +648,7 @@ namespace YAXLib
                     SerializationLocation = ".";
                 }
             }
-            else if (attr is YAXAttributeForAttribute)
+            else if (attr is YAXAttributeForAttribute forAttribute)
             {
                 // it is required that YAXCustomSerializerAttribute is processed earlier
                 if (ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer ||
@@ -640,28 +656,26 @@ namespace YAXLib
                     YAXCollectionSerializationTypes.Serially)
                 {
                     IsSerializedAsAttribute = true;
-                    string path, alias;
-                    StringUtils.ExttractPathAndAliasFromLocationString((attr as YAXAttributeForAttribute).Parent,
-                        out path, out alias);
+                    StringUtils.ExttractPathAndAliasFromLocationString(forAttribute.Parent,
+                        out var path, out var alias);
 
                     SerializationLocation = path;
                     if (!string.IsNullOrEmpty(alias))
                         Alias = StringUtils.RefineSingleElement(alias);
                 }
             }
-            else if (attr is YAXElementForAttribute)
+            else if (attr is YAXElementForAttribute attribute)
             {
                 IsSerializedAsElement = true;
 
-                string path, alias;
-                StringUtils.ExttractPathAndAliasFromLocationString((attr as YAXElementForAttribute).Parent, out path,
-                    out alias);
+                StringUtils.ExttractPathAndAliasFromLocationString(attribute.Parent, out var path,
+                    out var alias);
 
                 SerializationLocation = path;
                 if (!string.IsNullOrEmpty(alias))
                     Alias = StringUtils.RefineSingleElement(alias);
             }
-            else if (attr is YAXValueForAttribute)
+            else if (attr is YAXValueForAttribute valueForAttribute)
             {
                 // it is required that YAXCustomSerializerAttribute is processed earlier
                 if (ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer ||
@@ -670,9 +684,8 @@ namespace YAXLib
                 {
                     IsSerializedAsValue = true;
 
-                    string path, alias;
-                    StringUtils.ExttractPathAndAliasFromLocationString((attr as YAXValueForAttribute).Parent, out path,
-                        out alias);
+                    StringUtils.ExttractPathAndAliasFromLocationString(valueForAttribute.Parent, out var path,
+                        out var alias);
 
                     SerializationLocation = path;
                     if (!string.IsNullOrEmpty(alias))
@@ -683,9 +696,9 @@ namespace YAXLib
             {
                 IsAttributedAsDontSerialize = true;
             }
-            else if (attr is YAXSerializeAsAttribute)
+            else if (attr is YAXSerializeAsAttribute asAttribute)
             {
-                Alias = StringUtils.RefineSingleElement((attr as YAXSerializeAsAttribute).SerializeAs);
+                Alias = StringUtils.RefineSingleElement(asAttribute.SerializeAs);
             }
             else if (attr is YAXCollectionAttribute)
             {
@@ -697,13 +710,15 @@ namespace YAXLib
             }
             else if (attr is YAXErrorIfMissedAttribute)
             {
-                var temp = attr as YAXErrorIfMissedAttribute;
-                DefaultValue = temp.DefaultValue;
-                TreatErrorsAs = temp.TreatAs;
+                if (attr is YAXErrorIfMissedAttribute temp)
+                {
+                    TreatErrorsAs = temp.TreatAs;
+                    DefaultValue = temp.DefaultValue;
+                }
             }
-            else if (attr is YAXFormatAttribute)
+            else if (attr is YAXFormatAttribute formatAttribute)
             {
-                Format = (attr as YAXFormatAttribute).Format;
+                Format = formatAttribute.Format;
             }
             else if (attr is YAXNotCollectionAttribute)
             {
@@ -736,16 +751,15 @@ namespace YAXLib
                 // this should not happen
                 throw new Exception("This attribute is not applicable to fields and properties!");
             }
-            else if (attr is YAXNamespaceAttribute)
+            else if (attr is YAXNamespaceAttribute nsAttrib)
             {
-                var nsAttrib = attr as YAXNamespaceAttribute;
                 Namespace = nsAttrib.Namespace;
                 NamespacePrefix = nsAttrib.Prefix;
             }
             else if (attr is YAXTypeAttribute)
             {
                 var yaxTypeAttr = attr as YAXTypeAttribute;
-                var alias = yaxTypeAttr.Alias;
+                var alias = yaxTypeAttr?.Alias;
                 if (alias != null)
                 {
                     alias = alias.Trim();
@@ -753,22 +767,22 @@ namespace YAXLib
                         alias = null;
                 }
 
-                if (_possibleRealTypes.Any(x => x.Type == yaxTypeAttr.Type))
+                if (_possibleRealTypes.Any(x => x.Type == yaxTypeAttr?.Type))
                     throw new YAXPolymorphicException(string.Format(
                         "The type \"{0}\" for field/property \"{1}\" has already been defined through another attribute.",
-                        yaxTypeAttr.Type.Name, _memberInfo));
+                        yaxTypeAttr?.Type.Name, _memberInfo));
 
                 if (alias != null && _possibleRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
                     throw new YAXPolymorphicException(string.Format(
                         "The alias \"{0}\" given to type \"{1}\" for field/property \"{2}\" has already been given to another type through another attribute.",
-                        alias, yaxTypeAttr.Type.Name, _memberInfo));
+                        alias, yaxTypeAttr?.Type.Name, _memberInfo));
 
-                _possibleRealTypes.Add(yaxTypeAttr);
+                if (yaxTypeAttr != null) _possibleRealTypes.Add(yaxTypeAttr);
             }
             else if (attr is YAXCollectionItemTypeAttribute)
             {
                 var yaxColletionItemTypeAttr = attr as YAXCollectionItemTypeAttribute;
-                var alias = yaxColletionItemTypeAttr.Alias;
+                var alias = yaxColletionItemTypeAttr?.Alias;
                 if (alias != null)
                 {
                     alias = alias.Trim();
@@ -776,18 +790,18 @@ namespace YAXLib
                         alias = null;
                 }
 
-                if (_possibleCollectionItemRealTypes.Any(x => x.Type == yaxColletionItemTypeAttr.Type))
+                if (_possibleCollectionItemRealTypes.Any(x => x.Type == yaxColletionItemTypeAttr?.Type))
                     throw new YAXPolymorphicException(string.Format(
                         "The collection-item type \"{0}\" for collection \"{1}\" has already been defined through another attribute.",
-                        yaxColletionItemTypeAttr.Type.Name, _memberInfo));
+                        yaxColletionItemTypeAttr?.Type.Name, _memberInfo));
 
                 if (alias != null &&
                     _possibleCollectionItemRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
                     throw new YAXPolymorphicException(string.Format(
                         "The alias \"{0}\" given to collection-item type \"{1}\" for field/property \"{2}\" has already been given to another type through another attribute.",
-                        alias, yaxColletionItemTypeAttr.Type.Name, _memberInfo));
+                        alias, yaxColletionItemTypeAttr?.Type.Name, _memberInfo));
 
-                _possibleCollectionItemRealTypes.Add(yaxColletionItemTypeAttr);
+                if (yaxColletionItemTypeAttr != null) _possibleCollectionItemRealTypes.Add(yaxColletionItemTypeAttr);
             }
             else if (attr is YAXDontSerializeIfNullAttribute)
             {
@@ -795,7 +809,7 @@ namespace YAXLib
             }
             else if (attr is YAXElementOrder)
             {
-                Order = (attr as YAXElementOrder).Order;
+                Order = (attr as YAXElementOrder)?.Order ?? 0;
             }
             else
             {

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -736,31 +736,24 @@ namespace YAXLib
         }
 
         /// <summary>
-        ///     Test whether the <see cref="MemberInfo"/> parameter is part of a .NET module.
+        ///     Test whether the <see cref="MemberInfo"/> parameter is part of a .NET assembly.
         /// </summary>
         /// <remarks>
         ///     Might require modifications when supporting future versions of .NET.
         /// </remarks>
         /// <param name="memberInfo"></param>
-        /// <returns>Returns <see langword="true"/>, if the <see cref="MemberInfo"/> parameter is part of a .NET module, else <see langword="false"/>.</returns>
-        /// <summary>
-        ///     Test whether the <see cref="MemberInfo"/> parameter is part of a .NET module.
-        /// </summary>
-        /// <remarks>
-        ///     Might require modifications when supporting future versions of .NET.
-        /// </remarks>
-        /// <returns>Returns <see langword="true"/>, if the <see cref="MemberInfo"/> parameter is part of a .NET module, else <see langword="false"/>.</returns>
+        /// <returns>Returns <see langword="true"/>, if the <see cref="MemberInfo"/> parameter is part of a .NET assembly, else <see langword="false"/>.</returns>
         public static bool IsPartOfNetFx(MemberInfo memberInfo)
         {
-            var moduleName = memberInfo.Module.Name;
+            var assemblyName = memberInfo.DeclaringType.Assembly.GetName().Name;
 #if NETSTANDARD
-            return moduleName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
-                   moduleName.StartsWith("mscorlib.", StringComparison.OrdinalIgnoreCase) ||
-                   moduleName.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase);
+            return assemblyName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.StartsWith("mscorlib.", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase);
 #else
-            return moduleName.Equals("mscorlib.dll", StringComparison.OrdinalIgnoreCase)
-                   || moduleName.Equals("System.dll", StringComparison.OrdinalIgnoreCase)
-                   || moduleName.Equals("System.Core.dll", StringComparison.OrdinalIgnoreCase);
+            return assemblyName.Equals("mscorlib", StringComparison.OrdinalIgnoreCase)
+                   || assemblyName.Equals("System", StringComparison.OrdinalIgnoreCase)
+                   || assemblyName.Equals("System.Core", StringComparison.OrdinalIgnoreCase);
 #endif
         }
 

--- a/YAXLib/SerializationContext.cs
+++ b/YAXLib/SerializationContext.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+#nullable enable
+using System;
+using System.Reflection;
+using YAXLib.Options;
+
+namespace YAXLib;
+
+/// <inheritdoc/>
+internal class SerializationContext : ISerializationContext
+{
+    /// <summary>
+    /// Creates a new serialization context instance.
+    /// </summary>
+    /// <param name="memberWrapper"></param>
+    /// <param name="udtWrapper"></param>
+    /// <param name="serializerOptions"></param>
+    public SerializationContext(MemberWrapper? memberWrapper, UdtWrapper? udtWrapper, SerializerOptions serializerOptions)
+    {
+        SerializerOptions = serializerOptions;
+
+        // Class level serialization
+        ClassType = udtWrapper?.UnderlyingType;
+        
+        if (memberWrapper == null) return;
+        
+        // Member level serialization
+        FieldInfo = memberWrapper.FieldInfo;
+        MemberInfo = memberWrapper.MemberInfo;
+        PropertyInfo = memberWrapper.PropertyInfo;
+        MemberType = memberWrapper.MemberType;
+    }
+
+    /// <inheritdoc/>
+    public FieldInfo? FieldInfo { get; }
+
+    /// <inheritdoc/>
+    public MemberInfo? MemberInfo { get; }
+
+    /// <inheritdoc/>
+    public PropertyInfo? PropertyInfo { get; }
+
+    /// <inheritdoc/>
+    public Type? MemberType { get; }
+
+    /// <inheritdoc/>
+    public Type? ClassType { get; }
+
+    /// <inheritdoc/>
+    public SerializerOptions SerializerOptions { get; }
+}

--- a/YAXLibTests/CustomSerializerTests.cs
+++ b/YAXLibTests/CustomSerializerTests.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+using System;
+using System.Reflection;
 using NUnit.Framework;
 using YAXLib;
 using YAXLib.Exceptions;
+using YAXLib.Options;
 using YAXLibTests.SampleClasses.CustomSerialization;
 
 namespace YAXLibTests
@@ -86,21 +89,21 @@ namespace YAXLibTests
         {
             // The custom serializer handles Body property
             
-            var original = new FieldLevelSample
+            var original = new PropertyLevelSample
             {
                 Id = "1234", // default serializer
                 Title = "This is the title", // default serializer
                 Body = "Just a short message body" // use custom serializer
             };
-            var s = new YAXSerializer(typeof(FieldLevelSample));
+            var s = new YAXSerializer(typeof(PropertyLevelSample));
             var xml = s.Serialize(original);
-            var deserialized = (FieldLevelSample) s.Deserialize(xml);
+            var deserialized = (PropertyLevelSample) s.Deserialize(xml);
             var expectedXml = 
-                @"<FieldLevelSample>
+                @"<PropertyLevelSample>
   <Id>1234</Id>
   <Title>This is the title</Title>
   <Body>ELE__Just a short message body</Body>
-</FieldLevelSample>";
+</PropertyLevelSample>";
             
             Assert.That(xml, Is.EqualTo(expectedXml));
             Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()));
@@ -133,6 +136,7 @@ namespace YAXLibTests
         public void Custom_NonGenericClass_Interface_Serializer()
         {
             // Use an interface as type to serialize a non-generic class
+            // with a custom serializer
 
             var s = new YAXSerializer(typeof(ISampleInterface));
             var original = (ISampleInterface) new NonGenericClassWithInterface
@@ -141,12 +145,16 @@ namespace YAXLibTests
                 Name = "The " + nameof(ISampleInterface.Name)
             };
             var xml = s.Serialize(original);
+            // Deserialization makes use of SerializationContext
             var deserialized = (ISampleInterface) s.Deserialize(xml);
             var expectedXmlPart = 
                 $@"
-  <Id>{original.Id}</Id>
-  <Name>{original.Name}</Name>
+  <C_Id>{original.Id}</C_Id>
+  <C_Name>{original.Name}</C_Name>
 </ISampleInterface>";
+            
+            // Note: Prefix "C_" is evidence for custom serializer was invoked
+            // during serialization and deserialization
             Assert.That(xml, Does.Contain(expectedXmlPart), "Serialized XML");
             Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()), "Deserialized Object");
         }
@@ -155,22 +163,31 @@ namespace YAXLibTests
         public void Custom_GenericClass_Interface_Serializer()
         {
             // Use an interface as type to serialize a generic class
+            // with a custom serializer
 
             var s = new YAXSerializer(typeof(ISampleInterface));
             var original = new GenericClassWithInterface<int>
             { 
-                Something = 9876,
                 Id = 12345,
-                Name = "The " + nameof(ISampleInterface.Name)
+                Name = "The " + nameof(ISampleInterface.Name),
+                // 'Something' is not an ISampleInterface member
+                Something = 9876
             };
             var xml = s.Serialize(original);
+
+            // Deserialization makes use of SerializationContext
             var deserialized = (ISampleInterface) s.Deserialize(xml);
+            
+            // Comment for 'Something' is just for demonstration
             var expectedXmlPart = 
                 $@"
-  <Id>{original.Id}</Id>
-  <Name>{original.Name}</Name>
+  <C_Id>{original.Id}</C_Id>
+  <C_Name>{original.Name}</C_Name>
+  <!--Value of 'Something': '9876'-->
 </ISampleInterface>";
 
+            // Note: Prefix "C_" is evidence for custom serializer was invoked
+            // during serialization and deserialization
             Assert.That(xml, Does.Contain(expectedXmlPart), "Serialized XML");
             Assert.That(deserialized.ToString(), Is.EqualTo(original.ToString()), "Deserialized Object");
         }

--- a/YAXLibTests/SampleClasses/Code4PublicTheme.cs
+++ b/YAXLibTests/SampleClasses/Code4PublicTheme.cs
@@ -161,22 +161,22 @@ namespace YAXLibTests.SampleClasses
 
     internal class ColorSerializer : ICustomSerializer<Color>
     {
-        public void SerializeToAttribute(Color objectToSerialize, XAttribute attrToFill)
+        public void SerializeToAttribute(Color objectToSerialize, XAttribute attrToFill, ISerializationContext serializationContext)
         {
             attrToFill.Value = ColorTo6CharHtmlString(objectToSerialize);
         }
 
-        public void SerializeToElement(Color objectToSerialize, XElement elemToFill)
+        public void SerializeToElement(Color objectToSerialize, XElement elemToFill, ISerializationContext serializationContext)
         {
             elemToFill.Value = ColorTo6CharHtmlString(objectToSerialize);
         }
 
-        public string SerializeToValue(Color objectToSerialize)
+        public string SerializeToValue(Color objectToSerialize, ISerializationContext serializationContext)
         {
             return ColorTo6CharHtmlString(objectToSerialize);
         }
 
-        public Color DeserializeFromAttribute(XAttribute attrib)
+        public Color DeserializeFromAttribute(XAttribute attrib, ISerializationContext serializationContext)
         {
             if (TryParseColor(attrib.Value, out var color))
                 return color;
@@ -184,7 +184,7 @@ namespace YAXLibTests.SampleClasses
             throw new YAXBadlyFormedInput(attrib.Name.ToString(), attrib.Value, attrib);
         }
 
-        public Color DeserializeFromElement(XElement element)
+        public Color DeserializeFromElement(XElement element, ISerializationContext serializationContext)
         {
             if (TryParseColor(element.Value, out var color))
                 return color;
@@ -192,7 +192,7 @@ namespace YAXLibTests.SampleClasses
             throw new YAXBadlyFormedInput(element.Name.ToString(), element.Value, element);
         }
 
-        public Color DeserializeFromValue(string value)
+        public Color DeserializeFromValue(string value, ISerializationContext serializationContext)
         {
             if (TryParseColor(value, out var color))
                 return color;

--- a/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelSerializer.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelSerializer.cs
@@ -9,29 +9,29 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
 {
     public class ClassLevelSerializer : ICustomSerializer<ClassLevelSample>
     {
-        public void SerializeToAttribute(ClassLevelSample objectToSerialize, XAttribute attrToFill)
+        public void SerializeToAttribute(ClassLevelSample objectToSerialize, XAttribute attrToFill, ISerializationContext serializationContext)
         {
             attrToFill.Value = string.Join("|", "ATTR", objectToSerialize.Title, objectToSerialize.MessageBody);
         }
 
-        public void SerializeToElement(ClassLevelSample objectToSerialize, XElement elemToFill)
+        public void SerializeToElement(ClassLevelSample objectToSerialize, XElement elemToFill, ISerializationContext serializationContext)
         {
             elemToFill.Add(new XElement(nameof(objectToSerialize.Title), objectToSerialize.Title));
             elemToFill.Add(new XElement(nameof(objectToSerialize.MessageBody), objectToSerialize.MessageBody));
         }
 
-        public string SerializeToValue(ClassLevelSample objectToSerialize)
+        public string SerializeToValue(ClassLevelSample objectToSerialize, ISerializationContext serializationContext)
         {
             return string.Join("|", "VAL", objectToSerialize.Title, objectToSerialize.MessageBody);
         }
 
-        public ClassLevelSample DeserializeFromAttribute(XAttribute attrib)
+        public ClassLevelSample DeserializeFromAttribute(XAttribute attrib, ISerializationContext serializationContext)
         {
             var split = attrib.Value.Split('|');
             return new ClassLevelSample {Title = split[1], MessageBody = split[2]};
         }
 
-        public ClassLevelSample DeserializeFromElement(XElement element)
+        public ClassLevelSample DeserializeFromElement(XElement element, ISerializationContext serializationContext)
         {
             return new ClassLevelSample {
                 Title = element.Element(nameof(ClassLevelSample.Title))?.Value,
@@ -39,7 +39,7 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
             };
         }
 
-        public ClassLevelSample DeserializeFromValue(string value)
+        public ClassLevelSample DeserializeFromValue(string value, ISerializationContext serializationContext)
         {
             var split = value.Split('|');
             return new ClassLevelSample {Title = split[1], MessageBody = split[2]};

--- a/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelCombinedSerializer.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelCombinedSerializer.cs
@@ -9,32 +9,32 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
 {
     public class FieldLevelCombinedSerializer : ICustomSerializer<string>
     {
-        public void SerializeToAttribute(string objectToSerialize, XAttribute attrToFill)
+        public void SerializeToAttribute(string objectToSerialize, XAttribute attrToFill, ISerializationContext serializationContext)
         {
             attrToFill.Value = "ATTR_" + objectToSerialize;
         }
 
-        public void SerializeToElement(string objectToSerialize, XElement elemToFill)
+        public void SerializeToElement(string objectToSerialize, XElement elemToFill, ISerializationContext serializationContext)
         {
             elemToFill.Add(new XText("ELE__" + objectToSerialize));
         }
 
-        public string SerializeToValue(string objectToSerialize)
+        public string SerializeToValue(string objectToSerialize, ISerializationContext serializationContext)
         {
             return "VAL__" + objectToSerialize;
         }
 
-        public string DeserializeFromAttribute(XAttribute attrib)
+        public string DeserializeFromAttribute(XAttribute attrib, ISerializationContext serializationContext)
         {
             return attrib.Value.Substring(5);
         }
 
-        public string DeserializeFromElement(XElement element)
+        public string DeserializeFromElement(XElement element, ISerializationContext serializationContext)
         {
             return element.Value.Substring(5);
         }
 
-        public string DeserializeFromValue(string value)
+        public string DeserializeFromValue(string value, ISerializationContext serializationContext)
         {
             return value.Substring(5);
         }

--- a/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelSerializer.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/FieldLevelSerializer.cs
@@ -7,34 +7,37 @@ using YAXLib;
 
 namespace YAXLibTests.SampleClasses.CustomSerialization
 {
-    public class FieldLevelSerializer : ICustomSerializer<string>
+    public class FieldLevelSerializer : PropertyLevelSerializer
+    { }
+
+    public class PropertyLevelSerializer : ICustomSerializer<string>
     {
-        public void SerializeToAttribute(string objectToSerialize, XAttribute attrToFill)
+        public void SerializeToAttribute(string objectToSerialize, XAttribute attrToFill, ISerializationContext serializationContext)
         {
             attrToFill.Value = "ATTR_" + objectToSerialize;
         }
 
-        public void SerializeToElement(string objectToSerialize, XElement elemToFill)
+        public void SerializeToElement(string objectToSerialize, XElement elemToFill, ISerializationContext serializationContext)
         {
             elemToFill.Add(new XText("ELE__" + objectToSerialize));
         }
 
-        public string SerializeToValue(string objectToSerialize)
+        public string SerializeToValue(string objectToSerialize, ISerializationContext serializationContext)
         {
             return "VAL__" + objectToSerialize;
         }
 
-        public string DeserializeFromAttribute(XAttribute attrib)
+        public string DeserializeFromAttribute(XAttribute attrib, ISerializationContext serializationContext)
         {
             return attrib.Value.Substring(5);
         }
 
-        public string DeserializeFromElement(XElement element)
+        public string DeserializeFromElement(XElement element, ISerializationContext serializationContext)
         {
             return element.Value.Substring(5);
         }
 
-        public string DeserializeFromValue(string value)
+        public string DeserializeFromValue(string value, ISerializationContext serializationContext)
         {
             return value.Substring(5);
         }

--- a/YAXLibTests/SampleClasses/CustomSerialization/InterfaceSerializer.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/InterfaceSerializer.cs
@@ -9,33 +9,50 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
 {
     public class InterfaceSerializer : ICustomSerializer<ISampleInterface>
     {
-        public void SerializeToAttribute(ISampleInterface objectToSerialize, XAttribute attrToFill)
+        public void SerializeToAttribute(ISampleInterface objectToSerialize, XAttribute attrToFill,
+            ISerializationContext serializationContext)
         {
             throw new NotImplementedException();
         }
 
-        public void SerializeToElement(ISampleInterface objectToSerialize, XElement elemToFill)
+        public void SerializeToElement(ISampleInterface objectToSerialize, XElement elemToFill, ISerializationContext serializationContext)
         {
-            elemToFill.Add(new XElement("Id", objectToSerialize.Id));
-            elemToFill.Add(new XElement("Name", objectToSerialize.Name));
+            // Serialize ISampleInterface members
+            elemToFill.Add(new XElement("C_Id", objectToSerialize.Id));
+            elemToFill.Add(new XElement("C_Name", objectToSerialize.Name));
+
+            // Serialize another class member as comment
+            // only when serializing GenericClassWithInterface
+            var classType = serializationContext.ClassType!;
+            if (classType.IsGenericType && classType.GetGenericTypeDefinition() == typeof(GenericClassWithInterface<>))
+            {
+                var valueOfT = objectToSerialize.GetType().GetProperty("Something")?.GetValue(objectToSerialize);
+                elemToFill.Add(new XComment($"Value of 'Something': '{valueOfT}'"));
+            }
         }
 
-        public string SerializeToValue(ISampleInterface objectToSerialize)
+        public string SerializeToValue(ISampleInterface objectToSerialize, ISerializationContext serializationContext)
         {
             throw new NotImplementedException();
         }
 
-        public ISampleInterface DeserializeFromAttribute(XAttribute attrib)
+        public ISampleInterface DeserializeFromAttribute(XAttribute attrib, ISerializationContext serializationContext)
         {
             throw new NotImplementedException();
         }
 
-        public ISampleInterface DeserializeFromElement(XElement element)
+        public ISampleInterface DeserializeFromElement(XElement element, ISerializationContext serializationContext)
         {
-            throw new NotImplementedException();
+            var o = (ISampleInterface) Activator.CreateInstance(serializationContext.ClassType!);
+            if (element.HasElements)
+            {
+                o.Id = int.Parse(element.Element("C_" + nameof(ISampleInterface.Id))!.Value);
+                o.Name = element.Element("C_" + nameof(ISampleInterface.Name))!.Value;
+            }
+            return o;
         }
 
-        public ISampleInterface DeserializeFromValue(string value)
+        public ISampleInterface DeserializeFromValue(string value, ISerializationContext serializationContext)
         {
             throw new NotImplementedException();
         }

--- a/YAXLibTests/SampleClasses/CustomSerialization/PropertyLevelSample.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/PropertyLevelSample.cs
@@ -5,14 +5,14 @@ using YAXLib.Attributes;
 
 namespace YAXLibTests.SampleClasses.CustomSerialization
 {
-    public class FieldLevelSample
+    public class PropertyLevelSample
     {
-        public string Id;
-
-        public string Title;
-
-        [YAXCustomSerializer(typeof(FieldLevelSerializer))]
-        public string Body;
+        public string Id { get; set; }
+        
+        public string Title { get; set; }
+        
+        [YAXCustomSerializer(typeof(PropertyLevelSerializer))]
+        public string Body { get; set; }
 
         public override string ToString()
         {

--- a/YAXLibTests/SampleClasses/CustomSerializationDemoClasses.cs
+++ b/YAXLibTests/SampleClasses/CustomSerializationDemoClasses.cs
@@ -57,12 +57,12 @@ namespace YAXLibTests.SampleClasses
 
     public class CustomMessageClassSerializer : ICustomSerializer<Message>
     {
-        public void SerializeToAttribute(Message objectToSerialize, XAttribute attrToFill)
+        public void SerializeToAttribute(Message objectToSerialize, XAttribute attrToFill, ISerializationContext serializationContext)
         {
             throw new NotImplementedException();
         }
 
-        public void SerializeToElement(Message objectToSerialize, XElement elemToFill)
+        public void SerializeToElement(Message objectToSerialize, XElement elemToFill, ISerializationContext serializationContext)
         {
             var message = objectToSerialize.MessageText;
             var beforeBold = message.Substring(0, objectToSerialize.BoldIndex);
@@ -73,17 +73,17 @@ namespace YAXLibTests.SampleClasses
             elemToFill.Add(new XText(afterBold));
         }
 
-        public string SerializeToValue(Message objectToSerialize)
+        public string SerializeToValue(Message objectToSerialize, ISerializationContext serializationContext)
         {
             throw new NotImplementedException();
         }
 
-        public Message DeserializeFromAttribute(XAttribute attrib)
+        public Message DeserializeFromAttribute(XAttribute attrib, ISerializationContext serializationContext)
         {
             throw new NotImplementedException();
         }
 
-        public Message DeserializeFromElement(XElement element)
+        public Message DeserializeFromElement(XElement element, ISerializationContext serializationContext)
         {
             var wholeMessage = "";
             var boldIndex = -1;
@@ -116,7 +116,7 @@ namespace YAXLibTests.SampleClasses
             };
         }
 
-        public Message DeserializeFromValue(string value)
+        public Message DeserializeFromValue(string value, ISerializationContext serializationContext)
         {
             throw new NotImplementedException();
         }
@@ -124,17 +124,17 @@ namespace YAXLibTests.SampleClasses
 
     public class CustomTitleSerializer : ICustomSerializer<string>
     {
-        public string DeserializeFromAttribute(XAttribute attrib)
+        public string DeserializeFromAttribute(XAttribute attrib, ISerializationContext serializationContext)
         {
             return RetrieveValue(attrib.Value);
         }
 
-        public string DeserializeFromElement(XElement element)
+        public string DeserializeFromElement(XElement element, ISerializationContext serializationContext)
         {
             return RetrieveValue(element.Value);
         }
 
-        public string DeserializeFromValue(string value)
+        public string DeserializeFromValue(string value, ISerializationContext serializationContext)
         {
             return RetrieveValue(value);
         }
@@ -150,17 +150,17 @@ namespace YAXLibTests.SampleClasses
             return sb.ToString();
         }
 
-        public void SerializeToAttribute(string objectToSerialize, XAttribute attrToFill)
+        public void SerializeToAttribute(string objectToSerialize, XAttribute attrToFill, ISerializationContext serializationContext)
         {
             attrToFill.Value = CreateMixedValue(objectToSerialize);
         }
 
-        public void SerializeToElement(string objectToSerialize, XElement elemToFill)
+        public void SerializeToElement(string objectToSerialize, XElement elemToFill, ISerializationContext serializationContext)
         {
             elemToFill.Value = CreateMixedValue(objectToSerialize);
         }
 
-        public string SerializeToValue(string objectToSerialize)
+        public string SerializeToValue(string objectToSerialize, ISerializationContext serializationContext)
         {
             return CreateMixedValue(objectToSerialize);
         }

--- a/YAXLibTests/SampleClasses/SerializationOptionsSample.cs
+++ b/YAXLibTests/SampleClasses/SerializationOptionsSample.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
 using YAXLib;
 using YAXLib.Attributes;
 using YAXLib.Enums;
@@ -10,11 +11,11 @@ namespace YAXLibTests.SampleClasses
     [YAXSerializableType(Options = YAXSerializationOptions.DontSerializeNullObjects)]
     public class ClassWithOptionsSet
     {
-        public string StrNotNull { get; set; }
+        public string StrNotNull { get; set; } = string.Empty;
 
         // the default value should not be used && no warning or errors should be reported
         [YAXErrorIfMissed(YAXExceptionTypes.Warning, DefaultValue = "Salam")]
-        public string StrNull { get; set; }
+        public string? StrNull { get; set; }
 
         [YAXErrorIfMissed(YAXExceptionTypes.Warning, DefaultValue = 123)]
         public int SomeValueType { get; set; }
@@ -23,19 +24,38 @@ namespace YAXLibTests.SampleClasses
     [YAXSerializableType(Options = YAXSerializationOptions.SerializeNullObjects)]
     public class AnotherClassWithOptionsSet
     {
-        public string StrNotNull { get; set; }
-        public string StrNull { get; set; }
+        public string StrNotNull { get; set; } = string.Empty;
+        public string? StrNull { get; set; }
     }
 
     public class ClassWithoutOptionsSet
     {
-        public string StrNotNull { get; set; }
-        public string StrNull { get; set; }
+        public string StrNotNull { get; set; } = string.Empty;
+        public string? StrNull { get; set; }
     }
 
     [ShowInDemoApplication]
     public class SerializationOptionsSample
     {
+        public SerializationOptionsSample()
+        {
+            ObjectWithOptionsSet = new ClassWithOptionsSet {
+                StrNull = null,
+                StrNotNull = "SomeString",
+                SomeValueType = default
+            };
+
+            AnotherObjectWithOptionsSet = new AnotherClassWithOptionsSet {
+                StrNull = null,
+                StrNotNull = "Some other string"
+            };
+
+            ObjectWithoutOptionsSet = new ClassWithoutOptionsSet {
+                StrNull = null,
+                StrNotNull = "Another string"
+            };
+        }
+
         [YAXComment(@"Str2Null must NOT be serialized when it is null, even 
 if the serialization options of the serializer is changed")]
         public ClassWithOptionsSet ObjectWithOptionsSet { get; set; }
@@ -55,26 +75,30 @@ in the serializer itself")]
 
         public static SerializationOptionsSample GetSampleInstance()
         {
-            return new SerializationOptionsSample
-            {
-                ObjectWithOptionsSet = new ClassWithOptionsSet
-                {
-                    StrNull = null,
-                    StrNotNull = "SomeString"
-                },
+            return new SerializationOptionsSample();
+        }
 
-                AnotherObjectWithOptionsSet = new AnotherClassWithOptionsSet
-                {
-                    StrNull = null,
-                    StrNotNull = "Some other string"
-                },
+        [YAXSerializeAs("my_customer")]
+        public class MissingElementsSample1
+        {
+            [YAXSerializeAs("cust_id")]
+            public int Id { get; set; }
+            [YAXSerializeAs("cust_name")]
+            public string? Name { get; set; }
+            [YAXSerializeAs("option")]
+            public int? Optional { get; set; }
+        }
 
-                ObjectWithoutOptionsSet = new ClassWithoutOptionsSet
-                {
-                    StrNull = null,
-                    StrNotNull = "Another string"
-                }
-            };
+        [YAXSerializeAs("my_customer")]
+        [YAXSerializableType(Options = YAXSerializationOptions.DontSerializeNullObjects)]
+        public class MissingElementsSample2
+        {
+            [YAXSerializeAs("cust_id")]
+            public int Id { get; set; }
+            [YAXSerializeAs("cust_name")]
+            public string? Name { get; set; }
+            [YAXSerializeAs("option")]
+            public int? Optional { get; set; }
         }
     }
 }

--- a/YAXLibTests/SerializationContextTests.cs
+++ b/YAXLibTests/SerializationContextTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using NUnit.Framework;
+using YAXLib;
+using YAXLib.Options;
+using YAXLibTests.SampleClasses.CustomSerialization;
+
+namespace YAXLibTests
+{
+    [TestFixture]
+    public class SerializationContextTests
+    {
+        [TestCase(typeof(PropertyLevelSample))]
+        [TestCase(typeof(FieldLevelSample))]
+        public void SerializationContext_All_Set_For_Class_And_Members(Type sampleType)
+        {
+            const string memberName = "Title";
+            var udtWrapper = new UdtWrapper(sampleType, null);
+            var memberInfo = udtWrapper.UnderlyingType.GetMember(memberName)[0];
+            var memberWrapper = new MemberWrapper(memberInfo, null);
+            var sc = new SerializationContext(memberWrapper, udtWrapper, new SerializerOptions());
+
+            Assert.That(sc.SerializerOptions, Is.Not.Null);
+            Assert.That(sc.ClassType!.Name, Is.EqualTo(sampleType.Name));
+            Assert.That(sc.MemberType!.UnderlyingSystemType.Name, Is.EqualTo(nameof(String)));
+            Assert.That(sc.MemberInfo!.Name, Is.EqualTo(memberName));
+            Assert.That(sc.PropertyInfo != null ? sc.PropertyInfo!.Name : sc.FieldInfo!.Name, Is.EqualTo(memberName));
+        }
+    }
+}


### PR DESCRIPTION
### Serialization Context
Added a serialization context when invoking CustomSerializers (#167)

* Added a serialization context when invoking CustomSerializers
* Feature/initial step single responsibility principal (#168)
* Added regions to help make the YAXSerializer more readable.
* Single Responsibility Principal, moved logic related to creating a custom serializer to it's own class.
* Single Responsibility Principal, moved all or at least most logic related to namespaces to it's own class.
Co-authored-by: bob.sanders <bob.sanders@valtech.com>
* Fixes #166 ICustomSerializers may have an interface as the generic argument (#169), e.g. 
      ```
      public class SomeSerializer : ICustomSerializer<ISomeInterface> {
         //...
      }
      ```

### Custom Serialization bug fixes
* Fix: ICustomSerializer was only called after first deserialization
   * Reasons:
      * In YAXSerializer, HasCustomSerializer was tested BEFORE analyzing the RealType attribute, to it was not called for deserialization
      * At the same time, the default deserialization gave the correct result
   * Measures:
      * HasCustomSerializer is tested AFTER analyzing any RealType attribute
      * Tests will now fail, if ICustomSerializer is not called