### PR TITLE
Fix/get default value type

### DIFF
--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -597,11 +597,6 @@ internal static class ReflectionUtils
     /// </returns>
     public static object? GetDefaultValue(Type type)
     {
-        if (!type.IsValueType)
-        {
-            return null;
-        }
-
         if (type == typeof(BigInteger))
         {
             return BigInteger.Zero;
@@ -647,6 +642,15 @@ internal static class ReflectionUtils
                 return 0M;
             case TypeCode.DateTime:
                 return DateTime.MinValue;
+            case TypeCode.DBNull:
+                return DBNull.Value;
+            case TypeCode.Empty:
+                return null;
+        }
+
+        if (!type.IsValueType)
+        {
+            return null;
         }
 
         if (IsNullable(type))

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -622,22 +622,29 @@ internal static class ReflectionUtils
             case TypeCode.Boolean:
                 return false;
             case TypeCode.Char:
+                return (char) 0;
             case TypeCode.SByte:
+                return (sbyte) 0;
             case TypeCode.Byte:
+                return (byte) 0;
             case TypeCode.Int16:
+                return (short) 0;
             case TypeCode.UInt16:
+                return (ushort) 0;
             case TypeCode.Int32:
-            case TypeCode.UInt32:
                 return 0;
+            case TypeCode.UInt32:
+                return 0U;
             case TypeCode.Int64:
-            case TypeCode.UInt64:
                 return 0L;
+            case TypeCode.UInt64:
+                return 0UL;
             case TypeCode.Single:
-                return 0f;
+                return 0F;
             case TypeCode.Double:
-                return 0.0;
+                return 0D;
             case TypeCode.Decimal:
-                return 0m;
+                return 0M;
             case TypeCode.DateTime:
                 return DateTime.MinValue;
         }

--- a/YAXLibTests/ReflectionUtilsTest.cs
+++ b/YAXLibTests/ReflectionUtilsTest.cs
@@ -203,21 +203,21 @@ public class ReflectionUtilsTest
     [Test]
     public void GetDefaultValueTest()
     {
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(string)), Is.Null);
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(bool)), Is.False);
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(char)), Is.EqualTo(default(char)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(sbyte)), Is.EqualTo(default(sbyte)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(byte)), Is.EqualTo(default(byte)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(short)), Is.EqualTo(default(short)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(ushort)), Is.EqualTo(default(ushort)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(int)), Is.EqualTo(default(int)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(uint)), Is.EqualTo(default(uint)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(long)), Is.EqualTo(default(long)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(ulong)), Is.EqualTo(default(ulong)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(float)), Is.EqualTo(default(float)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(double)), Is.EqualTo(default(double)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(decimal)), Is.EqualTo(default(decimal)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(DateTime)), Is.EqualTo(default(DateTime)));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(DBNull)), Is.EqualTo(DBNull.Value));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(string)), null));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(bool)), default(bool)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(char)), default(char)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(sbyte)), default(sbyte)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(byte)), default(byte)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(short)), default(short)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(ushort)), default(ushort)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(int)), default(int)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(uint)), default(uint)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(long)), default(long)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(ulong)), default(ulong)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(float)), default(float)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(double)), default(double)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(decimal)), default(decimal)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(DateTime)), default(DateTime)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(DBNull)), DBNull.Value));
     }
 }

--- a/YAXLibTests/ReflectionUtilsTest.cs
+++ b/YAXLibTests/ReflectionUtilsTest.cs
@@ -199,4 +199,25 @@ public class ReflectionUtilsTest
         Assert.That(baseClassProperty1AfterSet, Is.EqualTo(113));
         Assert.That(baseClassProperty2AfterSet, Is.EqualTo(123));
     }
+
+    [Test]
+    public void GetDefaultValueTest()
+    {
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(string)), Is.Null);
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(bool)), Is.False);
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(char)), Is.EqualTo((char) 0));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(sbyte)), Is.EqualTo((sbyte) 0));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(byte)), Is.EqualTo((byte) 0));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(short)), Is.EqualTo((short) 0));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(ushort)), Is.EqualTo((ushort) 0));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(int)), Is.EqualTo(0));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(uint)), Is.EqualTo(0U));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(long)), Is.EqualTo(0L));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(ulong)), Is.EqualTo(0UL));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(float)), Is.EqualTo(0F));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(double)), Is.EqualTo(0D));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(decimal)), Is.EqualTo(0M));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(DateTime)), Is.EqualTo(DateTime.MinValue));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(DBNull)), Is.EqualTo(DBNull.Value));
+    }
 }

--- a/YAXLibTests/ReflectionUtilsTest.cs
+++ b/YAXLibTests/ReflectionUtilsTest.cs
@@ -205,19 +205,19 @@ public class ReflectionUtilsTest
     {
         Assert.That(ReflectionUtils.GetDefaultValue(typeof(string)), Is.Null);
         Assert.That(ReflectionUtils.GetDefaultValue(typeof(bool)), Is.False);
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(char)), Is.EqualTo((char) 0));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(sbyte)), Is.EqualTo((sbyte) 0));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(byte)), Is.EqualTo((byte) 0));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(short)), Is.EqualTo((short) 0));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(ushort)), Is.EqualTo((ushort) 0));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(int)), Is.EqualTo(0));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(uint)), Is.EqualTo(0U));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(long)), Is.EqualTo(0L));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(ulong)), Is.EqualTo(0UL));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(float)), Is.EqualTo(0F));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(double)), Is.EqualTo(0D));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(decimal)), Is.EqualTo(0M));
-        Assert.That(ReflectionUtils.GetDefaultValue(typeof(DateTime)), Is.EqualTo(DateTime.MinValue));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(char)), Is.EqualTo(default(char)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(sbyte)), Is.EqualTo(default(sbyte)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(byte)), Is.EqualTo(default(byte)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(short)), Is.EqualTo(default(short)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(ushort)), Is.EqualTo(default(ushort)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(int)), Is.EqualTo(default(int)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(uint)), Is.EqualTo(default(uint)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(long)), Is.EqualTo(default(long)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(ulong)), Is.EqualTo(default(ulong)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(float)), Is.EqualTo(default(float)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(double)), Is.EqualTo(default(double)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(decimal)), Is.EqualTo(default(decimal)));
+        Assert.That(ReflectionUtils.GetDefaultValue(typeof(DateTime)), Is.EqualTo(default(DateTime)));
         Assert.That(ReflectionUtils.GetDefaultValue(typeof(DBNull)), Is.EqualTo(DBNull.Value));
     }
 }


### PR DESCRIPTION
Fix returned type for the GetDefaultValue function to get `object.Equals(GetDefaultValue(typeof(char)), '\0')` working.