### PR TITLE
Add DateOnly and TimeOnly as KnownTypes

### DIFF
--- a/YAXLib/Attributes/YAXAttributeForAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForAttribute.cs
@@ -37,7 +37,7 @@ public class YAXAttributeForAttribute : YAXBaseAttribute, IYaxMemberLevelAttribu
 
             memberWrapper.SerializationLocation = path;
             if (!string.IsNullOrEmpty(alias))
-                memberWrapper.Alias = StringUtils.RefineSingleElement(alias);
+                memberWrapper.Alias = StringUtils.RefineSingleElement(alias)!;
         }
     }
 }

--- a/YAXLib/Attributes/YAXElementForAttribute.cs
+++ b/YAXLib/Attributes/YAXElementForAttribute.cs
@@ -37,6 +37,6 @@ public class YAXElementForAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
 
         memberWrapper.SerializationLocation = path;
         if (!string.IsNullOrEmpty(alias))
-            memberWrapper.Alias = StringUtils.RefineSingleElement(alias);
+            memberWrapper.Alias = StringUtils.RefineSingleElement(alias)!;
     }
 }

--- a/YAXLib/Attributes/YAXSerializeAsAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializeAsAttribute.cs
@@ -31,12 +31,12 @@ public class YAXSerializeAsAttribute : YAXBaseAttribute, IYaxMemberLevelAttribut
     /// <inheritdoc />
     void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
     {
-        memberWrapper.Alias = StringUtils.RefineSingleElement(SerializeAs);
+        memberWrapper.Alias = StringUtils.RefineSingleElement(SerializeAs)!;
     }
 
     /// <inheritdoc />
     void IYaxTypeLevelAttribute.Setup(UdtWrapper udtWrapper)
     {
-        udtWrapper.Alias = StringUtils.RefineSingleElement(SerializeAs);
+        udtWrapper.Alias = StringUtils.RefineSingleElement(SerializeAs)!;
     }
 }

--- a/YAXLib/Attributes/YAXValueForAttribute.cs
+++ b/YAXLib/Attributes/YAXValueForAttribute.cs
@@ -38,7 +38,7 @@ public class YAXValueForAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
 
             memberWrapper.SerializationLocation = path;
             if (!string.IsNullOrEmpty(alias))
-                memberWrapper.Alias = StringUtils.RefineSingleElement(alias);
+                memberWrapper.Alias = StringUtils.RefineSingleElement(alias)!;
         }
     }
 }

--- a/YAXLib/Caching/MemberWrapperCache.cs
+++ b/YAXLib/Caching/MemberWrapperCache.cs
@@ -57,8 +57,9 @@ internal class MemberWrapperCache : TypeCacheBase<IList<MemberWrapper>>
         {
             lock (Locker)
             {
-                if (CacheDictionary.TryGetValue(t, out memberWrappers))
+                if (CacheDictionary.TryGetValue(t, out var mw))
                 {
+                    memberWrappers = mw;
                     return true;
                 }
             }

--- a/YAXLib/Customization/CustomSerializerWrapper.cs
+++ b/YAXLib/Customization/CustomSerializerWrapper.cs
@@ -24,7 +24,7 @@ internal class CustomSerializerWrapper : ICustomSerializer<object>
     {
         Type = csType;
         // Create the instance by invoking a public or non-public constructor
-        _csInstance = Activator.CreateInstance(csType, true);
+        _csInstance = Activator.CreateInstance(csType, true) ?? throw new InvalidOperationException($"Can't create instance for type '{Type.Name}'");
     }
 
     /// <inheritdoc />
@@ -61,7 +61,7 @@ internal class CustomSerializerWrapper : ICustomSerializer<object>
         return (string) Type.InvokeMember(nameof(ICustomSerializer<object>.SerializeToValue),
             BindingFlags.InvokeMethod, null,
             _csInstance,
-            new[] { objectToSerialize, serializationContext });
+            new[] { objectToSerialize, serializationContext })!;
     }
 
     /// <inheritdoc />
@@ -71,7 +71,7 @@ internal class CustomSerializerWrapper : ICustomSerializer<object>
 
         return Type.InvokeMember(nameof(ICustomSerializer<object>.DeserializeFromAttribute),
             BindingFlags.InvokeMethod, null, _csInstance,
-            new object[] { attribute, serializationContext });
+            new object[] { attribute, serializationContext })!;
     }
 
     /// <inheritdoc />
@@ -81,7 +81,7 @@ internal class CustomSerializerWrapper : ICustomSerializer<object>
 
         return Type.InvokeMember(nameof(ICustomSerializer<object>.DeserializeFromElement),
             BindingFlags.InvokeMethod, null, _csInstance,
-            new object[] { element, serializationContext });
+            new object[] { element, serializationContext })!;
     }
 
     /// <inheritdoc />
@@ -91,6 +91,6 @@ internal class CustomSerializerWrapper : ICustomSerializer<object>
 
         return Type.InvokeMember(nameof(ICustomSerializer<object>.DeserializeFromValue),
             BindingFlags.InvokeMethod, null, _csInstance,
-            new object[] { value, serializationContext });
+            new object[] { value, serializationContext })!;
     }
 }

--- a/YAXLib/Customization/Locker.cs
+++ b/YAXLib/Customization/Locker.cs
@@ -15,20 +15,20 @@ internal class Locker : IDisposable
     public Locker(Type typeToLock)
     {
         _lockedType = typeToLock;
-        if (!LockedTypes.Value.Add(typeToLock))
+        if (!LockedTypes.Value!.Add(typeToLock))
             throw new ArgumentException("The type is already locked.", nameof(typeToLock));
     }
 
     public static bool IsLocked(Type typeToTest)
     {
-        return LockedTypes.Value.Contains(typeToTest);
+        return LockedTypes.Value!.Contains(typeToTest);
     }
 
     protected virtual void Dispose(bool disposing)
     {
         if (disposing)
         {
-            LockedTypes.Value.Remove(_lockedType);
+            LockedTypes.Value!.Remove(_lockedType);
         }
         else
         {

--- a/YAXLib/Customization/TypeContext.cs
+++ b/YAXLib/Customization/TypeContext.cs
@@ -54,7 +54,7 @@ public class TypeContext : ITypeContext
         try
         {
             ((IRecursionCounter) _serializer).RecursionCount++;
-            return serializer.SerializeToXDocument(obj).Root;
+            return serializer.SerializeToXDocument(obj).Root!;
         }
         finally
         {

--- a/YAXLib/EnumWrapper.cs
+++ b/YAXLib/EnumWrapper.cs
@@ -89,7 +89,7 @@ internal class EnumWrapper
     /// <returns>the alias corresponding to the specified enum member</returns>
     public object GetAlias(object enumMember)
     {
-        var originalName = enumMember.ToString();
+        var originalName = enumMember.ToString()!;
 
         var components = originalName.Split(new[] { ',', ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
 

--- a/YAXLib/ICustomSerializer.cs
+++ b/YAXLib/ICustomSerializer.cs
@@ -71,7 +71,7 @@ public interface ICustomSerializer<T>
     /// <param name="attribute">The attribute to deserialize.</param>
     /// <param name="serializationContext">Contains information about the type and members of the object to deserialize.</param>
     /// <returns></returns>
-    T DeserializeFromAttribute(XAttribute attribute, ISerializationContext serializationContext);
+    T? DeserializeFromAttribute(XAttribute attribute, ISerializationContext serializationContext);
 
     /// <summary>
     /// Deserializes from an xml element, and returns the retrieved value.
@@ -81,7 +81,7 @@ public interface ICustomSerializer<T>
     /// <param name="element">The element to deserialize.</param>
     /// <param name="serializationContext">Contains information about the type and members of the object to deserialize.</param>
     /// <returns></returns>
-    T DeserializeFromElement(XElement element, ISerializationContext serializationContext);
+    T? DeserializeFromElement(XElement element, ISerializationContext serializationContext);
 
     /// <summary>
     /// Deserializes from a string value which has been serialized as the content of an element
@@ -89,5 +89,5 @@ public interface ICustomSerializer<T>
     /// <param name="value">The string value to deserialize.</param>
     /// <param name="serializationContext">Contains information about the type and members of the object to deserialize.</param>
     /// <returns></returns>
-    T DeserializeFromValue(string value, ISerializationContext serializationContext);
+    T? DeserializeFromValue(string value, ISerializationContext serializationContext);
 }

--- a/YAXLib/KnownTypes/ColorDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/ColorDynamicKnownType.cs
@@ -26,7 +26,7 @@ internal class ColorDynamicKnownType : DynamicKnownTypeBase
         if (isKnownColor)
         {
             var colorName = ReflectionUtils.InvokeGetProperty<string>(obj, "Name");
-            elem.Value = colorName;
+            elem.Value = colorName!;
         }
         else
         {

--- a/YAXLib/KnownTypes/DataSetDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/DataSetDynamicKnownType.cs
@@ -32,8 +32,8 @@ internal class DataSetDynamicKnownType : DynamicKnownTypeBase
             return null;
 
         using var xr = child.CreateReader();
-        var dsType = ReflectionUtils.GetTypeByName("System.Data.DataSet");
-        var ds = Activator.CreateInstance(dsType);
+        var dsType = ReflectionUtils.GetTypeByName("System.Data.DataSet") ?? throw new InvalidOperationException($"Type for 'System.Data.DataSet' not found");
+        var ds = Activator.CreateInstance(dsType) ?? throw new InvalidOperationException($"Can't create instance of type '{dsType.Name}'");
         ReflectionUtils.InvokeMethod(ds, "ReadXml", xr);
         return ds;
     }

--- a/YAXLib/KnownTypes/DataTableDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/DataTableDynamicKnownType.cs
@@ -20,8 +20,9 @@ internal class DataTableDynamicKnownType : DynamicKnownTypeBase
         if (obj == null) throw new ArgumentException("Object must not be null", nameof(obj));
 
         using var xw = elem.CreateWriter();
-        var dsType = ReflectionUtils.GetTypeByName("System.Data.DataSet");
-        var ds = Activator.CreateInstance(dsType);
+
+        var dsType = ReflectionUtils.GetTypeByName("System.Data.DataSet") ?? throw new InvalidOperationException($"Type for 'System.Data.DataSet' not found");
+        var ds = Activator.CreateInstance(dsType) ?? throw new InvalidOperationException($"Can't create instance of type '{dsType.Name}'");
         var dsTables = ReflectionUtils.InvokeGetProperty<object>(ds, "Tables")!;
         var dtCopy = ReflectionUtils.InvokeMethod(obj, "Copy")!;
         ReflectionUtils.InvokeMethod(dsTables, "Add", dtCopy);
@@ -37,8 +38,8 @@ internal class DataTableDynamicKnownType : DynamicKnownTypeBase
             return null;
 
         using var xr = dsElem.CreateReader();
-        var dsType = ReflectionUtils.GetTypeByName("System.Data.DataSet");
-        var ds = Activator.CreateInstance(dsType);
+        var dsType = ReflectionUtils.GetTypeByName("System.Data.DataSet") ?? throw new InvalidOperationException($"Type for 'System.Data.DataSet' not found");
+        var ds = Activator.CreateInstance(dsType) ?? throw new InvalidOperationException($"Can't create instance of type '{dsType.Name}'");
         ReflectionUtils.InvokeMethod(ds, "ReadXml", xr);
         var dsTables = ReflectionUtils.InvokeGetProperty<object>(ds, "Tables")!;
         var dsTablesCount = ReflectionUtils.InvokeGetProperty<int>(dsTables, "Count");

--- a/YAXLib/KnownTypes/DateOnlyKnownType.cs
+++ b/YAXLib/KnownTypes/DateOnlyKnownType.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Xml.Linq;
+using YAXLib.Customization;
+using YAXLib.Exceptions;
+
+namespace YAXLib.KnownTypes;
+
+internal class DateOnlyKnownType : KnownTypeBase<DateOnly>
+{
+    /// <inheritdoc />
+    public override void Serialize(DateOnly dateOnly, XElement elem, XNamespace overridingNamespace,
+        ISerializationContext serializationContext)
+    {
+        var elemDayNumber = new XElement(nameof(DateOnly.DayNumber), dateOnly.DayNumber.ToString());
+        elem.Add(elemDayNumber);
+    }
+
+    /// <inheritdoc />
+    public override DateOnly Deserialize(XElement elem, XNamespace overridingNamespace,
+        ISerializationContext serializationContext)
+    {
+        var elemDayNumber = elem.Element(overridingNamespace.GetXName(nameof(DateOnly.DayNumber)));
+
+        // Child element not found, so we use the element value as a fallback
+        if (elemDayNumber == null)
+        {
+            var strDateOnlyString = elem.Value;
+            if (!int.TryParse(strDateOnlyString, out var dateOnlyResult))
+                throw new YAXBadlyFormedInput(elem.Name.ToString(), elem.Value, elem);
+            return DateOnly.FromDayNumber(dateOnlyResult);
+        }
+
+        // Process the child element
+        if (!int.TryParse(elemDayNumber.Value, out var dayNumber))
+            throw new YAXBadlyFormedInput(elemDayNumber.Name.ToString(), elemDayNumber.Value, elemDayNumber);
+        return DateOnly.FromDayNumber(dayNumber);
+    }
+}

--- a/YAXLib/KnownTypes/ExceptionKnownBaseType.cs
+++ b/YAXLib/KnownTypes/ExceptionKnownBaseType.cs
@@ -96,7 +96,7 @@ internal class ExceptionKnownBaseType : KnownBaseTypeBase<Exception>
         {
             // The serializer does not call this method recursively
             var parent = new XElement(XName.Get(member.MemberInfo.Name), overridingNamespace);
-            var element = member.TypeContext.Serialize(value, new SerializerOptions { MaxRecursion = 4 }).Document.Root;
+            var element = member.TypeContext.Serialize(value, new SerializerOptions { MaxRecursion = 4 }).Document!.Root;
             if (!XMLUtils.IsElementCompletelyEmpty(element)) parent.Add(element);
             elem.Add(parent);
         }

--- a/YAXLib/KnownTypes/RuntimeTypeDynamicKnownType.cs
+++ b/YAXLib/KnownTypes/RuntimeTypeDynamicKnownType.cs
@@ -20,7 +20,7 @@ internal class RuntimeTypeDynamicKnownType : DynamicKnownTypeBase
         if (obj == null || objectType == null || objectType.FullName != TypeName)
             throw new ArgumentException("Object type does not match the provided typename", nameof(obj));
 
-        elem.Value = ReflectionUtils.InvokeGetProperty<string>(obj, "FullName");
+        elem.Value = ReflectionUtils.InvokeGetProperty<string>(obj, "FullName") ?? string.Empty;
     }
 
     /// <inheritdoc />

--- a/YAXLib/KnownTypes/TimeOnlyKnownType.cs
+++ b/YAXLib/KnownTypes/TimeOnlyKnownType.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Xml.Linq;
+using YAXLib.Customization;
+using YAXLib.Exceptions;
+
+namespace YAXLib.KnownTypes;
+
+internal class TimeOnlyKnownType : KnownTypeBase<TimeOnly>
+{
+    /// <inheritdoc />
+    public override void Serialize(TimeOnly timeOnly, XElement elem, XNamespace overridingNamespace,
+        ISerializationContext serializationContext)
+    {
+        var elemDayNumber = new XElement(nameof(timeOnly.Ticks), timeOnly.Ticks.ToString());
+        elem.Add(elemDayNumber);
+    }
+
+    /// <inheritdoc />
+    public override TimeOnly Deserialize(XElement elem, XNamespace overridingNamespace,
+        ISerializationContext serializationContext)
+    {
+        var elemTicks = elem.Element(overridingNamespace.GetXName(nameof(TimeOnly.Ticks)));
+        long ticks;
+
+        // Child element not found, so we use the element value as a fallback
+        if (elemTicks == null)
+        {
+            var strTimeOnlyString = elem.Value;
+            if (!long.TryParse(strTimeOnlyString, out ticks))
+                throw new YAXBadlyFormedInput(elem.Name.ToString(), elem.Value, elem);
+            return TimeOnly.FromTimeSpan(TimeSpan.FromTicks(ticks));
+        }
+
+        // Process the child element
+        if (!long.TryParse(elemTicks.Value, out ticks))
+            throw new YAXBadlyFormedInput(elemTicks.Name.ToString(), elemTicks.Value, elemTicks);
+        return TimeOnly.FromTimeSpan(new TimeSpan(ticks));
+    }
+}

--- a/YAXLib/KnownTypes/WellknownTypes.cs
+++ b/YAXLib/KnownTypes/WellknownTypes.cs
@@ -110,7 +110,7 @@ public static class WellKnownTypes
     public static bool Remove(Type theType)
     {
         return _dictKnownTypes.Remove(theType)
-               || _dictDynamicKnownTypes.Remove(theType.FullName)
+               || _dictDynamicKnownTypes.Remove(theType.FullName!)
                || _dictKnownBaseTypes.Remove(theType);
     }
 

--- a/YAXLib/KnownTypes/WellknownTypes.cs
+++ b/YAXLib/KnownTypes/WellknownTypes.cs
@@ -59,6 +59,8 @@ public static class WellKnownTypes
         // Register all known types
 
         Add(new TimeSpanKnownType());
+        Add(new DateOnlyKnownType());
+        Add(new TimeOnlyKnownType());
         Add(new XElementKnownType());
         Add(new XAttributeKnownType());
         Add(new DbNullKnownType());

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -83,7 +83,7 @@ internal class MemberWrapper
             _isProperty = true;
         }
 
-        _alias = Alias = StringUtils.RefineSingleElement(MemberInfo.Name);
+        _alias = Alias = StringUtils.RefineSingleElement(MemberInfo.Name)!;
         if (_isProperty)
         {
             PropertyInfo = (PropertyInfo) memberInfo;
@@ -161,7 +161,7 @@ internal class MemberWrapper
         {
             if (Namespace.IsEmpty())
             {
-                _alias = Namespace + value?.LocalName;
+                _alias = Namespace + value.LocalName;
             }
             else
             {
@@ -460,7 +460,7 @@ internal class MemberWrapper
         {
             _namespace = value;
             // explicit namespace definition overrides namespace definitions in SerializeAs attributes.
-            _alias = _namespace + _alias?.LocalName;
+            _alias = _namespace + _alias.LocalName;
         }
     }
 
@@ -578,7 +578,7 @@ internal class MemberWrapper
     /// </returns>
     public override string ToString()
     {
-        return MemberInfo.ToString();
+        return MemberInfo.ToString()!;
     }
 
     // Private Methods 

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -489,7 +489,7 @@ internal class MemberWrapper
 
     public YAXTypeAttribute? GetRealTypeDefinition(Type? type)
     {
-        return _possibleRealTypes.FirstOrDefault(x => ReferenceEquals(x.Type, type));
+        return _possibleRealTypes.Find(x => ReferenceEquals(x.Type, type));
     }
 
     /// <summary>
@@ -638,11 +638,11 @@ internal class MemberWrapper
                 alias = null;
         }
 
-        if (_possibleRealTypes.Any(x => x.Type == yaxTypeAttribute.Type))
+        if (_possibleRealTypes.Exists(x => x.Type == yaxTypeAttribute.Type))
             throw new YAXPolymorphicException(
                 $"The type \"{yaxTypeAttribute.Type.Name}\" for field/property \"{MemberInfo}\" has already been defined through another attribute.");
 
-        if (alias != null && _possibleRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
+        if (alias != null && _possibleRealTypes.Exists(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
             throw new YAXPolymorphicException(
                 $"The alias \"{alias}\" given to type \"{yaxTypeAttribute.Type.Name}\" for field/property \"{MemberInfo}\" has already been given to another type through another attribute.");
 
@@ -664,13 +664,13 @@ internal class MemberWrapper
                 alias = null;
         }
 
-        if (_possibleCollectionItemRealTypes.Any(x => x.Type == yaxCollectionItemTypeAttr.Type))
+        if (_possibleCollectionItemRealTypes.Exists(x => x.Type == yaxCollectionItemTypeAttr.Type))
             throw new YAXPolymorphicException(string.Format(
                 "The collection-item type \"{0}\" for collection \"{1}\" has already been defined through another attribute.",
                 yaxCollectionItemTypeAttr.Type.Name, MemberInfo));
 
         if (alias != null &&
-            _possibleCollectionItemRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
+            _possibleCollectionItemRealTypes.Exists(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
             throw new YAXPolymorphicException(string.Format(
                 "The alias \"{0}\" given to collection-item type \"{1}\" for field/property \"{2}\" has already been given to another type through another attribute.",
                 alias, yaxCollectionItemTypeAttr.Type.Name, MemberInfo));

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
@@ -502,7 +503,11 @@ internal class MemberWrapper
     /// properties.
     /// </param>
     /// <returns>the original value of this member in the specified object</returns>
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+    public object? GetOriginalValue([NotNullIfNotNull(nameof(obj))]object? obj, object[]? index)
+#else
     public object? GetOriginalValue(object? obj, object[]? index)
+#endif
     {
         if (obj == null) return null;
 
@@ -547,7 +552,7 @@ internal class MemberWrapper
 
     /// <summary>
     /// Determines whether this instance of <see cref="MemberWrapper" /> is allowed to be serialized.
-    /// This method evaluates <see cref="Boolean" />s and <see cref="Enum" />s (no expensive reflection methods).
+    /// This method evaluates <see cref="bool" />s and <see cref="Enum" />s (no expensive reflection methods).
     /// </summary>
     /// <param name="serializationFields">The <see cref="YAXSerializationFields" /> setting.</param>
     /// <param name="dontSerializePropertiesWithNoSetter">Skip serialization of fields which doesn't have a setter.</param>

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -752,7 +752,7 @@ internal static class ReflectionUtils
     public static bool IsPartOfNetFx(MemberInfo memberInfo)
     {
         var assemblyName = memberInfo.DeclaringType.Assembly.GetName().Name;
-#if NETSTANDARD
+#if NETSTANDARD || NET6_0_OR_GREATER
             return assemblyName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("mscorlib.", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase);

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -756,6 +756,7 @@ internal static class ReflectionUtils
         var assemblyName = memberInfo.DeclaringType?.Assembly.GetName().Name;
         if (assemblyName == null) return false;
 
+#pragma warning disable S2681  // conditional execution
 #if NETSTANDARD || NET6_0_OR_GREATER
             return assemblyName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("mscorlib.", StringComparison.OrdinalIgnoreCase) ||
@@ -766,6 +767,7 @@ internal static class ReflectionUtils
                || assemblyName.Equals("System.Core", StringComparison.OrdinalIgnoreCase);
 #endif
     }
+#pragma warning restore S2681
 
     public static bool IsInstantiableCollection(Type colType)
     {

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -54,7 +54,7 @@ internal static class ReflectionUtils
     {
         if (type.IsArray)
         {
-            elementType = type.GetElementType();
+            elementType = type.GetElementType()!;
             return true;
         }
 
@@ -126,7 +126,7 @@ internal static class ReflectionUtils
         }
         else if (type.IsArray)
         {
-            var t = type.GetElementType();
+            var t = type.GetElementType()!;
             name = string.Format(CultureInfo.InvariantCulture, "Array{0}Of{1}", type.GetArrayRank(),
                 GetTypeFriendlyName(t));
         }
@@ -498,14 +498,16 @@ internal static class ReflectionUtils
     public static object? ConvertBasicType(object value, Type dstType, CultureInfo culture)
     {
         object convertedObj;
+        var valueAsString = value.ToString()!;
+
         if (dstType.IsEnum)
         {
             var typeWrapper = UdtWrapperCache.Instance.GetOrAddItem(dstType, DefaultSerializerOptions);
-            convertedObj = typeWrapper.EnumWrapper!.ParseAlias(value.ToString());
+            convertedObj = typeWrapper.EnumWrapper!.ParseAlias(valueAsString);
         }
         else if (dstType == typeof(DateTime))
         {
-            convertedObj = StringUtils.ParseDateTimeTimeZoneSafe(value.ToString(), culture);
+            convertedObj = StringUtils.ParseDateTimeTimeZoneSafe(valueAsString, culture);
         }
         else if (dstType == typeof(decimal))
         {
@@ -514,7 +516,7 @@ internal static class ReflectionUtils
         }
         else if (dstType == typeof(bool))
         {
-            var strValue = value.ToString().Trim().ToLower();
+            var strValue = valueAsString.Trim().ToLower();
             if (strValue == "false" || strValue == "no" || strValue == "0")
             {
                 convertedObj = false;
@@ -534,7 +536,7 @@ internal static class ReflectionUtils
         }
         else if (dstType == typeof(Guid))
         {
-            return new Guid(value.ToString());
+            return new Guid(valueAsString);
         }
         else
         {
@@ -665,7 +667,7 @@ internal static class ReflectionUtils
         try
         {
             formattedObject = src.GetType().InvokeMember("ToString", BindingFlags.InvokeMethod,
-                null, src, new object[] { format });
+                null, src, new object[] { format })!;
         }
         catch
         {
@@ -696,7 +698,7 @@ internal static class ReflectionUtils
                 : @"\,\s+(mscorlib)\,\s+Version\=\d+(\.\d+)*\,\s+Culture=\b\w+\b\,\s+PublicKeyToken\=\b\w+\b";
 
         var execAppFxName =
-            Regex.Replace(name, pattern, name.GetType().Assembly.FullName,
+            Regex.Replace(name, pattern, name.GetType().Assembly.FullName!,
                 RegexOptions.None, TimeSpan.FromMilliseconds(100));
 
         var assemblies = AppDomain.CurrentDomain.GetAssemblies();
@@ -751,7 +753,9 @@ internal static class ReflectionUtils
     /// </returns>
     public static bool IsPartOfNetFx(MemberInfo memberInfo)
     {
-        var assemblyName = memberInfo.DeclaringType.Assembly.GetName().Name;
+        var assemblyName = memberInfo.DeclaringType?.Assembly.GetName().Name;
+        if (assemblyName == null) return false;
+
 #if NETSTANDARD || NET6_0_OR_GREATER
             return assemblyName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("mscorlib.", StringComparison.OrdinalIgnoreCase) ||
@@ -886,7 +890,7 @@ internal static class ReflectionUtils
 
 #pragma warning restore S3011 // restore sonar accessibility bypass warning
 
-    public static bool IsBaseClassOrSubclassOf(Type subType, string baseName)
+    public static bool IsBaseClassOrSubclassOf(Type? subType, string? baseName)
     {
         if (baseName == null || subType == null) return false;
         var baseType = Type.GetType(baseName);

--- a/YAXLib/Serialization.cs
+++ b/YAXLib/Serialization.cs
@@ -252,7 +252,7 @@ internal class Serialization
 
         AddMetadataAttribute(xElement,
             _serializer.Options.Namespace.Uri + _serializer.Options.AttributeName.RealType,
-            obj.GetType().FullName, _serializer.DocumentDefaultNamespace);
+            obj.GetType().FullName!, _serializer.DocumentDefaultNamespace);
         _serializer.XmlNamespaceManager.AddNamespacesToElement(xElement, _serializer.DocumentDefaultNamespace,
             _serializer.Options, _serializer.UdtWrapper);
 
@@ -458,12 +458,12 @@ internal class Serialization
             if (existingElem == null)
             {
                 // if not add the new element gracefully
-                parElem.Add((object) elemToAdd);
+                parElem.Add(elemToAdd);
             }
             else // if an element with our desired name already exists
             {
                 if (ReflectionUtils.IsBasicType(member.MemberType))
-                    existingElem.SetValue(elementValue);
+                    existingElem.SetValue(elementValue ?? string.Empty);
                 else
                     XMLUtils.MoveDescendants(elemToAdd, existingElem);
             }
@@ -816,7 +816,7 @@ internal class Serialization
         if (eachElementName == null)
         {
             eachElementName =
-                StringUtils.RefineSingleElement(ReflectionUtils.GetTypeFriendlyName(obj.GetType()));
+                StringUtils.RefineSingleElement(ReflectionUtils.GetTypeFriendlyName(obj.GetType()))!;
             eachElementName =
                 eachElementName.OverrideNsIfEmpty(elementName.Namespace.IfEmptyThen(_serializer.TypeNamespace)
                     .IfEmptyThenNone());
@@ -857,7 +857,7 @@ internal class Serialization
 
                 AddMetadataAttribute(addedElem,
                     _serializer.Options.Namespace.Uri + _serializer.Options.AttributeName.RealType,
-                    valueObj!.GetType().FullName, _serializer.DocumentDefaultNamespace);
+                    valueObj!.GetType().FullName!, _serializer.DocumentDefaultNamespace);
             }
         }
     }
@@ -888,7 +888,7 @@ internal class Serialization
                 // keyObj can't be null, if areKeyOfSameType is false
                 AddMetadataAttribute(addedElem,
                     _serializer.Options.Namespace.Uri + _serializer.Options.AttributeName.RealType,
-                    keyObj!.GetType().FullName, _serializer.DocumentDefaultNamespace);
+                    keyObj!.GetType().FullName!, _serializer.DocumentDefaultNamespace);
             }
         }
     }
@@ -916,13 +916,13 @@ internal class Serialization
         details.keyFormat = dicAttrInst.KeyFormatString;
         details.valueFormat = dicAttrInst.ValueFormatString;
 
-        details.keyAlias = StringUtils.RefineSingleElement(dicAttrInst.KeyName ?? "Key");
+        details.keyAlias = StringUtils.RefineSingleElement(dicAttrInst.KeyName ?? "Key")!;
         if (details.keyAlias.Namespace.IsEmpty())
             _serializer.XmlNamespaceManager.RegisterNamespace(details.keyAlias.Namespace, null);
         details.keyAlias = details.keyAlias.OverrideNsIfEmpty(
             elementName.Namespace.IfEmptyThen(_serializer.TypeNamespace).IfEmptyThenNone());
 
-        details.valueAlias = StringUtils.RefineSingleElement(dicAttrInst.ValueName ?? "Value");
+        details.valueAlias = StringUtils.RefineSingleElement(dicAttrInst.ValueName ?? "Value")!;
         if (details.valueAlias.Namespace.IsEmpty())
             _serializer.XmlNamespaceManager.RegisterNamespace(details.valueAlias.Namespace, null);
         details.valueAlias =
@@ -939,7 +939,7 @@ internal class Serialization
 
         if (collectionAttrInst == null || string.IsNullOrEmpty(collectionAttrInst.EachElementName)) return false;
 
-        eachElementName = StringUtils.RefineSingleElement(collectionAttrInst.EachElementName);
+        eachElementName = StringUtils.RefineSingleElement(collectionAttrInst.EachElementName)!;
         if (eachElementName.Namespace.IsEmpty())
             _serializer.XmlNamespaceManager.RegisterNamespace(eachElementName.Namespace, string.Empty);
         eachElementName =
@@ -954,7 +954,7 @@ internal class Serialization
         eachElementName = null;
         if (dicAttrInst == null || dicAttrInst.EachPairName == null) return false;
 
-        eachElementName = StringUtils.RefineSingleElement(dicAttrInst.EachPairName);
+        eachElementName = StringUtils.RefineSingleElement(dicAttrInst.EachPairName)!;
         if (eachElementName.Namespace.IsEmpty())
             _serializer.XmlNamespaceManager.RegisterNamespace(eachElementName.Namespace, string.Empty);
         eachElementName =
@@ -1090,10 +1090,7 @@ internal class Serialization
         foreach (var obj in collectionInst)
         {
             var objToAdd = ReflectionUtils.TryFormatObject(obj, format);
-            var curElemName = eachElementName;
-
-            if (curElemName == null) curElemName = colItemsUdt.Alias;
-
+            var curElemName = eachElementName ?? colItemsUdt.Alias;
             var itemElem = AddObjectToElement(elemToAdd, curElemName.OverrideNsIfEmpty(elementName.Namespace),
                 objToAdd);
 
@@ -1105,7 +1102,7 @@ internal class Serialization
 
             AddMetadataAttribute(itemElem,
                 _serializer.Options.Namespace.Uri + _serializer.Options.AttributeName.RealType,
-                obj.GetType().FullName, _serializer.DocumentDefaultNamespace);
+                obj.GetType().FullName!, _serializer.DocumentDefaultNamespace);
         }
     }
 
@@ -1192,7 +1189,7 @@ internal class Serialization
         if (ReflectionUtils.IsStringConvertibleIFormattable(value.GetType()))
         {
             var elementValue = (string) value.GetType().InvokeMember("ToString", BindingFlags.InvokeMethod, null,
-                value, Array.Empty<object>());
+                value, Array.Empty<object>())!;
             return new XElement(name, elementValue.StripInvalidXmlChars(_stripInvalidXmlChars));
         }
 

--- a/YAXLib/StringExtensions.cs
+++ b/YAXLib/StringExtensions.cs
@@ -16,7 +16,7 @@ internal static class StringExtensions
     /// <param name="encoding">Default is <see cref="Encoding.UTF8" />.</param>
     /// <param name="insertLineBreaks">Inserts line breaks after every 76 characters in the string representation.</param>
     /// <returns>The encoded string.</returns>
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
     public static string? ToBase64([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("textToEncode")] this string? textToEncode, Encoding? encoding
         = null, bool insertLineBreaks = true)
     {
@@ -60,7 +60,7 @@ internal static class StringExtensions
     /// <param name="encodedText"></param>
     /// <param name="encoding">Default is <see cref="Encoding.UTF8" />.</param>
     /// <returns>The decoded string.</returns>
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
     public static string? FromBase64([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("encodedText")] this string? encodedText, Encoding? encoding
         = null)
     {

--- a/YAXLib/StringExtensions.cs
+++ b/YAXLib/StringExtensions.cs
@@ -17,7 +17,7 @@ internal static class StringExtensions
     /// <param name="insertLineBreaks">Inserts line breaks after every 76 characters in the string representation.</param>
     /// <returns>The encoded string.</returns>
 #if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
-    public static string? ToBase64([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("textToEncode")] this string? textToEncode, Encoding? encoding
+    public static string? ToBase64([System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(textToEncode))] this string? textToEncode, Encoding? encoding
         = null, bool insertLineBreaks = true)
     {
         if (textToEncode == null) return null;
@@ -61,7 +61,7 @@ internal static class StringExtensions
     /// <param name="encoding">Default is <see cref="Encoding.UTF8" />.</param>
     /// <returns>The decoded string.</returns>
 #if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
-    public static string? FromBase64([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("encodedText")] this string? encodedText, Encoding? encoding
+    public static string? FromBase64([System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(encodedText))] this string? encodedText, Encoding? encoding
         = null)
     {
         if (encodedText == null) return null;

--- a/YAXLib/StringUtils.cs
+++ b/YAXLib/StringUtils.cs
@@ -69,7 +69,11 @@ internal static class StringUtils
     /// </summary>
     /// <param name="elemName">Name of the element.</param>
     /// <returns>the refined element name</returns>
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+    public static string? RefineSingleElement([NotNullIfNotNull(nameof(elemName))] string? elemName)
+#else
     public static string? RefineSingleElement(string? elemName)
+#endif
     {
         if (elemName == null)
             return null;
@@ -89,9 +93,11 @@ internal static class StringUtils
             // Leave namespace part alone, refine localname part.
             var closingBrace = elemName.IndexOf('}');
             var refinedLocalname = RefineSingleElement(elemName.Substring(closingBrace + 1));
-#pragma warning disable CA1845  // span-based 'string.Concat' and 'AsSpan' can only be used for NET6.0+
+#if NET6_0_OR_GREATER
+            return string.Concat(elemName.AsSpan(0, closingBrace + 1), refinedLocalname);
+#else
             return elemName.Substring(0, closingBrace + 1) + refinedLocalname;
-#pragma warning restore CA1845
+#endif
         }
 
         using var pooledObject = StringBuilderPool.Instance.Get(out var sb);

--- a/YAXLib/StringUtils.cs
+++ b/YAXLib/StringUtils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using System.Xml.Linq;

--- a/YAXLib/StringUtils.cs
+++ b/YAXLib/StringUtils.cs
@@ -89,7 +89,9 @@ internal static class StringUtils
             // Leave namespace part alone, refine localname part.
             var closingBrace = elemName.IndexOf('}');
             var refinedLocalname = RefineSingleElement(elemName.Substring(closingBrace + 1));
+#pragma warning disable CA1845  // span-based 'string.Concat' and 'AsSpan' can only be used for NET6.0+
             return elemName.Substring(0, closingBrace + 1) + refinedLocalname;
+#pragma warning restore CA1845
         }
 
         using var pooledObject = StringBuilderPool.Instance.Get(out var sb);

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -73,7 +73,7 @@ internal class UdtWrapper
         _ = WellKnownTypes.TryGetKnownType(_udtType, out var knownType);
         KnownType = knownType;
 
-        _alias = Alias = StringUtils.RefineSingleElement(ReflectionUtils.GetTypeFriendlyName(_udtType));
+        _alias = Alias = StringUtils.RefineSingleElement(ReflectionUtils.GetTypeFriendlyName(_udtType))!;
 
         Comment = null;
         FieldsToSerialize = YAXSerializationFields.PublicPropertiesOnly;
@@ -343,7 +343,7 @@ internal class UdtWrapper
     }
 
     /// <inheritdoc />
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (obj is UdtWrapper udtWrapper)
         {

--- a/YAXLib/XMLUtils.cs
+++ b/YAXLib/XMLUtils.cs
@@ -416,9 +416,9 @@ internal static class XMLUtils
     /// <c>true</c> if the specified element has neither any child attributes nor any child elements; otherwise,
     /// <c>false</c>.
     /// </returns>
-    public static bool IsElementCompletelyEmpty(XElement elem)
+    public static bool IsElementCompletelyEmpty(XElement? elem)
     {
-        return !elem.HasAttributes && !elem.HasElements && elem.IsEmpty;
+        return elem != null && !elem.HasAttributes && !elem.HasElements && elem.IsEmpty;
     }
 
     /// <summary>

--- a/YAXLib/YAXLib.csproj
+++ b/YAXLib/YAXLib.csproj
@@ -39,6 +39,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Portable.System.DateTimeOnly" Version="7.0.1" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/YAXLib/YAXLib.csproj
+++ b/YAXLib/YAXLib.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../Key/YAXLib.Key.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461;net6.0</TargetFrameworks>
     <PackageId>YAXLib</PackageId>
     <Title>YAXLib</Title>
     <Description>YAXLib is an XML Serialization library which allows the programmer to structure 
@@ -33,15 +33,20 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
+    <PackageReference Include="Portable.System.DateTimeOnly" Version="7.0.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="Portable.System.DateTimeOnly" Version="7.0.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Portable.System.DateTimeOnly" Version="7.0.1" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/YAXLibTests/EqualsHelpers.cs
+++ b/YAXLibTests/EqualsHelpers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace YAXLibTests;
@@ -38,6 +39,7 @@ internal class EqualsHelpers
 
         foreach (var k in me.Keys)
         {
+            if (k is null) return false;
             if (!other.Contains(k)) return false;
             var val1 = me[k];
             var val2 = other[k];
@@ -45,7 +47,7 @@ internal class EqualsHelpers
         }
 
         foreach (var k in other.Keys)
-            if (!me.Contains(k))
+            if (k is null || !me.Contains(k))
                 return false;
         return true;
     }

--- a/YAXLibTests/KnownTypeTests.cs
+++ b/YAXLibTests/KnownTypeTests.cs
@@ -203,8 +203,8 @@ public class KnownTypeTests
     [Test]
     public void DateOnly_Bad_Format_Should_Throw()
     {
-        var xml1 = "<DateOnly>no-time-span</DateOnly>";
-        var xml2 = "<DateOnly><Ticks>not-a-long</Ticks></DateOnly>";
+        var xml1 = "<DateOnly>not-an-int</DateOnly>";
+        var xml2 = "<DateOnly><Ticks>not-an-int</Ticks></DateOnly>";
         var serializer = new YAXSerializer<DateOnly>();
 
         Assert.That(code: () => serializer.Deserialize(xml1), Throws.TypeOf<YAXBadlyFormedInput>());
@@ -255,7 +255,7 @@ public class KnownTypeTests
     [Test]
     public void TimeOnly_Bad_Format_Should_Throw()
     {
-        var xml1 = "<TimeOnly>no-time-span</TimeOnly>";
+        var xml1 = "<TimeOnly>not-a-long</TimeOnly>";
         var xml2 = "<TimeOnly><Ticks>not-a-long</Ticks></TimeOnly>";
         var serializer = new YAXSerializer<TimeOnly>();
 

--- a/YAXLibTests/KnownTypeTests.cs
+++ b/YAXLibTests/KnownTypeTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using YAXLib;
 using YAXLib.Customization;
 using YAXLib.Enums;
+using YAXLib.Exceptions;
 using YAXLib.KnownTypes;
 using YAXLib.Options;
 using YAXLibTests.SampleClasses;
@@ -156,6 +157,110 @@ public class KnownTypeTests
 
         Assert.That(serialized, Is.EqualTo(expectedXml));
         Assert.That(deserialized?.ToString(), Is.EqualTo("YAXLibTests.KnownTypeTests"));
+    }
+
+    [Test]
+    public void DateOnlyKnownTypeSerialization()
+    {
+        const string expectedXml = @"<DateOnly>
+  <DayNumber>738884</DayNumber>
+</DateOnly>";
+        var date = new DateOnly(2023, 12, 31);
+        var serializer = new YAXSerializer(typeof(DateOnly));
+        var serialized = serializer.Serialize(date);
+
+        Assert.That(serialized, Is.EqualTo(expectedXml));
+    }
+
+    [Test]
+    public void DateOnlyKnownTypeDeserialization()
+    {
+        var date = new DateOnly(2023, 12, 31);
+        var xml = @$"<DateOnly>
+  <DayNumber>{date.DayNumber}</DayNumber>
+</DateOnly>";
+        
+        var serializer = new YAXSerializer(typeof(DateOnly));
+        var deserialized = serializer.Deserialize(xml);
+
+        Assert.That(deserialized, Is.EqualTo(date));
+    }
+
+    [Test]
+    public void DateOnlyKnownTypeDeserializationFallback()
+    {
+        var date = new DateOnly(2023, 12, 31);
+        var xml = @$"<DateOnly>
+{date.DayNumber}
+</DateOnly>";
+        
+        var serializer = new YAXSerializer(typeof(DateOnly));
+        var deserialized = serializer.Deserialize(xml);
+
+        Assert.That(deserialized, Is.EqualTo(date));
+    }
+
+    [Test]
+    public void DateOnly_Bad_Format_Should_Throw()
+    {
+        var xml1 = "<DateOnly>no-time-span</DateOnly>";
+        var xml2 = "<DateOnly><Ticks>not-a-long</Ticks></DateOnly>";
+        var serializer = new YAXSerializer<DateOnly>();
+
+        Assert.That(code: () => serializer.Deserialize(xml1), Throws.TypeOf<YAXBadlyFormedInput>());
+        Assert.That(code: () => serializer.Deserialize(xml2), Throws.TypeOf<YAXBadlyFormedInput>());
+    }
+
+    [Test]
+    public void TimeOnlyKnownTypeSerialization()
+    {
+        const string expectedXml = @"<TimeOnly>
+  <Ticks>183670890000</Ticks>
+</TimeOnly>";
+        var time = new TimeOnly(5,6, 7, 89);
+        var serializer = new YAXSerializer(typeof(TimeOnly));
+        var serialized = serializer.Serialize(time);
+
+        Assert.That(serialized, Is.EqualTo(expectedXml));
+    }
+
+    [Test]
+    public void TimeOnlyKnownTypeDeserialization()
+    {
+        var time = new TimeOnly(5,6, 7, 89);
+        var xml = @$"<TimeOnly>
+  <Ticks>{time.Ticks}</Ticks>
+</TimeOnly>";
+        
+        var serializer = new YAXSerializer(typeof(TimeOnly));
+        var deserialized = serializer.Deserialize(xml);
+
+        Assert.That(deserialized, Is.EqualTo(time));
+    }
+
+    [Test]
+    public void TimeOnlyKnownTypeDeserializationFallback()
+    {
+        var time = new TimeOnly(5,6, 7, 89);
+        var xml = @$"<TimeOnly>
+{time.Ticks}
+</TimeOnly>";
+        
+        var serializer = new YAXSerializer(typeof(TimeOnly));
+        var deserialized = serializer.Deserialize(xml);
+
+        Assert.That(deserialized, Is.EqualTo(time));
+    }
+
+    [Test]
+    public void TimeOnly_Bad_Format_Should_Throw()
+    {
+        var xml1 = "<TimeOnly>no-time-span</TimeOnly>";
+        var xml2 = "<TimeOnly><Ticks>not-a-long</Ticks></TimeOnly>";
+        var serializer = new YAXSerializer<TimeOnly>();
+
+        Assert.That(code: () => serializer.Deserialize(xml1), Throws.TypeOf<YAXBadlyFormedInput>());
+        Assert.That(code: () => serializer.Deserialize(xml2), Throws.TypeOf<YAXBadlyFormedInput>());
     }
 
     [Test]

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -4,7 +4,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../Key/YAXLib.Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <nullable>enable</nullable>
   </PropertyGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ for:
     build_script:
       - ps: dotnet restore --verbosity quiet
       - ps: |
-          $version = "4.0.0"
+          $version = "4.1.0"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {


### PR DESCRIPTION
Resolves #223
Add `DateOnly` and `TimeOnly`as `KnownType`s that can be serialized and deserialized

* Add NET6.0 as a target framework
* Add reference to Portable.System.DateTimeOnly v7.0.1  (Project https://github.com/OlegRa/System.DateTimeOnly supports DateOnly and TimeOnly types for NetStandard2.x and .NET Framework 4.6.x)
* Bump version to v4.1.0
