### PR TITLE
Fix: SonarCloud do not support analysis of forked PRs

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -1,14 +1,17 @@
 name: SonarCloud
 on:
   push:
-    branches: [ master, 'pr-**' ]
+    branches: [ master, 'version/**', 'pr/**', 'pr-**' ]
   pull_request:
-    branches: [ master, 'pr-**' ]
+    branches: [ master, 'version/**', 'pr/**', 'pr-**' ]
     types: [opened, synchronize, reopened]
 jobs:
   build:
     name: Build
     runs-on: windows-latest
+    # SonarCloud do not support analysis of forked PRs, even when those PRs come from members of the organization
+    # (PRs from forks can't access secrets other than secrets.GITHUB_TOKEN for security reasons)
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Set up JDK 11
         uses: actions/setup-java@v1


### PR DESCRIPTION
No CI failure: The SonarCloud GitHub action won't run for PRs from forks.
SonarCloud do not support analysis of forked PRs, even when those PRs come from members of the organization.