### PR TITLE
fix: Pass a timeout to limit the RegEx execution time

### DIFF
--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using YAXLib.Caching;
 using YAXLib.Options;
 using YAXLib.Pooling.SpecializedPools;
@@ -695,7 +696,8 @@ internal static class ReflectionUtils
                 : @"\,\s+(mscorlib)\,\s+Version\=\d+(\.\d+)*\,\s+Culture=\b\w+\b\,\s+PublicKeyToken\=\b\w+\b";
 
         var execAppFxName =
-            System.Text.RegularExpressions.Regex.Replace(name, pattern, name.GetType().Assembly.FullName);
+            Regex.Replace(name, pattern, name.GetType().Assembly.FullName,
+                RegexOptions.None, TimeSpan.FromMilliseconds(100));
 
         var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fix: Pass a timeout to limit the RegEx execution time
chore(YAXLibTests): Update referenced packages in csproj