### PR TITLE
Bump version 4.0.0-pre.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Copyright>Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors</Copyright>
     <RepositoryUrl>https://github.com/YAXLib/YAXLib.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
+    <AssemblyVersion>4.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
     <LangVersion>latest</LangVersion>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.0.{build}
+version: 4.0.{build}
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true 
   matrix:
@@ -21,7 +21,7 @@ for:
     build_script:
       - ps: dotnet restore --verbosity quiet
       - ps: |
-          $version = "3.0.1"
+          $version = "4.0.0-pre.1"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
@@ -39,7 +39,7 @@ for:
       api_key:
         secure: MDEy3s/MsVPa+RLi3gzmjZrS2IjQKI3Nw72+wZoNaX7SGY6o7IdmVZYRY8/2E7/t
       on:
-        branch: master
+        branch: version/4.0
   
   -
     matrix:


### PR DESCRIPTION
# Release Notes `v4.0.0-pre.1`

## Breaking changes

* Invoke `ICustomSerializer`s and `IKnownType`s with `ISerializationContext` as additional parameter.
* For `ICustomSerializer`s and `IKnownType`s a single instance is used for all invokations (instead of one instance per invokation)
* `YAXSerializationOptions` now have flag `None = 0`. `SerializeNullObjects` is still the default, and is set in the CTOR of `YAXSerializer`.
* Migrate `YAXLib` using Nullable Reference Types (aka `#nullable enable`)
* Default `SerializerOptions.MaxRecursion = 50` (was 300 before). Can be changed, if needed.
* Remove types and members marked as obsolete in v3

## Features

* Add generic ` YAXSerializer<T>`
* Use caching and object pooling for better performance
    * Increase speed by factor > 5.5
    * Descrease GC pressure by factor > 5.5
* Custom `IKnownType`s can dynamically added and removed. `WellKnownTypes` are `public` now.
* `ISerializationContext` contains `ITypeContext`, `IMemberContext?`, `SerializerOptions`, `RecursionCount` for a better implementation experience of `ICustomSerializer`s and `IKnownType`s. Block recursive calls to `ICustomSerializer`s and `IKnownType`s.
* `ITypeContext` offers methods
    * to de/serialize the current type. This leaves the heavy lifting to the `IYAXSerializer`.
    * `GetFieldsForSerialization()` and `GetFieldsForDeserialization()` to get fields identified by `IYaxSerializer`.
* `ICustomSerializer`s can be also invoked using a `private` constructor
* `Exception` and derived classes can be serialized and deserialized fast and reliably
* Add option to serialize private members from base types (`YAXSerializableTypeAttribute.IncludePrivateMembersFromBaseTypes`)
* Add `NetStandard2.1` as target framework, containing specific optimization  
