### PR TITLE
chore: Don't run build/test workflows for markdown file changes

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -2,9 +2,13 @@ name: SonarCloud
 on:
   push:
     branches: [ master, 'version/**', 'pr/**', 'pr-**' ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ master, 'version/**', 'pr/**', 'pr-**' ]
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
 jobs:
   build:
     name: Build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,7 @@
 version: 4.0.{build}
+skip_commits:
+  files:
+    - '**/*.md'
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true 
   matrix:
@@ -8,7 +11,6 @@ environment:
     appveyor_build_worker_image: Ubuntu
 matrix:
   fast_finish: true
-
 
 for:
   -


### PR DESCRIPTION
Don't run build/test workflows for markdown file changes
* exclude `'**/*.md'` for AppVeyor
* exclude `'**/*.md'` for GitHub actions