### PR TITLE
Set SerializerOptions.TypeInspector to DefaultTypeInspector.Instance when instantiating

### DIFF
--- a/YAXLib/ITypeInspector.cs
+++ b/YAXLib/ITypeInspector.cs
@@ -10,6 +10,11 @@ namespace YAXLib;
 
 /// <summary>
 /// Provides type-specific information during serialization/deserialization.
+/// <para/>
+/// It is recommended to derive a custom <see cref="ITypeInspector"/> from the <see cref="DefaultTypeInspector"/>.
+/// <see cref="DefaultTypeInspector.GetMembers"/> will then return the default members for further processing.
+/// <see cref="DefaultTypeInspector.GetTypeName"/> lets you define the type names.
+/// customization.
 /// </summary>
 public interface ITypeInspector
 {

--- a/YAXLib/Options/SerializerOptions.cs
+++ b/YAXLib/Options/SerializerOptions.cs
@@ -31,6 +31,7 @@ public class SerializerOptions
         SerializationOptions = YAXSerializationOptions.SerializeNullObjects;
         AttributeName = new YAXAttributeName { Dimensions = "dims", RealType = "realtype" };
         Namespace = new YAXNameSpace { Prefix = "yaxlib", Uri = XNamespace.Get("http://www.sinairv.com/yaxlib/") };
+        TypeInspector = DefaultTypeInspector.Instance;
     }
 
     /// <summary>
@@ -73,7 +74,15 @@ public class SerializerOptions
     public CultureInfo Culture { get; set; }
 
     /// <summary>
-    /// Allows override default type naming and member list for given type
+    /// Gets or sets the <see cref="ITypeInspector"/>. Is set to <see cref="DefaultTypeInspector"/> by default.
+    /// <para/>
+    /// With a custom <see cref="ITypeInspector"/> it is possible to control
+    /// which members are serialized/deserialized, and which type names are used for a given type.
+    /// <para/>
+    /// It is recommended to derive a custom <see cref="ITypeInspector"/> from the <see cref="DefaultTypeInspector"/>.
+    /// <see cref="DefaultTypeInspector.GetMembers"/> will then return the default members for further processing.
+    /// <see cref="DefaultTypeInspector.GetTypeName"/> lets you define the type names.
+    /// customization.
     /// </summary>
-    public ITypeInspector? TypeInspector { get; set; }
+    public ITypeInspector TypeInspector { get; set; }
 }

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -69,7 +69,7 @@ internal class UdtWrapper
 
         _ = WellKnownTypes.TryGetKnownType(_udtType, out var knownType);
         KnownType = knownType;
-        _typeInspector = serializerOptions.TypeInspector ?? DefaultTypeInspector.Instance;
+        _typeInspector = serializerOptions.TypeInspector;
 
         _alias = Alias = StringUtils.RefineSingleElement(_typeInspector.GetTypeName(_udtType, serializerOptions))!;
 


### PR DESCRIPTION
Reasoning: As soon as we're serializing types that have framework types to be serialized, the `DefaultTypeInspector` is necessary.
Allow `null` for `SerializerOptions.TypeInspector` may look like we can do without.

Also added some more xmldoc.