### PR TITLE
Add text embedding for XML elements, option to strip invalid XML chars

### DIFF
--- a/YAXLib/Attributes/YAXTextEmbeddingAttribute.cs
+++ b/YAXLib/Attributes/YAXTextEmbeddingAttribute.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using YAXLib.Enums;
+
+namespace YAXLib.Attributes;
+
+/// <summary>
+/// Specifies how to de/serialize a string value.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public class YAXTextEmbeddingAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
+{
+    private static readonly Type[] CompatibleAttributes = {
+        typeof(YAXTextEmbeddingAttribute), typeof(YAXDontSerializeAttribute), typeof(YAXDontSerializeIfNullAttribute),
+        typeof(YAXSerializeAsAttribute), typeof(YAXCommentAttribute), typeof(YAXSerializableFieldAttribute),
+        typeof(YAXNamespaceAttribute), typeof(YAXErrorIfMissedAttribute), typeof(YAXElementOrder), typeof(YAXElementForAttribute)
+    };
+
+    /// <summary>
+    /// Determines how to embed a value of an XML <see cref="XElement"/> or <see cref="XAttribute"/>.
+    /// </summary>
+    /// <param name="embedding">
+    /// The kind of <see cref="TextEmbedding"/> to use for the value.
+    /// The attribute can be omitted, if embedding is <see cref="TextEmbedding.None"/>.
+    /// </param>
+    public YAXTextEmbeddingAttribute(TextEmbedding embedding)
+    {
+        Embedding = embedding;
+    }
+
+    /// <inheritdoc cref="TextEmbedding"/>
+    public TextEmbedding Embedding { get; }
+
+    /// <inheritdoc/>
+    void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
+    {
+        if (GetCustomAttributes(memberWrapper.MemberInfo, typeof(Attribute), true)
+            .Where(a => a is YAXBaseAttribute)
+            .Select(a => a.GetType())
+            .Except(CompatibleAttributes)
+            .Any())
+        {
+            throw new InvalidOperationException(
+                $"{nameof(YAXTextEmbeddingAttribute)} can only be combined with {string.Join(", ", CompatibleAttributes.AsEnumerable())}");
+        }
+
+        if (memberWrapper.MemberType != typeof(string))
+            throw new InvalidOperationException($"Only fields or properties of type string may be decorated with {nameof(YAXTextEmbeddingAttribute)}.");
+
+        memberWrapper.TextEmbedding = Embedding;
+    }
+}

--- a/YAXLib/Enums/TextEmbedding.cs
+++ b/YAXLib/Enums/TextEmbedding.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System.Xml.Linq;
+
+namespace YAXLib.Enums;
+
+/// <summary>
+/// Options for embedding a string value to an <see cref="XElement"/>.
+/// </summary>
+public enum TextEmbedding
+{
+    /// <summary>
+    /// No embedding. Legal special characters like '&lt;' or '&amp;' will be entitized.
+    /// </summary>
+    None = 0,
+    /// <summary>
+    /// The element text is embedded as character data (CDATA, <see cref="XCData"/>).
+    /// <para>
+    /// This is useful, e.g. if a <see langword="string"/> contains HTML tags or script code.
+    /// The result is better human-readable.
+    /// </para>
+    /// </summary>
+    CData = 1,
+    /// <summary>
+    /// Embedded by encoding to a Base64-encoded string, and restored from a Base64-encoded string.
+    /// This is useful, if a <see langword="string"/> may contain control or other
+    /// invalid XML characters in an <see cref="XElement"/> value.
+    /// </summary>
+    Base64 = 2
+}

--- a/YAXLib/Enums/YAXSerializationOptions.cs
+++ b/YAXLib/Enums/YAXSerializationOptions.cs
@@ -48,5 +48,14 @@ namespace YAXLib.Enums
         ///     Enabling this has a performance impact
         /// </summary>
         DisplayLineInfoInExceptions = 32,
+
+        /// <summary>
+        /// Silently removes illegal XML characters when serializing, instead of throwing an exception.
+        /// Note: XML containing illegal characters cannot be loaded and deserialized.
+        /// <para>
+        /// Default: disabled.
+        /// </para>
+        /// </summary>
+        StripInvalidXmlChars = 64
     }
 }

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -327,6 +327,9 @@ namespace YAXLib
             }
         }
 
+        /// <inheritdoc cref="Enums.TextEmbedding"/>
+        public TextEmbedding TextEmbedding { get; internal set; } = TextEmbedding.None;
+
         /// <summary>
         ///     Gets the type of the member.
         /// </summary>

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -687,7 +687,7 @@ namespace YAXLib
             var pattern =
                 RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework")
                     // Forward compatibility:
-                    // if we get a yaxlib:realtype which is NETSTANDARD or NET5.0 System.Private.CoreLib, replace it with its equivalent
+                    // if we get a yaxlib:realtype which is NETSTANDARD (and later) System.Private.CoreLib, replace it with its equivalent
                     ? @"\,\s+(System\.Private\.CoreLib)\,\s+Version\=\d+(\.\d+)*\,\s+Culture=\b\w+\b\,\s+PublicKeyToken\=\b\w+\b"
                     // Backward compatibility:
                     // if we get a yaxlib:realtype which is .Net Framework 2.x/3.x/4.x mscorlib, replace it with its equivalent

--- a/YAXLib/StringExtensions.cs
+++ b/YAXLib/StringExtensions.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+#nullable enable
+using System;
+using System.Buffers;
+using System.Text;
+
+namespace YAXLib
+{
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// Encodes the given text to Base64, using the given <see cref="Encoding"/> (default: <see cref="Encoding.UTF8"/>
+        /// </summary>
+        /// <param name="textToEncode"></param>
+        /// <param name="encoding">Default is <see cref="Encoding.UTF8"/>.</param>
+        /// <param name="insertLineBreaks">Inserts line breaks after every 76 characters in the string representation.</param>
+        /// <returns>The encoded string.</returns>
+        public static string? ToBase64(this string? textToEncode, Encoding? encoding = null, bool insertLineBreaks = true)
+        {
+            if (textToEncode == null) return null;
+
+            encoding ??= Encoding.UTF8;
+#if NETSTANDARD2_1_OR_GREATER
+            var length = (textToEncode.Length + 2) / 3 * 4;
+            var buffer = ArrayPool<char>.Shared.Rent(length);
+            try
+            {
+                if (!Convert.TryToBase64Chars(encoding.GetBytes(textToEncode), buffer.AsSpan(), out var charsWritten,
+                        insertLineBreaks ? Base64FormattingOptions.InsertLineBreaks : Base64FormattingOptions.None))
+                {
+                    throw new FormatException("Error encoding text to Base64.");
+                }
+
+                return buffer.AsSpan(0, charsWritten).ToString();
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer);
+            }
+#else
+           var bytes = encoding.GetBytes(textToEncode);
+           return Convert.ToBase64String(bytes,
+               insertLineBreaks ? Base64FormattingOptions.InsertLineBreaks : Base64FormattingOptions.None);
+#endif
+        }
+
+        /// <summary>
+        /// Decodes the given text from Base64, using the given <see cref="Encoding"/> (default: <see cref="Encoding.UTF8"/>
+        /// </summary>
+        /// <param name="encodedText"></param>
+        /// <param name="encoding">Default is <see cref="Encoding.UTF8"/>.</param>
+        /// <returns>The decoded string.</returns>
+        public static string? FromBase64(this string? encodedText, Encoding? encoding = null)
+        {
+            if (encodedText == null) return null;
+
+            encoding ??= Encoding.UTF8;
+#if NETSTANDARD2_1_OR_GREATER
+            var length = ((encodedText.Length * 3) + 3) / 4;
+            var buffer = ArrayPool<byte>.Shared.Rent(length);
+            try
+            {
+                if (!Convert.TryFromBase64String(encodedText, buffer.AsSpan(), out var bytesWritten))
+                {
+                    throw new FormatException("Invalid Base64 sequence.");
+                }
+
+                return encoding.GetString(buffer, 0, bytesWritten);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+#else
+            var bytes = Convert.FromBase64String(encodedText);
+            return encoding.GetString(bytes);           
+#endif
+        }
+    }
+}

--- a/YAXLib/StringUtils.cs
+++ b/YAXLib/StringUtils.cs
@@ -75,7 +75,7 @@ namespace YAXLib
 
             elemName = elemName.Trim(' ', '\t', '\r', '\n', '\v', '/', '\\');
             if (IsSingleLocationGeneric(elemName)) return elemName;
-
+            
             if (LooksLikeExpandedXName(elemName))
             {
                 // thanks go to CodePlex user: tg73 (http://www.codeplex.com/site/users/view/tg73)
@@ -255,10 +255,10 @@ namespace YAXLib
         }
 
         /// <summary>
-        ///     Gets the string corresponidng to the given array dimensions.
+        ///     Gets the string corresponiding to the given array dimensions.
         /// </summary>
         /// <param name="dims">The array dimensions.</param>
-        /// <returns>the string corresponidng to the given array dimensions</returns>
+        /// <returns>the string corresponiding to the given array dimensions</returns>
         public static string GetArrayDimsString(int[] dims)
         {
             var sb = new StringBuilder();
@@ -284,8 +284,7 @@ namespace YAXLib
             var lst = new List<int>();
             foreach (var strDim in strDims)
             {
-                int dim;
-                if (int.TryParse(strDim, out dim))
+                if (int.TryParse(strDim, out var dim))
                     lst.Add(dim);
             }
 
@@ -327,8 +326,9 @@ namespace YAXLib
 
         public static DateTime ParseDateTimeTimeZoneSafe(string str, IFormatProvider formatProvider)
         {
-            DateTimeOffset dto;
-            if (!DateTimeOffset.TryParse(str, formatProvider, DateTimeStyles.None, out dto)) return DateTime.MinValue;
+            if (!DateTimeOffset.TryParse(str, formatProvider, DateTimeStyles.None, out var dto))
+                return DateTime.MinValue;
+
             return dto.Offset == TimeSpan.Zero ? dto.UtcDateTime : dto.DateTime;
         }
     }

--- a/YAXLib/XMLUtils.cs
+++ b/YAXLib/XMLUtils.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 using YAXLib.Exceptions;
 
@@ -71,6 +72,21 @@ namespace YAXLib
 
             return currentLocation;
         }
+
+#nullable enable
+        /// <summary>
+        /// Strips all invalid characters from the input value, if <paramref name="enabled"/> is <see langword="true"/>.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="enabled"></param>
+        /// <returns></returns>
+        public static string StripInvalidXmlChars(this string? input, bool enabled)
+        {
+            return enabled && input != null
+                ? new string(input.Where(XmlConvert.IsXmlChar).ToArray())
+                : input ?? string.Empty;
+        }
+#nullable disable
 
         /// <summary>
         ///     Determines whether the specified location can be created in the specified XML element.

--- a/YAXLib/YAXLib.csproj
+++ b/YAXLib/YAXLib.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../Key/YAXLib.Key.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <PackageId>YAXLib</PackageId>
     <Title>YAXLib</Title>
     <Description>YAXLib is an XML Serialization library which allows the programmer to structure freely the XML result, choose the fields to serialize (public, or non-public properties, or member variables), serialize all known generic and non-generic collections, serialize different kinds of arrays (single-dimensional, multi-dimensional, and jagged arrays), serialize objects through a reference to their base-class or interface (polymorphic serialization), define custom serializers, add comments for the elements in the XML result, and many more ...</Description>

--- a/YAXLib/YAXLib.csproj
+++ b/YAXLib/YAXLib.csproj
@@ -6,7 +6,15 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <PackageId>YAXLib</PackageId>
     <Title>YAXLib</Title>
-    <Description>YAXLib is an XML Serialization library which allows the programmer to structure freely the XML result, choose the fields to serialize (public, or non-public properties, or member variables), serialize all known generic and non-generic collections, serialize different kinds of arrays (single-dimensional, multi-dimensional, and jagged arrays), serialize objects through a reference to their base-class or interface (polymorphic serialization), define custom serializers, add comments for the elements in the XML result, and many more ...</Description>
+    <Description>YAXLib is an XML Serialization library which allows the programmer to structure 
+        freely the XML result, choose the fields to serialize (public, non-public 
+        properties, or member variables), serialize all known generic and non-generic 
+        collections, serialize different kinds of arrays (single-dimensional, 
+        multi-dimensional, jagged arrays), serialize objects through a reference to 
+        their base-class or interface (polymorphic serialization), define custom 
+        serializers, add comments for the elements in the XML result, serialize as CDATA or
+        Base64-encoded, strip invalid XML characters, and much more..
+    </Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/YAXLib/YAXLib</PackageProjectUrl>
     <RepositoryUrl>https://github.com/YAXLib/YAXLib.git</RepositoryUrl>
@@ -31,6 +39,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/YAXLibTests/NumericMinMaxTests.cs
+++ b/YAXLibTests/NumericMinMaxTests.cs
@@ -40,7 +40,7 @@ namespace YAXLibTests
             }
             catch (Exception ex)
             {
-                Assert.Fail("No exception should have been throwned, but received:" + Environment.NewLine + ex);
+                Assert.Fail("No exception should have been thrown, but received:" + Environment.NewLine + ex);
             }
         }
 
@@ -61,7 +61,7 @@ namespace YAXLibTests
             }
             catch (Exception ex)
             {
-                Assert.Fail("No exception should have been throwned, but received:" + Environment.NewLine + ex);
+                Assert.Fail("No exception should have been thrown, but received:" + Environment.NewLine + ex);
             }
         }
 
@@ -83,7 +83,7 @@ namespace YAXLibTests
             }
             catch (Exception ex)
             {
-                Assert.Fail("No exception should have been throwned, but received:" + Environment.NewLine + ex);
+                Assert.Fail("No exception should have been thrown, but received:" + Environment.NewLine + ex);
             }
         }
 

--- a/YAXLibTests/SampleClasses/StripInvalidCharsSample.cs
+++ b/YAXLibTests/SampleClasses/StripInvalidCharsSample.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YAXLib.Attributes;
+
+namespace YAXLibTests.SampleClasses
+{
+    internal class StripInvalidCharsSample
+    {
+        [YAXValueForClass]
+        public string ValueForClass { get; set; } = nameof(ValueForClass);
+
+        public string ValueOfElement { get; set; } = nameof(ValueOfElement);
+
+        [YAXAttributeFor(nameof(ValueOfElement))]
+        public string ValueForAttribute { get; set; } = nameof(ValueForAttribute);
+
+        public List<string> TheList { get; set; } = new();
+
+        public Dictionary<string, string> TheDictionary { get; set; } = new();
+    }
+}

--- a/YAXLibTests/SampleClasses/TextEmbedding/DisallowedAttributeCombinationSample.cs
+++ b/YAXLibTests/SampleClasses/TextEmbedding/DisallowedAttributeCombinationSample.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+#nullable enable
+using YAXLib.Attributes;
+
+namespace YAXLibTests.SampleClasses.TextEmbedding
+{
+    internal class DisallowedAttributeCombinationSample
+    {
+        [YAXAttributeFor(".")]
+        [YAXTextEmbedding(YAXLib.Enums.TextEmbedding.CData)]
+        public string TextCDataEmbedding { get; set; } = string.Empty;
+
+        public override string ToString()
+        {
+            return GeneralToStringProvider.GeneralToString(this);
+        }
+
+        public static DisallowedAttributeCombinationSample GetSampleInstance()
+        {
+            return new DisallowedAttributeCombinationSample
+            {
+                TextCDataEmbedding = @"<script>
+    let X = 4; let Y = 5; let Z = 8;
+    if (Y < Z && Y > X) {
+        console.log(`'X < Y < Z' or 'Z > Y > X'`);
+    }
+</script>".Replace("\r\n", "\n")
+            };
+        }
+    }
+}

--- a/YAXLibTests/SampleClasses/TextEmbedding/SuccessfulEmbeddingSample.cs
+++ b/YAXLibTests/SampleClasses/TextEmbedding/SuccessfulEmbeddingSample.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+#nullable enable
+using YAXLib.Attributes;
+
+namespace YAXLibTests.SampleClasses.TextEmbedding
+{
+    internal class SuccessfulEmbeddingSample
+    {
+        [YAXTextEmbedding(YAXLib.Enums.TextEmbedding.None)]
+        [YAXSerializeAs("Text-No-Embedding")]
+        public string TextNoEmbedding { get; set; } = string.Empty;
+
+        [YAXTextEmbedding(YAXLib.Enums.TextEmbedding.CData)]
+        public string TextCDataEmbedding { get; set; } = string.Empty;
+
+        [YAXTextEmbedding(YAXLib.Enums.TextEmbedding.Base64)]
+        public string TextBase64Embedding { get; set; } = string.Empty;
+
+        [YAXTextEmbedding(YAXLib.Enums.TextEmbedding.Base64)]
+        public string? TextIsNull { get; set; }
+
+        public override string ToString()
+        {
+            return GeneralToStringProvider.GeneralToString(this);
+        }
+
+        public static SuccessfulEmbeddingSample GetSampleInstance()
+        {
+            return new SuccessfulEmbeddingSample
+            {
+                TextNoEmbedding = "< Text & NoEmbedding >",
+                // A compliant XML parsers must, before parsing,
+                // translate CRLF and any CR not followed by a LF to a single LF.
+                // This behavior is defined in the End-of-Line handling section of the XML 1.0 specification.
+                // So, for the unit tests we have to replace CRLF with LF for consistent comparisons.
+                TextCDataEmbedding = @"<script>
+    let X = 4; let Y = 5; let Z = 8;
+    if (Y < Z && Y > X) {
+        console.log(`'X < Y < Z' or 'Z > Y > X'`);
+    }
+</script>".Replace("\r\n", "\n"),
+                // All chars will be encoded
+                TextBase64Embedding = "part1\u0000part2"
+            };
+        }
+    }
+}

--- a/YAXLibTests/StringExtensionsTests.cs
+++ b/YAXLibTests/StringExtensionsTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+#nullable enable
+using System.Text;
+using NUnit.Framework;
+using YAXLib;
+
+namespace YAXLibTests
+{
+    [TestFixture]
+    internal class StringExtensionsTests
+    {
+        [Test]
+        public void Base64_DefaultEncoding_Roundtrip_Should_Succeed()
+        {
+            var toEncode = "\u0000abc\u0001def\u0000";
+            var encoded = toEncode.ToBase64();
+            Assert.That(encoded.FromBase64(), Is.EqualTo(toEncode));
+        }
+
+        [Test]
+        public void Base64_CustomEncoding_Roundtrip_Should_Succeed()
+        {
+            var toEncode = "\u0000abc\u0001def\u0000";
+            var encoded = toEncode.ToBase64(Encoding.ASCII);
+            Assert.That(encoded.FromBase64(Encoding.ASCII), Is.EqualTo(toEncode));
+        }
+
+        [Test]
+        public void Base64_Encode_Null_Should_Be_Null()
+        {
+            Assert.That(default(string?).ToBase64(), Is.Null);
+        }
+
+        [Test]
+        public void Base64_Decode_Null_Should_Be_Null()
+        {
+            Assert.That(default(string?).FromBase64(), Is.Null);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #206, #2 

* Added `YAXTextEmbeddingAttribute` which allows for `TextEmbedding.None`, `TextEmbedding.CData`, `TextEmbedding.Base64` for XML Element values
* Added `YAXSerializationOptions.StripInvalidXmlChars` to remove all invalid characters from the serialization output
