### PR TITLE
Refactor YAXLib for Nullable Reference Types

### DIFF
--- a/DemoApplication/DemoApplication.csproj
+++ b/DemoApplication/DemoApplication.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <nullable>disable</nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <Features>strict</Features>
+    <nullable>enable</nullable>
   </PropertyGroup>
   
 </Project>

--- a/YAXLib/Attributes/IYaxMemberLevelAttribute.cs
+++ b/YAXLib/Attributes/IYaxMemberLevelAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 namespace YAXLib
 {
     /// <summary>

--- a/YAXLib/Attributes/IYaxMemberLevelAttribute.cs
+++ b/YAXLib/Attributes/IYaxMemberLevelAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 namespace YAXLib
 {
     /// <summary>

--- a/YAXLib/Attributes/IYaxTypeLevelAttribute.cs
+++ b/YAXLib/Attributes/IYaxTypeLevelAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 namespace YAXLib
 {
     /// <summary>

--- a/YAXLib/Attributes/IYaxTypeLevelAttribute.cs
+++ b/YAXLib/Attributes/IYaxTypeLevelAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 namespace YAXLib
 {
     /// <summary>

--- a/YAXLib/Attributes/YAXAttributeForAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXAttributeForAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXAttributeForClassAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForClassAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXAttributeForClassAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForClassAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXBaseAttribute.cs
+++ b/YAXLib/Attributes/YAXBaseAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXBaseAttribute.cs
+++ b/YAXLib/Attributes/YAXBaseAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using YAXLib.Enums;
 

--- a/YAXLib/Attributes/YAXCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using YAXLib.Enums;
 
@@ -46,7 +48,7 @@ namespace YAXLib.Attributes
         ///     The name of each child element corresponding to the collection members, if the Serialization type is set to
         ///     <c>Recursive</c>.
         /// </value>
-        public string EachElementName { get; set; }
+        public string? EachElementName { get; set; }
 
         /// <summary>
         ///     Gets or sets a value indicating whether white space characters are to be

--- a/YAXLib/Attributes/YAXCollectionItemTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionItemTypeAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes
@@ -15,7 +17,7 @@ namespace YAXLib.Attributes
 
         public Type Type { get; }
 
-        public string Alias { get; set; }
+        public string Alias { get; set; } = string.Empty;
 
         /// <inheritdoc/>
         void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)

--- a/YAXLib/Attributes/YAXCollectionItemTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionItemTypeAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXCommentAttribute.cs
+++ b/YAXLib/Attributes/YAXCommentAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXCommentAttribute.cs
+++ b/YAXLib/Attributes/YAXCommentAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXCustomSerializerAttribute.cs
+++ b/YAXLib/Attributes/YAXCustomSerializerAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using YAXLib.Customization;
 using YAXLib.Exceptions;

--- a/YAXLib/Attributes/YAXCustomSerializerAttribute.cs
+++ b/YAXLib/Attributes/YAXCustomSerializerAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using YAXLib.Customization;
 using YAXLib.Exceptions;
@@ -54,7 +56,7 @@ namespace YAXLib.Attributes
             if (!isDesiredInterface)
                 throw new YAXObjectTypeMismatch(typeof(ICustomSerializer<>), CustomSerializerType);
 
-            if (!genTypeArg.IsAssignableFrom(type))
+            if (genTypeArg == null || !genTypeArg.IsAssignableFrom(type))
                 throw new YAXObjectTypeMismatch(type, genTypeArg);
         }
     }

--- a/YAXLib/Attributes/YAXDictionaryAttribute.cs
+++ b/YAXLib/Attributes/YAXDictionaryAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using YAXLib.Enums;
 
@@ -26,27 +28,27 @@ namespace YAXLib.Attributes
             KeyName = null;
             ValueName = null;
             EachPairName = null;
-            KeyFormatString = null;
-            ValueFormatString = null;
+            KeyFormatString = string.Empty;
+            ValueFormatString = string.Empty;
         }
 
         /// <summary>
         ///     Gets or sets the alias for the key part of the dicitonary.
         /// </summary>
         /// <value></value>
-        public string KeyName { get; set; }
+        public string? KeyName { get; set; }
 
         /// <summary>
         ///     Gets or sets alias for the value part of the dicitonary.
         /// </summary>
         /// <value></value>
-        public string ValueName { get; set; }
+        public string? ValueName { get; set; }
 
         /// <summary>
         ///     Gets or sets alias for the element containing the Key-Value pair.
         /// </summary>
         /// <value></value>
-        public string EachPairName { get; set; }
+        public string? EachPairName { get; set; }
 
         /// <summary>
         ///     Gets or sets the node type according to which the key part of the dictionary is serialized.

--- a/YAXLib/Attributes/YAXDictionaryAttribute.cs
+++ b/YAXLib/Attributes/YAXDictionaryAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using YAXLib.Enums;
 

--- a/YAXLib/Attributes/YAXDontSerializeAttribute.cs
+++ b/YAXLib/Attributes/YAXDontSerializeAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXDontSerializeAttribute.cs
+++ b/YAXLib/Attributes/YAXDontSerializeAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXDontSerializeIfNullAttribute.cs
+++ b/YAXLib/Attributes/YAXDontSerializeIfNullAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXDontSerializeIfNullAttribute.cs
+++ b/YAXLib/Attributes/YAXDontSerializeIfNullAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXElementForAttribute.cs
+++ b/YAXLib/Attributes/YAXElementForAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXElementForAttribute.cs
+++ b/YAXLib/Attributes/YAXElementForAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXElementOrder.cs
+++ b/YAXLib/Attributes/YAXElementOrder.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXElementOrder.cs
+++ b/YAXLib/Attributes/YAXElementOrder.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXEnumAttribute.cs
+++ b/YAXLib/Attributes/YAXEnumAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXEnumAttribute.cs
+++ b/YAXLib/Attributes/YAXEnumAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXErrorIfMissedAttribute.cs
+++ b/YAXLib/Attributes/YAXErrorIfMissedAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using YAXLib.Enums;
 

--- a/YAXLib/Attributes/YAXErrorIfMissedAttribute.cs
+++ b/YAXLib/Attributes/YAXErrorIfMissedAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using YAXLib.Enums;
 
@@ -36,7 +38,7 @@ namespace YAXLib.Attributes
         ///     Setting <c>null</c> means do nothing.
         /// </summary>
         /// <value>The default value.</value>
-        public object DefaultValue { get; set; }
+        public object? DefaultValue { get; set; }
 
         /// <inheritdoc/>
         void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)

--- a/YAXLib/Attributes/YAXFormatAttribute.cs
+++ b/YAXLib/Attributes/YAXFormatAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXFormatAttribute.cs
+++ b/YAXLib/Attributes/YAXFormatAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXNamespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXNamespaceAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXNamespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXNamespaceAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes
@@ -24,7 +26,7 @@ namespace YAXLib.Attributes
         public YAXNamespaceAttribute(string defaultNamespace)
         {
             Namespace = defaultNamespace;
-            Prefix = null;
+            Prefix = string.Empty;
         }
 
         /// <summary>

--- a/YAXLib/Attributes/YAXNotCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXNotCollectionAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXNotCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXNotCollectionAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXSerializableFieldAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializableFieldAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXSerializableFieldAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializableFieldAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXSerializableTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializableTypeAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using YAXLib.Enums;
 

--- a/YAXLib/Attributes/YAXSerializableTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializableTypeAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using YAXLib.Enums;
 

--- a/YAXLib/Attributes/YAXSerializeAsAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializeAsAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXSerializeAsAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializeAsAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXTextEmbeddingAttribute.cs
+++ b/YAXLib/Attributes/YAXTextEmbeddingAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Linq;
 using System.Xml.Linq;

--- a/YAXLib/Attributes/YAXTextEmbeddingAttribute.cs
+++ b/YAXLib/Attributes/YAXTextEmbeddingAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Xml.Linq;

--- a/YAXLib/Attributes/YAXTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXTypeAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes
@@ -15,7 +17,7 @@ namespace YAXLib.Attributes
 
         public Type Type { get; }
 
-        public string Alias { get; set; }
+        public string Alias { get; set; } = string.Empty;
 
         /// <inheritdoc/>
         void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)

--- a/YAXLib/Attributes/YAXTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXTypeAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXValueForClassAttribute.cs
+++ b/YAXLib/Attributes/YAXValueForClassAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Attributes/YAXValueForClassAttribute.cs
+++ b/YAXLib/Attributes/YAXValueForClassAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Attributes

--- a/YAXLib/Caching/MemberWrapperCache.cs
+++ b/YAXLib/Caching/MemberWrapperCache.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/YAXLib/Caching/TypeCacheBase.cs
+++ b/YAXLib/Caching/TypeCacheBase.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/YAXLib/Caching/TypeCacheStaticBase.cs
+++ b/YAXLib/Caching/TypeCacheStaticBase.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-namespace YAXLib.Caching;
+﻿namespace YAXLib.Caching;
 
 /// <summary>
 /// A static field in a generic type is not shared among instances of different constructed types.

--- a/YAXLib/Caching/UdtWrapperCache.cs
+++ b/YAXLib/Caching/UdtWrapperCache.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using YAXLib.Options;
 

--- a/YAXLib/Customization/CustomSerializerWrapper.cs
+++ b/YAXLib/Customization/CustomSerializerWrapper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Reflection;
 using System.Xml.Linq;
@@ -28,7 +30,7 @@ internal class CustomSerializerWrapper : ICustomSerializer<object>
     }
 
     /// <inheritdoc/>
-    public void SerializeToAttribute(object objectToSerialize, XAttribute attrToFill,
+    public void SerializeToAttribute(object? objectToSerialize, XAttribute attrToFill,
         ISerializationContext serializationContext)
     {
         using var _ = new Locker(Type);
@@ -41,7 +43,7 @@ internal class CustomSerializerWrapper : ICustomSerializer<object>
     }
 
     /// <inheritdoc/>
-    public void SerializeToElement(object objectToSerialize, XElement elemToFill,
+    public void SerializeToElement(object? objectToSerialize, XElement elemToFill,
         ISerializationContext serializationContext)
     {
         using var _ = new Locker(Type);
@@ -54,7 +56,7 @@ internal class CustomSerializerWrapper : ICustomSerializer<object>
     }
 
     /// <inheritdoc/>
-    public string SerializeToValue(object objectToSerialize, ISerializationContext serializationContext)
+    public string SerializeToValue(object? objectToSerialize, ISerializationContext serializationContext)
     {
         using var _ = new Locker(Type);
 

--- a/YAXLib/Customization/CustomSerializerWrapper.cs
+++ b/YAXLib/Customization/CustomSerializerWrapper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Reflection;
 using System.Xml.Linq;

--- a/YAXLib/Customization/IMemberContext.cs
+++ b/YAXLib/Customization/IMemberContext.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System.Reflection;
 
 namespace YAXLib.Customization;

--- a/YAXLib/Customization/ISerializationContext.cs
+++ b/YAXLib/Customization/ISerializationContext.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using YAXLib.Options;
 

--- a/YAXLib/Customization/ITypeContext.cs
+++ b/YAXLib/Customization/ITypeContext.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/YAXLib/Customization/ITypeContext.cs
+++ b/YAXLib/Customization/ITypeContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -42,7 +44,7 @@ public interface ITypeContext
     /// <param name="obj">The object of type <see cref="Type"/> to serialize.</param>
     /// <param name="options">The <see cref="SerializerOptions"/> or <see langword="null"/> to take options from the parent <seealso cref="YAXSerializer"/>.</param>
     /// <returns>The <see cref="XElement"/> representation of the object graph.</returns>
-    XElement Serialize(object obj, SerializerOptions options = null);
+    XElement Serialize(object obj, SerializerOptions options);
 
     /// <summary>
     /// Deserializes the <paramref name="element"/> to a new instance of <see cref="Type"/>.
@@ -54,5 +56,5 @@ public interface ITypeContext
     /// <param name="element">The object of type <see cref="Type"/> to serialize.</param>
     /// <param name="options">The <see cref="SerializerOptions"/> or <see langword="null"/> to take options from the parent <seealso cref="YAXSerializer"/>.</param>
     /// <returns>A new instance of <see cref="Type"/> created from the <paramref name="element"/></returns>
-    object Deserialize(XElement element, SerializerOptions options = null);
+    object? Deserialize(XElement element, SerializerOptions options);
 }

--- a/YAXLib/Customization/Locker.cs
+++ b/YAXLib/Customization/Locker.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 
 namespace YAXLib.Customization;

--- a/YAXLib/Customization/Locker.cs
+++ b/YAXLib/Customization/Locker.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/YAXLib/Customization/MemberContext.cs
+++ b/YAXLib/Customization/MemberContext.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System.Reflection;
 using YAXLib.Caching;
 

--- a/YAXLib/Customization/SerializationContext.cs
+++ b/YAXLib/Customization/SerializationContext.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 #nullable enable
-using System;
+
 using YAXLib.Options;
 
 namespace YAXLib.Customization;

--- a/YAXLib/Customization/SerializationContext.cs
+++ b/YAXLib/Customization/SerializationContext.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using YAXLib.Options;
 
 namespace YAXLib.Customization;

--- a/YAXLib/Customization/TypeContext.cs
+++ b/YAXLib/Customization/TypeContext.cs
@@ -47,7 +47,7 @@ public class TypeContext : ITypeContext
     }
 
     /// <inheritdoc/>
-    public XElement Serialize(object? obj, SerializerOptions? options = null)
+    public XElement Serialize(object? obj, SerializerOptions options)
     {
         using var serializerPoolObject = SerializerPool.Instance.Get(out var serializer);
         InitializeAsChildSerializer(serializer, options);
@@ -64,7 +64,7 @@ public class TypeContext : ITypeContext
     }
 
     /// <inheritdoc/>
-    public object Deserialize(XElement element, SerializerOptions? options = null)
+    public object? Deserialize(XElement element, SerializerOptions options)
     {
         using var serializerPoolObject = SerializerPool.Instance.Get(out var serializer);
         InitializeAsChildSerializer(serializer, options);

--- a/YAXLib/Customization/TypeContext.cs
+++ b/YAXLib/Customization/TypeContext.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/YAXLib/Deserialization.cs
+++ b/YAXLib/Deserialization.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/YAXLib/EnumWrapper.cs
+++ b/YAXLib/EnumWrapper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using YAXLib.Attributes;

--- a/YAXLib/EnumWrapper.cs
+++ b/YAXLib/EnumWrapper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using YAXLib.Attributes;
@@ -17,7 +19,7 @@ namespace YAXLib
         /// <summary>
         ///     Maps real enum names to their corresponding user defined aliases
         /// </summary>
-        private readonly Dictionary<string, string> _enumMembers = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> _enumMembers = new();
 
         /// <summary>
         ///     The enum underlying type

--- a/YAXLib/Enums/TextEmbedding.cs
+++ b/YAXLib/Enums/TextEmbedding.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+# nullable enable
+
 using System.Xml.Linq;
 
 namespace YAXLib.Enums;

--- a/YAXLib/Enums/YAXCollectionSerializationTypes.cs
+++ b/YAXLib/Enums/YAXCollectionSerializationTypes.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+# nullable enable
+
 namespace YAXLib.Enums
 {
     /// <summary>

--- a/YAXLib/Enums/YAXExceptionHandlingPolicies.cs
+++ b/YAXLib/Enums/YAXExceptionHandlingPolicies.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+# nullable enable
+
 namespace YAXLib.Enums
 {
     /// <summary>

--- a/YAXLib/Enums/YAXExceptionTypes.cs
+++ b/YAXLib/Enums/YAXExceptionTypes.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+# nullable enable
+
 namespace YAXLib.Enums
 {
     /// <summary>

--- a/YAXLib/Enums/YAXNodeTypes.cs
+++ b/YAXLib/Enums/YAXNodeTypes.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+# nullable enable
+
 namespace YAXLib.Enums
 {
     /// <summary>

--- a/YAXLib/Enums/YAXSerializationFields.cs
+++ b/YAXLib/Enums/YAXSerializationFields.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+# nullable enable
+
 using System;
 using YAXLib.Attributes;
 

--- a/YAXLib/Enums/YAXSerializationOptions.cs
+++ b/YAXLib/Enums/YAXSerializationOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+# nullable enable
+
 using System;
 
 namespace YAXLib.Enums

--- a/YAXLib/Exceptions/YAXAttributeAlreadyExistsException.cs
+++ b/YAXLib/Exceptions/YAXAttributeAlreadyExistsException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 
 namespace YAXLib.Exceptions

--- a/YAXLib/Exceptions/YAXAttributeAlreadyExistsException.cs
+++ b/YAXLib/Exceptions/YAXAttributeAlreadyExistsException.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Globalization;
 
 namespace YAXLib.Exceptions

--- a/YAXLib/Exceptions/YAXAttributeMissingException.cs
+++ b/YAXLib/Exceptions/YAXAttributeMissingException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 using System.Xml;
 

--- a/YAXLib/Exceptions/YAXAttributeMissingException.cs
+++ b/YAXLib/Exceptions/YAXAttributeMissingException.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Globalization;
 using System.Xml;
 
@@ -28,7 +30,7 @@ namespace YAXLib.Exceptions
         /// </summary>
         /// <param name="attrName">Name of the attribute.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
-        public YAXAttributeMissingException(string attrName, IXmlLineInfo lineInfo) :
+        public YAXAttributeMissingException(string attrName, IXmlLineInfo? lineInfo) :
             base(lineInfo)
         {
             AttributeName = attrName;

--- a/YAXLib/Exceptions/YAXBadLocationException.cs
+++ b/YAXLib/Exceptions/YAXBadLocationException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 
 namespace YAXLib.Exceptions

--- a/YAXLib/Exceptions/YAXBadLocationException.cs
+++ b/YAXLib/Exceptions/YAXBadLocationException.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Globalization;
 
 namespace YAXLib.Exceptions

--- a/YAXLib/Exceptions/YAXBadlyFormedInput.cs
+++ b/YAXLib/Exceptions/YAXBadlyFormedInput.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Globalization;
 using System.Xml;
 
@@ -31,7 +33,7 @@ namespace YAXLib.Exceptions
         /// <param name="elemName">Name of the element.</param>
         /// <param name="badInput">The value of the input which could not be converted to the type of the property.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
-        public YAXBadlyFormedInput(string elemName, string badInput, IXmlLineInfo lineInfo)
+        public YAXBadlyFormedInput(string elemName, string badInput, IXmlLineInfo? lineInfo)
             : base(lineInfo)
         {
             ElementName = elemName;

--- a/YAXLib/Exceptions/YAXBadlyFormedInput.cs
+++ b/YAXLib/Exceptions/YAXBadlyFormedInput.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 using System.Xml;
 

--- a/YAXLib/Exceptions/YAXBadlyFormedXML.cs
+++ b/YAXLib/Exceptions/YAXBadlyFormedXML.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Globalization;
 

--- a/YAXLib/Exceptions/YAXBadlyFormedXML.cs
+++ b/YAXLib/Exceptions/YAXBadlyFormedXML.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Globalization;
 
@@ -17,7 +19,7 @@ namespace YAXLib.Exceptions
         /// <summary>
         ///     The inner exception.
         /// </summary>
-        private readonly Exception innerException;
+        private readonly Exception? _innerException = null;
 
         #endregion
 
@@ -37,9 +39,9 @@ namespace YAXLib.Exceptions
                 var msg = string.Format(CultureInfo.CurrentCulture, "The input xml file is not properly formatted!{0}",
                     LineInfoMessage);
 
-                if (innerException != null)
+                if (_innerException != null)
                     msg += string.Format(CultureInfo.CurrentCulture, "{0}More Details:{1}{2}", Environment.NewLine, 
-                        this.innerException.Message, Environment.NewLine);
+                        _innerException.Message, Environment.NewLine);
 
                 return msg;
             }
@@ -55,20 +57,20 @@ namespace YAXLib.Exceptions
         /// <param name="innerException">The inner exception.</param>
         /// <param name="lineNumber">The line number on which the error occurred</param>
         /// <param name="linePosition">The line position on which the error occurred</param>
-        public YAXBadlyFormedXML(Exception innerException, int lineNumber, int linePosition)
+        public YAXBadlyFormedXML(Exception? innerException, int lineNumber, int linePosition)
             : base(lineNumber, linePosition)
         {
-            this.innerException = innerException;
+            _innerException = innerException;
         }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXBadlyFormedXML" /> class.
         /// </summary>
         /// <param name="innerException">The inner exception.</param>
-        public YAXBadlyFormedXML(Exception innerException)
+        public YAXBadlyFormedXML(Exception? innerException)
             : base(null)
         {
-            this.innerException = innerException;
+            _innerException = innerException;
         }
 
         /// <summary>

--- a/YAXLib/Exceptions/YAXCannotAddObjectToCollection.cs
+++ b/YAXLib/Exceptions/YAXCannotAddObjectToCollection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 using System.Xml;
 

--- a/YAXLib/Exceptions/YAXCannotAddObjectToCollection.cs
+++ b/YAXLib/Exceptions/YAXCannotAddObjectToCollection.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Globalization;
 using System.Xml;
 
@@ -19,7 +21,7 @@ namespace YAXLib.Exceptions
         /// </summary>
         /// <param name="propName">Name of the property.</param>
         /// <param name="obj">The object that could not be added to the collection.</param>
-        public YAXCannotAddObjectToCollection(string propName, object obj) :
+        public YAXCannotAddObjectToCollection(string propName, object? obj) :
             this(propName, obj, null)
         {
         }
@@ -30,7 +32,7 @@ namespace YAXLib.Exceptions
         /// <param name="propName">Name of the property.</param>
         /// <param name="obj">The object that could not be added to the collection.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
-        public YAXCannotAddObjectToCollection(string propName, object obj, IXmlLineInfo lineInfo) :
+        public YAXCannotAddObjectToCollection(string propName, object? obj, IXmlLineInfo? lineInfo) :
             base(lineInfo)
         {
             PropertyName = propName;
@@ -51,7 +53,7 @@ namespace YAXLib.Exceptions
         ///     Gets the object that could not be added to the collection.
         /// </summary>
         /// <value>the object that could not be added to the collection.</value>
-        public object ObjectToAdd { get; }
+        public object? ObjectToAdd { get; }
 
         /// <summary>
         ///     Gets a message that describes the current exception.
@@ -64,7 +66,7 @@ namespace YAXLib.Exceptions
             string.Format(
                 CultureInfo.CurrentCulture,
                 "Could not add object ('{0}') to the collection ('{1}').{2}",
-                ObjectToAdd,
+                ObjectToAdd ?? "(null)",
                 PropertyName,
                 LineInfoMessage);
 

--- a/YAXLib/Exceptions/YAXCannotSerializeSelfReferentialTypes.cs
+++ b/YAXLib/Exceptions/YAXCannotSerializeSelfReferentialTypes.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Globalization;
 

--- a/YAXLib/Exceptions/YAXCannotSerializeSelfReferentialTypes.cs
+++ b/YAXLib/Exceptions/YAXCannotSerializeSelfReferentialTypes.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Globalization;
 

--- a/YAXLib/Exceptions/YAXDefaultValueCannotBeAssigned.cs
+++ b/YAXLib/Exceptions/YAXDefaultValueCannotBeAssigned.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 using System.Xml;
 

--- a/YAXLib/Exceptions/YAXDefaultValueCannotBeAssigned.cs
+++ b/YAXLib/Exceptions/YAXDefaultValueCannotBeAssigned.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Globalization;
 using System.Xml;
 
@@ -21,7 +23,7 @@ namespace YAXLib.Exceptions
         /// <param name="propName">Name of the property.</param>
         /// <param name="defaultValue">The default value which caused the problem.</param>
         /// <param name="culture">The <see cref="CultureInfo"/> used for string formatting values.</param>
-        public YAXDefaultValueCannotBeAssigned(string propName, object defaultValue, CultureInfo culture) :
+        public YAXDefaultValueCannotBeAssigned(string propName, object? defaultValue, CultureInfo culture) :
             this(propName, defaultValue, null, culture)
         {
         }
@@ -33,7 +35,7 @@ namespace YAXLib.Exceptions
         /// <param name="defaultValue">The default value which caused the problem.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
         /// <param name="culture">The <see cref="CultureInfo"/> used for string formatting values in the <see cref="Message"/>.</param>
-        public YAXDefaultValueCannotBeAssigned(string propName, object defaultValue, IXmlLineInfo lineInfo, CultureInfo culture) :
+        public YAXDefaultValueCannotBeAssigned(string propName, object? defaultValue, IXmlLineInfo? lineInfo, CultureInfo culture) :
             base(lineInfo)
         {
             PropertyName = propName;
@@ -55,7 +57,7 @@ namespace YAXLib.Exceptions
         ///     Gets the default value which caused the problem.
         /// </summary>
         /// <value>The default value which caused the problem.</value>
-        public object TheDefaultValue { get; }
+        public object? TheDefaultValue { get; }
         
         /// <summary>
         ///     Gets the <see cref="CultureInfo"/> used for string formatting values in the <see cref="Message"/>,

--- a/YAXLib/Exceptions/YAXDeserializationException.cs
+++ b/YAXLib/Exceptions/YAXDeserializationException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 using System.Xml;
 

--- a/YAXLib/Exceptions/YAXDeserializationException.cs
+++ b/YAXLib/Exceptions/YAXDeserializationException.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Globalization;
 using System.Xml;
 
@@ -16,7 +18,7 @@ namespace YAXLib.Exceptions
         /// </summary>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
         /// <param name="message">The message with exception details.</param>
-        public YAXDeserializationException(IXmlLineInfo lineInfo, string message = "") : base(message)
+        public YAXDeserializationException(IXmlLineInfo? lineInfo, string message = "") : base(message)
         {
             if (lineInfo != null &&
                 lineInfo.HasLineInfo())

--- a/YAXLib/Exceptions/YAXElementMissingException.cs
+++ b/YAXLib/Exceptions/YAXElementMissingException.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Globalization;
 using System.Xml;
 
@@ -28,7 +30,7 @@ namespace YAXLib.Exceptions
         /// </summary>
         /// <param name="elemName">Name of the element.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
-        public YAXElementMissingException(string elemName, IXmlLineInfo lineInfo) :
+        public YAXElementMissingException(string elemName, IXmlLineInfo? lineInfo) :
             base(lineInfo)
         {
             ElementName = elemName;

--- a/YAXLib/Exceptions/YAXElementMissingException.cs
+++ b/YAXLib/Exceptions/YAXElementMissingException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 using System.Xml;
 

--- a/YAXLib/Exceptions/YAXElementValueMissingException.cs
+++ b/YAXLib/Exceptions/YAXElementValueMissingException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 using System.Xml;
 

--- a/YAXLib/Exceptions/YAXElementValueMissingException.cs
+++ b/YAXLib/Exceptions/YAXElementValueMissingException.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Globalization;
 using System.Xml;
 
@@ -29,7 +31,7 @@ namespace YAXLib.Exceptions
         /// </summary>
         /// <param name="elementName">Name of the element.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
-        public YAXElementValueMissingException(string elementName, IXmlLineInfo lineInfo)
+        public YAXElementValueMissingException(string elementName, IXmlLineInfo? lineInfo)
             : base(lineInfo)
         {
             ElementName = elementName;

--- a/YAXLib/Exceptions/YAXEnumAliasException.cs
+++ b/YAXLib/Exceptions/YAXEnumAliasException.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Exceptions

--- a/YAXLib/Exceptions/YAXEnumAliasException.cs
+++ b/YAXLib/Exceptions/YAXEnumAliasException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Exceptions

--- a/YAXLib/Exceptions/YAXException.cs
+++ b/YAXLib/Exceptions/YAXException.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace YAXLib.Exceptions

--- a/YAXLib/Exceptions/YAXException.cs
+++ b/YAXLib/Exceptions/YAXException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace YAXLib.Exceptions

--- a/YAXLib/Exceptions/YAXObjectTypeMismatch.cs
+++ b/YAXLib/Exceptions/YAXObjectTypeMismatch.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Globalization;
 

--- a/YAXLib/Exceptions/YAXObjectTypeMismatch.cs
+++ b/YAXLib/Exceptions/YAXObjectTypeMismatch.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Globalization;
 
@@ -18,7 +20,7 @@ namespace YAXLib.Exceptions
         /// </summary>
         /// <param name="expectedType">The expected type.</param>
         /// <param name="receivedType">The type of the object which did not match the expected type.</param>
-        public YAXObjectTypeMismatch(Type expectedType, Type receivedType)
+        public YAXObjectTypeMismatch(Type expectedType, Type? receivedType)
         {
             ExpectedType = expectedType;
             ReceivedType = receivedType;
@@ -34,7 +36,7 @@ namespace YAXLib.Exceptions
         ///     Gets the type of the object which did not match the expected type.
         /// </summary>
         /// <value>The type of the object which did not match the expected type.</value>
-        public Type ReceivedType { get; }
+        public Type? ReceivedType { get; }
 
         /// <summary>
         ///     Gets a message that describes the current exception.
@@ -47,6 +49,6 @@ namespace YAXLib.Exceptions
                 CultureInfo.CurrentCulture,
                 "Expected an object of type '{0}' but received an object of type '{1}'.",
                 ExpectedType.Name,
-                ReceivedType.Name);
+                ReceivedType?.Name ?? "null");
     }
 }

--- a/YAXLib/Exceptions/YAXPolymorphicException.cs
+++ b/YAXLib/Exceptions/YAXPolymorphicException.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 namespace YAXLib.Exceptions
 {
     /// <summary>

--- a/YAXLib/Exceptions/YAXPolymorphicException.cs
+++ b/YAXLib/Exceptions/YAXPolymorphicException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 namespace YAXLib.Exceptions
 {
     /// <summary>

--- a/YAXLib/Exceptions/YAXPropertyCannotBeAssignedTo.cs
+++ b/YAXLib/Exceptions/YAXPropertyCannotBeAssignedTo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 using System.Xml;
 

--- a/YAXLib/Exceptions/YAXPropertyCannotBeAssignedTo.cs
+++ b/YAXLib/Exceptions/YAXPropertyCannotBeAssignedTo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Globalization;
 using System.Xml;
 
@@ -29,7 +31,7 @@ namespace YAXLib.Exceptions
         /// </summary>
         /// <param name="propName">Name of the property.</param>
         /// <param name="lineInfo">IXmlLineInfo derived object, e.g. XElement, XAttribute containing line info</param>
-        public YAXPropertyCannotBeAssignedTo(string propName, IXmlLineInfo lineInfo) :
+        public YAXPropertyCannotBeAssignedTo(string propName, IXmlLineInfo? lineInfo) :
             base(lineInfo)
         {
             PropertyName = propName;

--- a/YAXLib/ICustomSerializer.cs
+++ b/YAXLib/ICustomSerializer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Xml.Linq;
 using YAXLib.Customization;
 

--- a/YAXLib/ICustomSerializer.cs
+++ b/YAXLib/ICustomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Xml.Linq;
 using YAXLib.Customization;
 

--- a/YAXLib/IRecursionCounter.cs
+++ b/YAXLib/IRecursionCounter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 namespace YAXLib;
 
 internal interface IRecursionCounter

--- a/YAXLib/IRecursionCounter.cs
+++ b/YAXLib/IRecursionCounter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 namespace YAXLib;
 
 internal interface IRecursionCounter

--- a/YAXLib/IYAXSerializer.cs
+++ b/YAXLib/IYAXSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.IO;
 using System.Xml;
 using System.Xml.Linq;

--- a/YAXLib/IYAXSerializer.cs
+++ b/YAXLib/IYAXSerializer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.IO;
 using System.Xml;
 using System.Xml.Linq;
@@ -31,76 +33,76 @@ namespace YAXLib
         /// </summary>
         /// <param name="obj">The object to serialize.</param>
         /// <returns>A <code>System.String</code> containing the XML</returns>
-        string Serialize(T obj);
+        string Serialize(T? obj);
 
         /// <summary>
         ///     Serializes the specified object into a <c>TextWriter</c> instance.
         /// </summary>
         /// <param name="obj">The object to serialize.</param>
         /// <param name="textWriter">The <c>TextWriter</c> instance.</param>
-        void Serialize(T obj, TextWriter textWriter);
+        void Serialize(T? obj, TextWriter textWriter);
 
         /// <summary>
         ///     Serializes the specified object into a <c>XmlWriter</c> instance.
         /// </summary>
         /// <param name="obj">The object to serialize.</param>
         /// <param name="xmlWriter">The <c>XmlWriter</c> instance.</param>
-        void Serialize(T obj, XmlWriter xmlWriter);
+        void Serialize(T? obj, XmlWriter xmlWriter);
 
         /// <summary>
         ///     Serializes the specified object and returns an instance of <c>XDocument</c> containing the result.
         /// </summary>
         /// <param name="obj">The object to serialize.</param>
         /// <returns>An instance of <c>XDocument</c> containing the resulting XML</returns>
-        XDocument SerializeToXDocument(T obj);
+        XDocument SerializeToXDocument(T? obj);
 
         /// <summary>
         ///     Serializes the specified object to file.
         /// </summary>
         /// <param name="obj">The object to serialize.</param>
         /// <param name="fileName">Path to the file.</param>
-        void SerializeToFile(T obj, string fileName);
+        void SerializeToFile(T? obj, string fileName);
 
         /// <summary>
         ///     Deserializes the specified string containing the XML serialization and returns an object.
         /// </summary>
         /// <param name="input">The input string containing the XML serialization.</param>
         /// <returns>The deserialized object.</returns>
-        T Deserialize(string input);
+        T? Deserialize(string input);
 
         /// <summary>
         ///     Deserializes an object while reading input from an instance of <c>XmlReader</c>.
         /// </summary>
         /// <param name="xmlReader">The <c>XmlReader</c> instance to read input from.</param>
         /// <returns>The deserialized object.</returns>
-        T Deserialize(XmlReader xmlReader);
+        T? Deserialize(XmlReader xmlReader);
 
         /// <summary>
         ///     Deserializes an object while reading input from an instance of <c>TextReader</c>.
         /// </summary>
         /// <param name="textReader">The <c>TextReader</c> instance to read input from.</param>
         /// <returns>The deserialized object.</returns>
-        T Deserialize(TextReader textReader);
+        T? Deserialize(TextReader textReader);
 
         /// <summary>
         ///     Deserializes an object while reading from an instance of <c>XElement</c>
         /// </summary>
         /// <param name="element">The <c>XElement</c> instance to read from.</param>
         /// <returns>The deserialized object</returns>
-        T Deserialize(XElement element);
+        T? Deserialize(XElement element);
 
         /// <summary>
         ///     Deserializes an object from the specified file which contains the XML serialization of the object.
         /// </summary>
         /// <param name="fileName">Path to the file.</param>
         /// <returns>The deserialized object.</returns>
-        T DeserializeFromFile(string fileName);
+        T? DeserializeFromFile(string fileName);
 
         /// <summary>
         ///     Sets the object used as the base object in the next stage of de-serialization.
         ///     This method enables multi-stage de-serialization for YAXLib.
         /// </summary>
         /// <param name="obj">The object used as the base object in the next stage of de-serialization.</param>
-        void SetDeserializationBaseObject(T obj);
+        void SetDeserializationBaseObject(T? obj);
     }
 }

--- a/YAXLib/KnownTypes/ColorDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/ColorDynamicKnownType.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/ColorDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/ColorDynamicKnownType.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;
@@ -13,11 +15,13 @@ namespace YAXLib.KnownTypes
         public override string TypeName => "System.Drawing.Color";
 
         /// <inheritdoc />
-        public override void Serialize(object obj, XElement elem, XNamespace overridingNamespace,
+        public override void Serialize(object? obj, XElement elem, XNamespace overridingNamespace,
             ISerializationContext serializationContext)
         {
+            if (obj == null) throw new ArgumentException("Object must not be null", nameof(obj));
+
             var objectType = obj.GetType();
-            if (objectType.FullName != TypeName)
+            if (objectType == null || objectType.FullName != TypeName)
                 throw new ArgumentException("Object type does not match the provided typename", nameof(obj));
 
             var isKnownColor = ReflectionUtils.InvokeGetProperty<bool>(obj, "IsKnownColor");
@@ -41,7 +45,7 @@ namespace YAXLib.KnownTypes
         }
 
         /// <inheritdoc />
-        public override object Deserialize(XElement elem, XNamespace overridingNamespace,
+        public override object? Deserialize(XElement elem, XNamespace overridingNamespace,
             ISerializationContext serializationContext)
         {
             var elemR = elem.Element(overridingNamespace.GetXName("R"));
@@ -52,13 +56,13 @@ namespace YAXLib.KnownTypes
                 return colorByName;
             }
 
-            int a = 255, r, g = 0, b = 0;
+            int a = 255, g = 0, b = 0;
 
             var elemA = elem.Element(overridingNamespace.GetXName("A"));
             if (elemA != null && !int.TryParse(elemA.Value, out a))
                 a = 0;
 
-            if (!int.TryParse(elemR.Value, out r))
+            if (!int.TryParse(elemR.Value, out var r))
                 r = 0;
 
             var elemG = elem.Element(overridingNamespace.GetXName("G"));

--- a/YAXLib/KnownTypes/DataSetDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/DataSetDynamicKnownType.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Linq;
 using System.Xml.Linq;

--- a/YAXLib/KnownTypes/DataSetDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/DataSetDynamicKnownType.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Xml.Linq;
@@ -14,15 +16,17 @@ namespace YAXLib.KnownTypes
         public override string TypeName => "System.Data.DataSet";
 
         /// <inheritdoc />
-        public override void Serialize(object obj, XElement elem, XNamespace overridingNamespace,
+        public override void Serialize(object? obj, XElement elem, XNamespace overridingNamespace,
             ISerializationContext serializationContext)
         {
+            if (obj == null) throw new ArgumentException("Object must not be null", nameof(obj));
+
             using var xw = elem.CreateWriter();
             ReflectionUtils.InvokeMethod(obj, "WriteXml", xw);
         }
 
         /// <inheritdoc />
-        public override object Deserialize(XElement elem, XNamespace overridingNamespace,
+        public override object? Deserialize(XElement elem, XNamespace overridingNamespace,
             ISerializationContext serializationContext)
         {
             var child = elem.Elements().FirstOrDefault();

--- a/YAXLib/KnownTypes/DataTableDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/DataTableDynamicKnownType.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Xml.Linq;
@@ -14,20 +16,22 @@ namespace YAXLib.KnownTypes
         public override string TypeName => "System.Data.DataTable";
 
         /// <inheritdoc />
-        public override void Serialize(object obj, XElement elem, XNamespace overridingNamespace,
+        public override void Serialize(object? obj, XElement elem, XNamespace overridingNamespace,
             ISerializationContext serializationContext)
         {
+            if (obj == null) throw new ArgumentException("Object must not be null", nameof(obj));
+
             using var xw = elem.CreateWriter();
             var dsType = ReflectionUtils.GetTypeByName("System.Data.DataSet");
             var ds = Activator.CreateInstance(dsType);
-            var dsTables = ReflectionUtils.InvokeGetProperty<object>(ds, "Tables");
-            var dtCopy = ReflectionUtils.InvokeMethod(obj, "Copy");
+            var dsTables = ReflectionUtils.InvokeGetProperty<object>(ds, "Tables")!;
+            var dtCopy = ReflectionUtils.InvokeMethod(obj, "Copy")!;
             ReflectionUtils.InvokeMethod(dsTables, "Add", dtCopy);
             ReflectionUtils.InvokeMethod(ds, "WriteXml", xw);
         }
 
         /// <inheritdoc />
-        public override object Deserialize(XElement elem, XNamespace overridingNamespace,
+        public override object? Deserialize(XElement elem, XNamespace overridingNamespace,
             ISerializationContext serializationContext)
         {
             var dsElem = elem.Elements().FirstOrDefault(x => x.Name.LocalName == "NewDataSet");
@@ -38,11 +42,11 @@ namespace YAXLib.KnownTypes
             var dsType = ReflectionUtils.GetTypeByName("System.Data.DataSet");
             var ds = Activator.CreateInstance(dsType);
             ReflectionUtils.InvokeMethod(ds, "ReadXml", xr);
-            var dsTables = ReflectionUtils.InvokeGetProperty<object>(ds, "Tables");
+            var dsTables = ReflectionUtils.InvokeGetProperty<object>(ds, "Tables")!;
             var dsTablesCount = ReflectionUtils.InvokeGetProperty<int>(dsTables, "Count");
             if (dsTablesCount > 0)
             {
-                var dsTablesZero = ReflectionUtils.InvokeIntIndexer<object>(dsTables, "Index", 0);
+                var dsTablesZero = ReflectionUtils.InvokeIntIndexer<object>(dsTables, 0)!;
                 var copyDt = ReflectionUtils.InvokeMethod(dsTablesZero, "Copy");
                 return copyDt;
             }

--- a/YAXLib/KnownTypes/DataTableDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/DataTableDynamicKnownType.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Linq;
 using System.Xml.Linq;

--- a/YAXLib/KnownTypes/DbNullKnownType.cs
+++ b/YAXLib/KnownTypes/DbNullKnownType.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/DynamicKnownTypeBase.cs
+++ b/YAXLib/KnownTypes/DynamicKnownTypeBase.cs
@@ -23,7 +23,7 @@ namespace YAXLib.KnownTypes
         public abstract string TypeName { get; }
 
         /// <inheritdoc />
-        public Type Type => _type ??= ReflectionUtils.GetTypeByName(TypeName);
+        public Type Type => _type ??= ReflectionUtils.GetTypeByName(TypeName) ?? throw new InvalidOperationException($"Type for name '{TypeName}' not found.");
 
         /// <inheritdoc />
         public abstract void Serialize(object? obj, XElement elem, XNamespace overridingNamespace,

--- a/YAXLib/KnownTypes/DynamicKnownTypeBase.cs
+++ b/YAXLib/KnownTypes/DynamicKnownTypeBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/ExceptionKnownBaseType.cs
+++ b/YAXLib/KnownTypes/ExceptionKnownBaseType.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
-using System.Reflection;
 using System.Xml.Linq;
 using YAXLib.Customization;
 using YAXLib.Enums;

--- a/YAXLib/KnownTypes/IKnownType.cs
+++ b/YAXLib/KnownTypes/IKnownType.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/KnownBaseTypeBase.cs
+++ b/YAXLib/KnownTypes/KnownBaseTypeBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/KnownTypeBase.cs
+++ b/YAXLib/KnownTypes/KnownTypeBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/RectangleDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/RectangleDynamicKnownType.cs
@@ -19,7 +19,7 @@ namespace YAXLib.KnownTypes
             ISerializationContext serializationContext)
         {
             var objectType = obj?.GetType();
-            if (objectType?.FullName != TypeName)
+            if (obj == null || objectType?.FullName != TypeName)
                 throw new ArgumentException("Object type does not match the provided typename", nameof(obj));
 
             var left = ReflectionUtils.InvokeGetProperty<int>(obj, "Left");

--- a/YAXLib/KnownTypes/RectangleDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/RectangleDynamicKnownType.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/RuntimeTypeDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/RuntimeTypeDynamicKnownType.cs
@@ -18,14 +18,14 @@ namespace YAXLib.KnownTypes
             ISerializationContext serializationContext)
         {
             var objectType = obj?.GetType();
-            if (objectType?.FullName != TypeName)
+            if (obj == null || objectType == null || objectType.FullName != TypeName)
                 throw new ArgumentException("Object type does not match the provided typename", nameof(obj));
 
             elem.Value = ReflectionUtils.InvokeGetProperty<string>(obj, "FullName");
         }
 
         /// <inheritdoc />
-        public override object Deserialize(XElement elem, XNamespace overridingNamespace,
+        public override object? Deserialize(XElement elem, XNamespace overridingNamespace,
             ISerializationContext serializationContext)
         {
             return ReflectionUtils.GetTypeByName(elem.Value);

--- a/YAXLib/KnownTypes/RuntimeTypeDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/RuntimeTypeDynamicKnownType.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/TimeSpanKnownType.cs
+++ b/YAXLib/KnownTypes/TimeSpanKnownType.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/TypeKnownType.cs
+++ b/YAXLib/KnownTypes/TypeKnownType.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/WellknownTypes.cs
+++ b/YAXLib/KnownTypes/WellknownTypes.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/YAXLib/KnownTypes/XAttributeKnownType.cs
+++ b/YAXLib/KnownTypes/XAttributeKnownType.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System.Linq;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/XElementKnownType.cs
+++ b/YAXLib/KnownTypes/XElementKnownType.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System.Linq;
 using System.Xml.Linq;
 using YAXLib.Customization;

--- a/YAXLib/KnownTypes/XNamespaceExtensions.cs
+++ b/YAXLib/KnownTypes/XNamespaceExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Xml.Linq;
 
 namespace YAXLib.KnownTypes

--- a/YAXLib/KnownTypes/XNamespaceExtensions.cs
+++ b/YAXLib/KnownTypes/XNamespaceExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Xml.Linq;
 
 namespace YAXLib.KnownTypes

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -485,7 +485,7 @@ namespace YAXLib
 
         // Public Methods
 
-        public YAXTypeAttribute? GetRealTypeDefinition(Type type)
+        public YAXTypeAttribute? GetRealTypeDefinition(Type? type)
         {
             return _possibleRealTypes.FirstOrDefault(x => ReferenceEquals(x.Type, type));
         }

--- a/YAXLib/Options/SerializerOptions.cs
+++ b/YAXLib/Options/SerializerOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Globalization;
 using System.Xml.Linq;

--- a/YAXLib/Options/SerializerOptions.cs
+++ b/YAXLib/Options/SerializerOptions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Globalization;
 using System.Xml.Linq;

--- a/YAXLib/Options/YAXAttributeName.cs
+++ b/YAXLib/Options/YAXAttributeName.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 namespace YAXLib.Options
 {
     /// <summary>
@@ -11,12 +13,12 @@ namespace YAXLib.Options
         /// <summary>
         ///     The attribute name used to de-serialize meta-data for multi-dimensional arrays.
         /// </summary>
-        public string Dimensions { get; set; }
-            
+        public string Dimensions { get; set; } = string.Empty;
+
         /// <summary>
         ///     The attribute name used to de-serialize meta-data for real types of objects serialized through
         ///     a reference to their base class or interface.
         /// </summary>
-        public string RealType { get; set; }
+        public string RealType { get; set; } = string.Empty;
     }
 }

--- a/YAXLib/Options/YAXAttributeName.cs
+++ b/YAXLib/Options/YAXAttributeName.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 namespace YAXLib.Options
 {
     /// <summary>

--- a/YAXLib/Options/YAXNameSpace.cs
+++ b/YAXLib/Options/YAXNameSpace.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Xml.Linq;
 
 namespace YAXLib.Options

--- a/YAXLib/Options/YAXNameSpace.cs
+++ b/YAXLib/Options/YAXNameSpace.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Xml.Linq;
 
 namespace YAXLib.Options
@@ -13,11 +15,11 @@ namespace YAXLib.Options
         /// <summary>
         ///     The URI address which holds the xmlns:yaxlib definition.
         /// </summary>
-        public XNamespace Uri { get; set; }
+        public XNamespace Uri { get; set; } = XNamespace.None;
             
         /// <summary>
         ///     The prefix used for the xml namespace.
         /// </summary>
-        public string Prefix { get; set; }
+        public string Prefix { get; set; } = string.Empty;
     }
 }

--- a/YAXLib/Pooling/ObjectPools/IObjectPool.cs
+++ b/YAXLib/Pooling/ObjectPools/IObjectPool.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 

--- a/YAXLib/Pooling/ObjectPools/IPoolCounters.cs
+++ b/YAXLib/Pooling/ObjectPools/IPoolCounters.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 namespace YAXLib.Pooling.ObjectPools;
 
 internal interface IPoolCounters

--- a/YAXLib/Pooling/ObjectPools/ObjectPool.cs
+++ b/YAXLib/Pooling/ObjectPools/ObjectPool.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 

--- a/YAXLib/Pooling/ObjectPools/ObjectPoolConcurrent.cs
+++ b/YAXLib/Pooling/ObjectPools/ObjectPoolConcurrent.cs
@@ -1,12 +1,13 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
-#nullable enable
 namespace YAXLib.Pooling.ObjectPools;
 
 /// <summary>

--- a/YAXLib/Pooling/ObjectPools/ObjectPoolConcurrent.cs
+++ b/YAXLib/Pooling/ObjectPools/ObjectPoolConcurrent.cs
@@ -1,8 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/YAXLib/Pooling/ObjectPools/PoolPolicy.cs
+++ b/YAXLib/Pooling/ObjectPools/PoolPolicy.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 
 namespace YAXLib.Pooling.ObjectPools;

--- a/YAXLib/Pooling/ObjectPools/PooledObject.cs
+++ b/YAXLib/Pooling/ObjectPools/PooledObject.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 
 namespace YAXLib.Pooling.ObjectPools;

--- a/YAXLib/Pooling/PoolRegistry.cs
+++ b/YAXLib/Pooling/PoolRegistry.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Concurrent;
 

--- a/YAXLib/Pooling/PoolSettings.cs
+++ b/YAXLib/Pooling/PoolSettings.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 namespace YAXLib.Pooling
 {
     internal static class PoolSettings

--- a/YAXLib/Pooling/PoolingException.cs
+++ b/YAXLib/Pooling/PoolingException.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 
 namespace YAXLib.Pooling;

--- a/YAXLib/Pooling/SpecializedPools/CollectionPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/CollectionPool.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/YAXLib/Pooling/SpecializedPools/DictionaryPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/DictionaryPool.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/YAXLib/Pooling/SpecializedPools/HashSetPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/HashSetPool.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/YAXLib/Pooling/SpecializedPools/ListPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/ListPool.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/YAXLib/Pooling/SpecializedPools/SpecializedPoolBase.cs
+++ b/YAXLib/Pooling/SpecializedPools/SpecializedPoolBase.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using YAXLib.Pooling.ObjectPools;
 

--- a/YAXLib/Pooling/SpecializedPools/StringBuilderPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/StringBuilderPool.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Text;
 using System.Threading;

--- a/YAXLib/Pooling/YAXLibPools/PoolBase.cs
+++ b/YAXLib/Pooling/YAXLibPools/PoolBase.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using YAXLib.Pooling.SpecializedPools;
 
 namespace YAXLib.Pooling.YAXLibPools;

--- a/YAXLib/Pooling/YAXLibPools/PoolBase.cs
+++ b/YAXLib/Pooling/YAXLibPools/PoolBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using YAXLib.Pooling.SpecializedPools;
 
 namespace YAXLib.Pooling.YAXLibPools;

--- a/YAXLib/Pooling/YAXLibPools/SerializerPool.cs
+++ b/YAXLib/Pooling/YAXLibPools/SerializerPool.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Threading;
 using YAXLib.Pooling.SpecializedPools;

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -35,8 +37,9 @@ namespace YAXLib
                 t == typeof(Guid))
                 return true;
 
-            if (IsNullable(t, out var nullableValueType))
+            if (IsNullable(t, out var nullableValueType) && nullableValueType != null)
                 return IsBasicType(nullableValueType);
+
             return false;
         }
 
@@ -168,7 +171,7 @@ namespace YAXLib
         }
 
         public static bool IsDerivedFromGenericInterfaceType(Type givenType, Type genericInterfaceType,
-            out Type genericType)
+            out Type? genericType)
         {
             genericType = null;
             if ((givenType.IsClass || givenType.IsValueType) && !givenType.IsAbstract)
@@ -417,8 +420,8 @@ namespace YAXLib
 
             var isTypeGenDef = type.IsGenericTypeDefinition;
             var isBaseGenDef = baseType.IsGenericTypeDefinition;
-            Type[] typeGenArgs = null;
-            Type[] baseGenArgs = null;
+            Type[]? typeGenArgs = null;
+            Type[]? baseGenArgs = null;
 
             if (type.IsGenericType)
             {
@@ -493,7 +496,7 @@ namespace YAXLib
         /// <param name="dstType">the destination type of conversion.</param>
         /// <param name="culture">The <see cref="CultureInfo"/> to use for culture-specific value formats.</param>
         /// <returns>the converted object</returns>
-        public static object ConvertBasicType(object value, Type dstType, CultureInfo culture)
+        public static object? ConvertBasicType(object value, Type dstType, CultureInfo culture)
         {
             object convertedObj;
             if (dstType.IsEnum)
@@ -537,9 +540,10 @@ namespace YAXLib
             {
                 if (IsNullable(dstType, out var nullableType))
                 {
-                    if (value == null || value.ToString() == string.Empty)
+                    if (value.ToString() == string.Empty)
                         return null;
-                    return ConvertBasicType(value, nullableType, culture);
+
+                    return ConvertBasicType(value, nullableType!, culture);
                 }
 
                 convertedObj = Convert.ChangeType(value, dstType, culture);
@@ -569,7 +573,7 @@ namespace YAXLib
         /// <returns>
         ///     <c>true</c> if the specified type is nullable; otherwise, <c>false</c>.
         /// </returns>
-        public static bool IsNullable(Type type, out Type valueType)
+        public static bool IsNullable(Type type, out Type? valueType)
         {
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
@@ -644,7 +648,6 @@ namespace YAXLib
             return false;
         }
 
-#nullable enable
         /// <summary>
         ///     Tries to format the specified object using the format string provided.
         ///     If the formatting operation is not applicable, the source object is returned intact.
@@ -671,7 +674,6 @@ namespace YAXLib
 
             return formattedObject ?? src;
         }
-#nullable disable
 
         /// <summary>
         ///     Searches all loaded assemblies to find a type with a special name.
@@ -682,7 +684,7 @@ namespace YAXLib
         /// </remarks>
         /// <param name="name">The <see cref="Type.AssemblyQualifiedName"/> of the type to find.</param>
         /// <returns><see cref="Type"/> found using the specified name</returns>
-        public static Type GetTypeByName(string name)
+        public static Type? GetTypeByName(string name)
         {
             var pattern =
                 RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework")
@@ -761,19 +763,19 @@ namespace YAXLib
             return colType.GetConstructor(Type.EmptyTypes) != null;
         }
 
-        public static T InvokeGetProperty<T>(object srcObj, string propertyName)
+        public static T? InvokeGetProperty<T>(object srcObj, string propertyName)
         {
-            return (T) srcObj.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance)
+            return (T?) srcObj.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance)
                 ?.GetValue(srcObj, null);
         }
 
-        public static T InvokeIntIndexer<T>(object srcObj, string propertyName, int index)
+        public static T? InvokeIntIndexer<T>(object srcObj, int index)
         {
             var pi = srcObj.GetType().GetProperty("Item", new[] {typeof(int)});
-            return (T) pi.GetValue(srcObj, new object[] {index});
+            return (T?) pi?.GetValue(srcObj, new object[] {index});
         }
 
-        public static object InvokeStaticMethod(Type type, string methodName, params object[] args)
+        public static object? InvokeStaticMethod(Type type, string methodName, params object[] args)
         {
             var argTypes = args.Select(x => x.GetType()).ToArray();
             var method = type.GetMethod(methodName, argTypes);
@@ -781,7 +783,7 @@ namespace YAXLib
             return result;
         }
 
-        public static object InvokeMethod(object srcObj, string methodName, params object[] args)
+        public static object? InvokeMethod(object srcObj, string methodName, params object[] args)
         {
             var argTypes = args.Select(x => x.GetType()).ToArray();
             var method = srcObj.GetType().GetMethod(methodName, argTypes);
@@ -790,7 +792,6 @@ namespace YAXLib
         }
 
 #pragma warning disable S3011 // disable sonar accessibility bypass warning: private members are intended
-#nullable enable
 
         /// <summary>
         /// Gets the value for a public or non-public instance field.
@@ -866,7 +867,6 @@ namespace YAXLib
 
             return null;
         }
-#nullable disable
 
 #pragma warning restore S3011 // restore sonar accessibility bypass warning
 

--- a/YAXLib/Serialization.cs
+++ b/YAXLib/Serialization.cs
@@ -42,8 +42,8 @@ namespace YAXLib
         {
             _baseElement = null;
             _mainDocument = null;
-            _stripInvalidXmlChars = (_serializer.Options.SerializationOptions &
-                                     YAXSerializationOptions.StripInvalidXmlChars) == YAXSerializationOptions.StripInvalidXmlChars;
+            _stripInvalidXmlChars =
+                _serializer.Options.SerializationOptions.HasFlag(YAXSerializationOptions.StripInvalidXmlChars);
         }
 
         public Serialization(YAXSerializer serializer)
@@ -661,6 +661,7 @@ namespace YAXLib
             out bool moveDescOnly, out bool alreadyAdded)
         {
             moveDescOnly = false;
+            alreadyAdded = false;
 
             _serializer.XmlNamespaceManager.RegisterNamespace(member.Namespace, member.NamespacePrefix);
 
@@ -685,7 +686,7 @@ namespace YAXLib
             else if (member.TextEmbedding != TextEmbedding.None && elementValue is string elementStringValue)
             {
                 elemToAdd = MakeBaseElement(member.Alias.OverrideNsIfEmpty(_serializer.TypeNamespace),
-                    member.TextEmbedding, elementStringValue, out alreadyAdded);
+                    member.TextEmbedding, elementStringValue);
             }
             else
             {
@@ -1170,16 +1171,11 @@ namespace YAXLib
         /// <param name="name"></param>
         /// <param name="embedding"></param>
         /// <param name="value"></param>
-        /// <param name="alreadyAdded">
-        /// If set to <see langword="true" /> specifies the element returned is
-        /// already added to the parent element and should not be added once more.
-        /// </param>
         /// <returns>
         /// An instance of <see cref="XElement"/> which will contain the serialized object.
         /// </returns>
-        private XElement MakeBaseElement(XName name, TextEmbedding embedding, string value, out bool alreadyAdded)
+        private XElement MakeBaseElement(XName name, TextEmbedding embedding, string value)
         {
-            alreadyAdded = false;
             var elem = new XElement(name);
             switch (embedding)
             {

--- a/YAXLib/Serialization.cs
+++ b/YAXLib/Serialization.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Diagnostics;

--- a/YAXLib/StringExtensions.cs
+++ b/YAXLib/StringExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #nullable enable
+
 using System;
 using System.Buffers;
 using System.Text;

--- a/YAXLib/StringExtensions.cs
+++ b/YAXLib/StringExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Buffers;
 using System.Text;

--- a/YAXLib/StringExtensions.cs
+++ b/YAXLib/StringExtensions.cs
@@ -16,12 +16,14 @@ namespace YAXLib
         /// <param name="encoding">Default is <see cref="Encoding.UTF8"/>.</param>
         /// <param name="insertLineBreaks">Inserts line breaks after every 76 characters in the string representation.</param>
         /// <returns>The encoded string.</returns>
-        public static string? ToBase64(this string? textToEncode, Encoding? encoding = null, bool insertLineBreaks = true)
+#if NETSTANDARD2_1_OR_GREATER
+        public static string? ToBase64([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("textToEncode")] this string? textToEncode, Encoding? encoding
+ = null, bool insertLineBreaks = true)
         {
             if (textToEncode == null) return null;
 
             encoding ??= Encoding.UTF8;
-#if NETSTANDARD2_1_OR_GREATER
+
             var length = (textToEncode.Length + 2) / 3 * 4;
             var buffer = ArrayPool<char>.Shared.Rent(length);
             try
@@ -38,25 +40,34 @@ namespace YAXLib
             {
                 ArrayPool<char>.Shared.Return(buffer);
             }
-#else
-           var bytes = encoding.GetBytes(textToEncode);
-           return Convert.ToBase64String(bytes,
-               insertLineBreaks ? Base64FormattingOptions.InsertLineBreaks : Base64FormattingOptions.None);
-#endif
         }
+#else
+        public static string? ToBase64(this string? textToEncode, Encoding? encoding = null,
+            bool insertLineBreaks = true)
+        {
+            if (textToEncode == null) return null;
 
+            encoding ??= Encoding.UTF8;
+
+            var bytes = encoding.GetBytes(textToEncode);
+            return Convert.ToBase64String(bytes,
+                insertLineBreaks ? Base64FormattingOptions.InsertLineBreaks : Base64FormattingOptions.None);
+        }
+#endif
         /// <summary>
         /// Decodes the given text from Base64, using the given <see cref="Encoding"/> (default: <see cref="Encoding.UTF8"/>
         /// </summary>
         /// <param name="encodedText"></param>
         /// <param name="encoding">Default is <see cref="Encoding.UTF8"/>.</param>
         /// <returns>The decoded string.</returns>
-        public static string? FromBase64(this string? encodedText, Encoding? encoding = null)
+#if NETSTANDARD2_1_OR_GREATER
+        public static string? FromBase64([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("encodedText")] this string? encodedText, Encoding? encoding
+ = null)
         {
             if (encodedText == null) return null;
 
             encoding ??= Encoding.UTF8;
-#if NETSTANDARD2_1_OR_GREATER
+
             var length = ((encodedText.Length * 3) + 3) / 4;
             var buffer = ArrayPool<byte>.Shared.Rent(length);
             try
@@ -72,10 +83,17 @@ namespace YAXLib
             {
                 ArrayPool<byte>.Shared.Return(buffer);
             }
-#else
-            var bytes = Convert.FromBase64String(encodedText);
-            return encoding.GetString(bytes);           
-#endif
         }
+#else
+        public static string? FromBase64(this string? encodedText, Encoding? encoding = null)
+        {
+            if (encodedText == null) return null;
+
+            encoding ??= Encoding.UTF8;
+
+            var bytes = Convert.FromBase64String(encodedText);
+            return encoding.GetString(bytes);
+        }
+#endif
     }
 }

--- a/YAXLib/StringUtils.cs
+++ b/YAXLib/StringUtils.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -68,7 +70,7 @@ namespace YAXLib
         /// </summary>
         /// <param name="elemName">Name of the element.</param>
         /// <returns>the refined element name</returns>
-        public static string RefineSingleElement(string elemName)
+        public static string? RefineSingleElement(string? elemName)
         {
             if (elemName == null)
                 return null;
@@ -201,7 +203,7 @@ namespace YAXLib
         public static bool DivideLocationOneStep(string location, out string newLocation, out string newElem)
         {
             newLocation = location;
-            newElem = null;
+            newElem = string.Empty;
 
             var slashIdx = location.LastIndexOf('/');
             if (slashIdx < 0) // no slashes found

--- a/YAXLib/StringUtils.cs
+++ b/YAXLib/StringUtils.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/YAXLib/StringUtils.cs
+++ b/YAXLib/StringUtils.cs
@@ -255,10 +255,10 @@ namespace YAXLib
         }
 
         /// <summary>
-        ///     Gets the string corresponiding to the given array dimensions.
+        ///     Gets the string corresponding to the given array dimensions.
         /// </summary>
         /// <param name="dims">The array dimensions.</param>
-        /// <returns>the string corresponiding to the given array dimensions</returns>
+        /// <returns>the string corresponding to the given array dimensions</returns>
         public static string GetArrayDimsString(int[] dims)
         {
             var sb = new StringBuilder();

--- a/YAXLib/TypeExtensions.cs
+++ b/YAXLib/TypeExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/YAXLib/TypeExtensions.cs
+++ b/YAXLib/TypeExtensions.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 
 namespace YAXLib
 {

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -66,7 +66,7 @@ namespace YAXLib
             _serializerOptions = serializerOptions;
             IsDictionaryType = false;
             _udtType = ReflectionUtils.IsNullable(udtType, out var nullableUnderlyingType)
-                ? nullableUnderlyingType
+                ? nullableUnderlyingType!
                 : udtType;
             IsCollectionType = ReflectionUtils.IsCollectionType(_udtType);
             IsDictionaryType = ReflectionUtils.IsIDictionary(_udtType);
@@ -323,7 +323,7 @@ namespace YAXLib
         ///     setting a default namespace for that element would make it apply to
         ///     the whole document).
         /// </remarks>
-        public string? NamespacePrefix { get; internal set; }
+        public string NamespacePrefix { get; internal set; } = string.Empty;
 
         /// <summary>
         ///     Sets the <see cref="YAXSerializationOptions"/>.

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/YAXLib/XMLUtils.cs
+++ b/YAXLib/XMLUtils.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/YAXLib/XMLUtils.cs
+++ b/YAXLib/XMLUtils.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -36,7 +38,7 @@ namespace YAXLib
         /// <param name="baseElement">The XML element.</param>
         /// <param name="location">The location string.</param>
         /// <returns>the XML element corresponding to the specified location, or <c>null</c> if it is not found</returns>
-        public static XElement FindLocation(XElement baseElement, string location)
+        public static XElement? FindLocation(XElement baseElement, string location)
         {
             if (baseElement == null)
                 throw new ArgumentNullException(nameof(baseElement));
@@ -73,7 +75,6 @@ namespace YAXLib
             return currentLocation;
         }
 
-#nullable enable
         /// <summary>
         /// Strips all invalid characters from the input value, if <paramref name="enabled"/> is <see langword="true"/>.
         /// </summary>
@@ -86,7 +87,6 @@ namespace YAXLib
                 ? new string(input.Where(XmlConvert.IsXmlChar).ToArray())
                 : input ?? string.Empty;
         }
-#nullable disable
 
         /// <summary>
         ///     Determines whether the specified location can be created in the specified XML element.
@@ -128,11 +128,11 @@ namespace YAXLib
         }
 
         /// <summary>
-        ///     Creates and returns XML element corresponding to the sepcified location in the given XML element.
+        ///     Creates and returns XML element corresponding to the specified location in the given XML element.
         /// </summary>
         /// <param name="baseElement">The XML element.</param>
         /// <param name="location">The location string.</param>
-        /// <returns>XML element corresponding to the sepcified location created in the given XML element</returns>
+        /// <returns>XML element corresponding to the specified location created in the given XML element</returns>
         public static XElement CreateLocation(XElement baseElement, string location)
         {
             var locSteps = location.SplitPathNamespaceSafe();
@@ -152,7 +152,7 @@ namespace YAXLib
                 else
                 {
                     XName curLocName = loc;
-                    XElement newLoc;
+                    XElement? newLoc;
                     if (curLocName.Namespace.IsEmpty())
                         newLoc = currentLocation.Element(curLocName);
                     else
@@ -170,7 +170,7 @@ namespace YAXLib
                     }
                 }
 
-            return currentLocation;
+            return currentLocation ?? baseElement;
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace YAXLib
         ///     a value indicating whether the attribute with the given name located in
         ///     the given location string in the given XML element has been found.
         /// </returns>
-        public static XAttribute FindAttribute(XElement baseElement, string location, XName attrName)
+        public static XAttribute? FindAttribute(XElement baseElement, string location, XName attrName)
         {
             var newLoc = FindLocation(baseElement, location);
             if (newLoc == null)
@@ -262,8 +262,8 @@ namespace YAXLib
         ///     returns the attribute with the given name in the location
         ///     specified by the given location string in the given XML element.
         /// </returns>
-        public static XAttribute CreateAttribute(XElement baseElement, string location, XName attrName,
-            object attrValue, XNamespace documentDefaultNamespace, CultureInfo culture)
+        public static XAttribute? CreateAttribute(XElement baseElement, string location, XName attrName,
+            object? attrValue, XNamespace documentDefaultNamespace, CultureInfo culture)
         {
             var newLoc = FindLocation(baseElement, location);
             if (newLoc == null)
@@ -300,7 +300,7 @@ namespace YAXLib
         ///     a value indicating whether the element with the given name located in
         ///     the given location string in the given XML element has been found
         /// </returns>
-        public static XElement FindElement(XElement baseElement, string location, XName elemName)
+        public static XElement? FindElement(XElement baseElement, string location, XName elemName)
         {
             return FindLocation(baseElement, StringUtils.CombineLocationAndElementName(location, elemName));
         }
@@ -368,8 +368,7 @@ namespace YAXLib
         public static XElement CreateElement(XElement baseElement, string location, XName elemName, object elemValue)
         {
             var elem = CreateElement(baseElement, location, elemName);
-            if (elem != null)
-                elem.SetValue(elemValue);
+            elem.SetValue(elemValue);
             return elem;
         }
 
@@ -428,7 +427,7 @@ namespace YAXLib
         /// <returns></returns>
         public static XElement AddPreserveSpaceAttribute(XElement element, CultureInfo culture)
         {
-            element.AddAttributeNamespaceSafe(XNamespace.Xml + "space", "preserve", null, culture);
+            element.AddAttributeNamespaceSafe(XNamespace.Xml + "space", "preserve", XNamespace.None, culture);
             return element;
         }
 
@@ -446,7 +445,7 @@ namespace YAXLib
 
             throw new InvalidOperationException("Cannot create a unique random prefix");
         }
-#nullable enable
+
         /// <summary>
         /// Gets the string representation of the object, or <see cref="string.Empty"/> if the object is <see langword="null"/>.
         /// </summary>
@@ -465,9 +464,8 @@ namespace YAXLib
                 _ => Convert.ToString(self, culture) ?? string.Empty
             };
         }
-#nullable disable
 
-        public static XAttribute AddAttributeNamespaceSafe(this XElement parent, XName attrName, object attrValue,
+        public static XAttribute AddAttributeNamespaceSafe(this XElement parent, XName attrName, object? attrValue,
             XNamespace documentDefaultNamespace, CultureInfo culture)
         {
             var newAttrName = attrName;
@@ -480,7 +478,7 @@ namespace YAXLib
             return newAttr;
         }
 
-        public static XAttribute Attribute_NamespaceSafe(this XElement parent, XName attrName,
+        public static XAttribute? Attribute_NamespaceSafe(this XElement parent, XName attrName,
             XNamespace documentDefaultNamespace)
         {
             if (attrName.Namespace == documentDefaultNamespace)
@@ -503,7 +501,7 @@ namespace YAXLib
         /// <param name="contentValue">An <see cref="object"/> for the content value.</param>
         /// <param name="culture">The <see cref="CultureInfo"/> to use for string-formatting the content value.</param>
         /// <returns>The XML content of an <see cref="XElement"/> with the value parameter formatted <see cref="CultureInfo"/>-specific.</returns>
-        public static XElement AddXmlContent(this XElement self, object contentValue, CultureInfo culture)
+        public static XElement AddXmlContent(this XElement self, object? contentValue, CultureInfo culture)
         {
             self.Add(new XText(contentValue.ToXmlValue(culture)));
             return self;
@@ -514,10 +512,11 @@ namespace YAXLib
             var values = self.Nodes().OfType<XText>().ToArray();
             if (values.Length > 0)
                 return values[0].Value;
-            return null;
+
+            return string.Empty;
         }
 
-        public static XAttribute Attribute_NamespaceNeutral(this XElement parent, XName name)
+        public static XAttribute? Attribute_NamespaceNeutral(this XElement parent, XName name)
         {
             return parent.Attributes().FirstOrDefault(e => e.Name.LocalName == name.LocalName);
         }
@@ -527,7 +526,7 @@ namespace YAXLib
             return parent.Attributes().Where(e => e.Name.LocalName == name.LocalName);
         }
 
-        public static XElement Element_NamespaceNeutral(this XContainer parent, XName name)
+        public static XElement? Element_NamespaceNeutral(this XContainer parent, XName name)
         {
             return parent.Elements().FirstOrDefault(e => e.Name.LocalName == name.LocalName);
         }
@@ -539,7 +538,7 @@ namespace YAXLib
 
         public static bool IsEmpty(this XNamespace self)
         {
-            return self != null && !string.IsNullOrEmpty(self.NamespaceName.Trim());
+            return !string.IsNullOrEmpty(self.NamespaceName.Trim());
         }
 
         public static XNamespace IfEmptyThen(this XNamespace self, XNamespace next)

--- a/YAXLib/XmlNamespaceManager.cs
+++ b/YAXLib/XmlNamespaceManager.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
@@ -36,10 +38,12 @@ namespace YAXLib
         /// </summary>
         /// <param name="ns">The namespace to be added</param>
         /// <param name="prefix">The prefix for the namespace.</param>
-        internal void RegisterNamespace(XNamespace ns, string prefix)
+        internal void RegisterNamespace(XNamespace ns, string? prefix)
         {
             if (!ns.IsEmpty())
                 return;
+
+            prefix ??= string.Empty;
 
             if (_namespaceToPrefix.ContainsKey(ns))
             {

--- a/YAXLib/XmlNamespaceManager.cs
+++ b/YAXLib/XmlNamespaceManager.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Xml.Linq;

--- a/YAXLib/YAXParsingErrors.cs
+++ b/YAXLib/YAXParsingErrors.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Globalization;
 using YAXLib.Enums;

--- a/YAXLib/YAXParsingErrors.cs
+++ b/YAXLib/YAXParsingErrors.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.Globalization;
 using YAXLib.Enums;

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -1,8 +1,6 @@
 ﻿﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/YAXLib/YAXSerializerOfT.cs
+++ b/YAXLib/YAXSerializerOfT.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-#nullable enable
-
 using System.IO;
 using System.Xml;
 using System.Xml.Linq;

--- a/YAXLib/YAXSerializerOfT.cs
+++ b/YAXLib/YAXSerializerOfT.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+#nullable enable
+
 using System.IO;
 using System.Xml;
 using System.Xml.Linq;
@@ -66,19 +68,9 @@ namespace YAXLib
         /// </summary>
         /// <param name="obj">The object to serialize.</param>
         /// <returns>A <code>System.String</code> containing the XML</returns>
-        public string Serialize(T obj)
+        public string Serialize(T? obj)
         {
             return _serializer.Serialize(obj);
-        }
-
-        /// <summary>
-        ///     Serializes the specified object and returns an instance of <c>XDocument</c> containing the result.
-        /// </summary>
-        /// <param name="obj">The object to serialize.</param>
-        /// <returns>An instance of <c>XDocument</c> containing the resulting XML</returns>
-        public XDocument SerializeToXDocument(T obj)
-        {
-            return _serializer.SerializeToXDocument(obj);
         }
 
         /// <summary>
@@ -86,7 +78,7 @@ namespace YAXLib
         /// </summary>
         /// <param name="obj">The object to serialize.</param>
         /// <param name="textWriter">The <c>TextWriter</c> instance.</param>
-        public void Serialize(T obj, TextWriter textWriter)
+        public void Serialize(T? obj, TextWriter textWriter)
         {
             _serializer.Serialize(obj, textWriter);
         }
@@ -96,9 +88,19 @@ namespace YAXLib
         /// </summary>
         /// <param name="obj">The object to serialize.</param>
         /// <param name="xmlWriter">The <c>XmlWriter</c> instance.</param>
-        public void Serialize(T obj, XmlWriter xmlWriter)
+        public void Serialize(T? obj, XmlWriter xmlWriter)
         {
             _serializer.Serialize(obj, xmlWriter);
+        }
+
+        /// <summary>
+        ///     Serializes the specified object and returns an instance of <c>XDocument</c> containing the result.
+        /// </summary>
+        /// <param name="obj">The object to serialize.</param>
+        /// <returns>An instance of <c>XDocument</c> containing the resulting XML</returns>
+        public XDocument SerializeToXDocument(T? obj)
+        {
+            return _serializer.SerializeToXDocument(obj);
         }
 
         /// <summary>
@@ -106,7 +108,7 @@ namespace YAXLib
         /// </summary>
         /// <param name="obj">The object to serialize.</param>
         /// <param name="fileName">Path to the file.</param>
-        public void SerializeToFile(T obj, string fileName)
+        public void SerializeToFile(T? obj, string fileName)
         {
             _serializer.SerializeToFile(obj, fileName);
         }
@@ -116,9 +118,9 @@ namespace YAXLib
         /// </summary>
         /// <param name="input">The input string containing the XML serialization.</param>
         /// <returns>The deserialized object.</returns>
-        public T Deserialize(string input)
+        public T? Deserialize(string input)
         {
-            return (T)_serializer.Deserialize(input);
+            return (T?)_serializer.Deserialize(input);
         }
 
         /// <summary>
@@ -126,9 +128,9 @@ namespace YAXLib
         /// </summary>
         /// <param name="xmlReader">The <c>XmlReader</c> instance to read input from.</param>
         /// <returns>The deserialized object.</returns>
-        public T Deserialize(XmlReader xmlReader)
+        public T? Deserialize(XmlReader xmlReader)
         {
-            return (T) _serializer.Deserialize(xmlReader);
+            return (T?) _serializer.Deserialize(xmlReader);
         }
 
         /// <summary>
@@ -136,9 +138,9 @@ namespace YAXLib
         /// </summary>
         /// <param name="textReader">The <c>TextReader</c> instance to read input from.</param>
         /// <returns>The deserialized object.</returns>
-        public T Deserialize(TextReader textReader)
+        public T? Deserialize(TextReader textReader)
         {
-            return (T) _serializer.Deserialize(textReader);
+            return (T?) _serializer.Deserialize(textReader);
         }
 
         /// <summary>
@@ -146,9 +148,9 @@ namespace YAXLib
         /// </summary>
         /// <param name="element">The <c>XElement</c> instance to read from.</param>
         /// <returns>The deserialized object</returns>
-        public T Deserialize(XElement element)
+        public T? Deserialize(XElement element)
         {
-            return (T) _serializer.Deserialize(element);
+            return (T?) _serializer.Deserialize(element);
         }
 
         /// <summary>
@@ -156,9 +158,9 @@ namespace YAXLib
         /// </summary>
         /// <param name="fileName">Path to the file.</param>
         /// <returns>The deserialized object.</returns>
-        public T DeserializeFromFile(string fileName)
+        public T? DeserializeFromFile(string fileName)
         {
-            return (T) _serializer.DeserializeFromFile(fileName);
+            return (T?) _serializer.DeserializeFromFile(fileName);
         }
 
         /// <summary>
@@ -166,7 +168,7 @@ namespace YAXLib
         ///     This method enables multi-stage de-serialization for YAXLib.
         /// </summary>
         /// <param name="obj">The object used as the base object in the next stage of de-serialization.</param>
-        public void SetDeserializationBaseObject(T obj)
+        public void SetDeserializationBaseObject(T? obj)
         {
             _serializer.SetDeserializationBaseObject(obj);
         }

--- a/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelCtxSerializer.cs
+++ b/YAXLibTests/SampleClasses/CustomSerialization/ClassLevelCtxSerializer.cs
@@ -4,17 +4,19 @@
 using System.Xml.Linq;
 using YAXLib;
 using YAXLib.Customization;
+using YAXLib.Options;
 
 namespace YAXLibTests.SampleClasses.CustomSerialization
 {
     public class ClassLevelCtxSerializer : ICustomSerializer<ClassLevelCtxSample>
     {
         private const string Custom = " CUSTOM";
+        private readonly SerializerOptions _serializerOptions = new();
 
         public void SerializeToAttribute(ClassLevelCtxSample objectToSerialize, XAttribute attrToFill, ISerializationContext serializationContext)
         {
             // Note: Using ISerializationContext here is to complete unit test coverage
-            var xElement = serializationContext.TypeContext.Serialize(objectToSerialize);
+            var xElement = serializationContext.TypeContext.Serialize(objectToSerialize, _serializerOptions);
             attrToFill.Value = string.Join("|", "ATTR", xElement.Element(nameof(objectToSerialize.Title))!.Value,
                 xElement.Element(nameof(objectToSerialize.MessageBody))!.Value);
         }
@@ -22,7 +24,7 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
         public void SerializeToElement(ClassLevelCtxSample objectToSerialize, XElement elemToFill, ISerializationContext serializationContext)
         {
             // Note: Using ISerializationContext here is to complete unit test coverage
-            var xElement = serializationContext.TypeContext.Serialize(objectToSerialize);
+            var xElement = serializationContext.TypeContext.Serialize(objectToSerialize, _serializerOptions);
             var valTitle = xElement.Element(nameof(objectToSerialize.Title))!.Value  + Custom;
             xElement.Element(nameof(objectToSerialize.Title))!.Value = valTitle;
             var valMessageBody = xElement.Element(nameof(objectToSerialize.MessageBody))!.Value  + Custom;
@@ -35,7 +37,7 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
         public string SerializeToValue(ClassLevelCtxSample objectToSerialize, ISerializationContext serializationContext)
         {
             // Note: Using ISerializationContext here is to complete unit test coverage
-            var xElement = serializationContext.TypeContext.Serialize(objectToSerialize);
+            var xElement = serializationContext.TypeContext.Serialize(objectToSerialize, _serializerOptions);
             return string.Join("|", "VAL", xElement.Element(nameof(objectToSerialize.Title))!.Value,
                 xElement.Element(nameof(objectToSerialize.MessageBody))!.Value);
         }
@@ -47,12 +49,12 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
 
             // Note: Using ISerializationContext here is to complete unit test coverage
             return (ClassLevelCtxSample) serializationContext.TypeContext.Deserialize(
-                serializationContext.TypeContext.Serialize(result));
+                serializationContext.TypeContext.Serialize(result, _serializerOptions), _serializerOptions);
         }
 
         public ClassLevelCtxSample DeserializeFromElement(XElement element, ISerializationContext serializationContext)
         {
-            var result = (ClassLevelCtxSample) serializationContext.TypeContext.Deserialize(element);
+            var result = (ClassLevelCtxSample) serializationContext.TypeContext.Deserialize(element, _serializerOptions);
             result.Title = result.Title.Replace(Custom, string.Empty);
             result.MessageBody = result.MessageBody.Replace(Custom, string.Empty);
 
@@ -66,7 +68,7 @@ namespace YAXLibTests.SampleClasses.CustomSerialization
 
             // Note: Using ISerializationContext here is to complete unit test coverage
             return (ClassLevelCtxSample) serializationContext.TypeContext.Deserialize(
-                serializationContext.TypeContext.Serialize(result));
+                serializationContext.TypeContext.Serialize(result, _serializerOptions), _serializerOptions);
         }
     }
 }

--- a/YAXLibTests/SampleClasses/KnownTypes/UsingSerializationContextKnownType.cs
+++ b/YAXLibTests/SampleClasses/KnownTypes/UsingSerializationContextKnownType.cs
@@ -1,20 +1,21 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-using System;
 using System.Xml.Linq;
-using YAXLib;
 using YAXLib.Customization;
 using YAXLib.KnownTypes;
+using YAXLib.Options;
 
 namespace YAXLibTests.SampleClasses.KnownTypes;
 
 internal class UsingSerializationContextKnownType : KnownTypeBase<UsingSerializationContextSample>
 {
+    private readonly SerializerOptions _serializerOptions = new();
+
     public override void Serialize(UsingSerializationContextSample obj, XElement elem, XNamespace overridingNamespace,
         ISerializationContext serializationContext)
     {
-        var serialized = serializationContext.TypeContext.Serialize(obj);
+        var serialized = serializationContext.TypeContext.Serialize(obj, _serializerOptions);
         // There is only one property
         serialized.Element(nameof(UsingSerializationContextSample.Text))!.Value = obj.Text + " KnownType";
         elem.Add(serialized.Element(nameof(UsingSerializationContextSample.Text)));
@@ -23,7 +24,7 @@ internal class UsingSerializationContextKnownType : KnownTypeBase<UsingSerializa
     public override UsingSerializationContextSample Deserialize(XElement elem, XNamespace overridingNamespace,
         ISerializationContext serializationContext)
     {
-        var deserialized = (UsingSerializationContextSample) serializationContext.TypeContext.Deserialize(elem);
+        var deserialized = (UsingSerializationContextSample) serializationContext.TypeContext.Deserialize(elem, _serializerOptions);
         deserialized.Text = deserialized.Text.Replace(" KnownType", string.Empty);
         return deserialized;
     }

--- a/YAXLibTests/StringUtilsTest.cs
+++ b/YAXLibTests/StringUtilsTest.cs
@@ -94,19 +94,19 @@ namespace YAXLibTests
             var location = "..";
             var returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
             Assert.That(newLocation, Is.EqualTo(".."));
-            Assert.That(newElement, Is.Null);
+            Assert.That(newElement, Is.Empty);
             Assert.That(returnValue, Is.False);
 
             location = ".";
             returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
             Assert.That(newLocation, Is.EqualTo("."));
-            Assert.That(newElement, Is.Null);
+            Assert.That(newElement, Is.Empty);
             Assert.That(returnValue, Is.False);
 
             location = "../..";
             returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
             Assert.That(newLocation, Is.EqualTo("../.."));
-            Assert.That(newElement, Is.Null);
+            Assert.That(newElement, Is.Empty);
             Assert.That(returnValue, Is.False);
 
             location = "../../folder";
@@ -118,7 +118,7 @@ namespace YAXLibTests
             location = "../../folder/..";
             returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
             Assert.That(newLocation, Is.EqualTo("../../folder/.."));
-            Assert.That(newElement, Is.Null);
+            Assert.That(newElement, Is.Empty);
             Assert.That(returnValue, Is.False);
 
             location = "one/two/three/four";

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -6,6 +6,7 @@
     <DelaySign>false</DelaySign>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <nullable>disable</nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Refactoring steps:
1. NRT for YAXLib.Options
2. NRT for YAXLib.Pooling
3. NRT for YAXLib.KnownTypes
4. NRT for YAXLib.Exceptions and ReflectionUtils
5. NRT for YAXLib.Enums
6. NRT for YAXLib.Customization
7. NRT for YAXLib.Caching and YAXLib.Attributes
8. NRT for EnumWrapper, StringExtensions, StringUtils, TypeExtensions
9. NRT for core classes (YAXSerializer, YAXSerializerOfT, MemberWrapper, UdtWrapper, Serialization, Deserialization, YAXParsingErrors, XmlNamespaceManager, XMLUtils, IYAXSerializer, IRecursionCounter, ICustomSerializer)
11. Set global 'nullable enable' except YAXLibTests, Demo
      * Removed #nullable enable preprocesser directive
      * Directory.Build.props: added nullable enable
      * YAXLibTests, DemoApplication: set nullable disable in *.csproj
  
[Sonar Cloud Quality Gate for this PR](https://sonarcloud.io/summary/new_code?id=axunonb_YAXLib&branch=pr-nullable-enable)