### PR TITLE
Prepare for v4.2

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -53,9 +53,9 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"${{ env.repository_owner_lc }}_YAXLib" /o:"${{ env.repository_owner_lc }}" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="**/coverage*.xml"
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"${{ env.repository_owner_lc }}_YAXLib" /o:"${{ env.repository_owner_lc }}" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="**/coverage*.xml"
           dotnet add ./YAXLibTests/YAXLibTests.csproj package AltCover
           dotnet restore YAXLib.sln --verbosity quiet
           dotnet build YAXLib.sln --verbosity minimal --configuration release --no-restore /p:IncludeSymbols=true
           dotnet test YAXLib.sln --no-build --verbosity normal /p:configuration=release /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCoverStrongNameKey="../Key/YAXLib.Key.snk" /p:AltCoverAssemblyExcludeFilter="YAXLibTests|NUnit3.TestAdapter"
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -17,22 +17,23 @@ jobs:
     # (PRs from forks can't access secrets other than secrets.GITHUB_TOKEN for security reasons)
     if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.11
-      - uses: actions/checkout@v2
+          distribution: 'microsoft'
+          java-version: '17'
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0   # Shallow clones should be disabled for a better relevancy of analysis
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner

--- a/YAXLib/Attributes/YAXTextEmbeddingAttribute.cs
+++ b/YAXLib/Attributes/YAXTextEmbeddingAttribute.cs
@@ -39,7 +39,7 @@ public class YAXTextEmbeddingAttribute : YAXBaseAttribute, IYaxMemberLevelAttrib
     /// <inheritdoc />
     void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
     {
-        if (GetCustomAttributes(memberWrapper.MemberInfo, typeof(Attribute), true)
+        if (memberWrapper.MemberDescriptor.GetCustomAttributes()
             .Where(a => a is YAXBaseAttribute)
             .Select(a => a.GetType())
             .Except(CompatibleAttributes)

--- a/YAXLib/Caching/CacheBase.cs
+++ b/YAXLib/Caching/CacheBase.cs
@@ -6,18 +6,15 @@ using System.Collections.Generic;
 
 namespace YAXLib.Caching;
 
-internal abstract class TypeCacheBase<T> : TypeCacheStaticBase
+internal abstract class CacheBase<TKey, TValue> : CacheStaticBase where TKey : notnull
 {
-    /// <summary>
-    /// The <see cref="TypeCacheBase{T}" /> instance.
-    /// </summary>
-    private protected static TypeCacheBase<T>? _instance { get; private set; }
+   private protected static CacheBase<TKey, TValue>? _instance { get; private set; }
 
     /// <summary>
     /// Sets the instance variable, if its current value is null.
     /// </summary>
     /// <param name="instance"></param>
-    protected static void SetInstanceVariable(TypeCacheBase<T> instance)
+    protected static void SetInstanceVariable(CacheBase<TKey, TValue> instance)
     {
         lock (Locker)
         {
@@ -25,15 +22,12 @@ internal abstract class TypeCacheBase<T> : TypeCacheStaticBase
         }
     }
 
-    /// <summary>
-    /// A dictionary from <see cref="Type" />s to the associated cache value.
-    /// </summary>
-    internal readonly Dictionary<Type, T> CacheDictionary = new();
+    internal readonly Dictionary<TKey, TValue> CacheDictionary = new();
 
     /// <summary>
     /// Stores the dictionary keys in the sequence as added
     /// </summary>
-    protected List<Type> TypeList { get; } = new();
+    protected List<TKey> KeyList { get; } = new();
 
     /// <summary>
     /// Gets or sets the maximum number of items in the cache.
@@ -53,7 +47,7 @@ internal abstract class TypeCacheBase<T> : TypeCacheStaticBase
     /// <param name="key">The key.</param>
     /// <param name="value">The value.</param>
     /// <returns><see langword="true" /> if the item could be added, else <see langword="false" />.</returns>
-    public bool TryAdd(Type key, T value)
+    public bool TryAdd(TKey key, TValue value)
     {
         if (_instance is null) return false;
 
@@ -72,7 +66,7 @@ internal abstract class TypeCacheBase<T> : TypeCacheStaticBase
     /// <param name="key">The key.</param>
     /// <param name="value">The value.</param>
     /// <exception cref="ArgumentException">Throws if the <paramref name="key" /> already exists.</exception>
-    public void Add(Type key, T value)
+    public void Add(TKey key, TValue value)
     {
         if (_instance is null) return;
 
@@ -82,7 +76,7 @@ internal abstract class TypeCacheBase<T> : TypeCacheStaticBase
                 EvictItems();
 
             CacheDictionary.Add(key, value);
-            TypeList.Add(key);
+            KeyList.Add(key);
         }
     }
 
@@ -97,8 +91,8 @@ internal abstract class TypeCacheBase<T> : TypeCacheStaticBase
         {
             while (CacheDictionary.Count > 0 && CacheDictionary.Count > MaxCacheSize - 1)
             {
-                CacheDictionary.Remove(TypeList[0]);
-                TypeList.RemoveAt(0);
+                CacheDictionary.Remove(KeyList[0]);
+                KeyList.RemoveAt(0);
             }
         }
     }
@@ -113,7 +107,7 @@ internal abstract class TypeCacheBase<T> : TypeCacheStaticBase
         lock (Locker)
         {
             CacheDictionary.Clear();
-            TypeList.Clear();
+            KeyList.Clear();
         }
     }
 }

--- a/YAXLib/Caching/CacheStaticBase.cs
+++ b/YAXLib/Caching/CacheStaticBase.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// A static field in a generic type is not shared among instances of different constructed types.
 /// </summary>
-internal abstract class TypeCacheStaticBase
+internal abstract class CacheStaticBase
 {
     private protected static readonly object Locker = new();
 }

--- a/YAXLib/Caching/MemberWrapperCache.cs
+++ b/YAXLib/Caching/MemberWrapperCache.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using YAXLib.Options;
 
 namespace YAXLib.Caching;
 
@@ -14,7 +15,7 @@ namespace YAXLib.Caching;
 /// Filtering of undesired members takes place later in the de/serialization process.
 /// </para>
 /// </summary>
-internal class MemberWrapperCache : TypeCacheBase<IList<MemberWrapper>>
+internal class MemberWrapperCache : CacheBase<(Type type, SerializerOptions options), IList<MemberWrapper>>
 {
     public const int DefaultCacheSize = 1000;
 
@@ -45,19 +46,19 @@ internal class MemberWrapperCache : TypeCacheBase<IList<MemberWrapper>>
     /// <summary>
     /// Gets the <see cref="MemberWrapper" />s for to the specified type.
     /// </summary>
-    /// <param name="t">The member whose wrapper is needed.</param>
+    /// <param name="to">The member whose wrapper is needed.</param>
     /// <param name="memberWrappers">
     /// The lists of <see cref="MemberWrapper" />s from the cache,
     /// or an empty list, if the type did not exist in the cache.
     /// </param>
-    /// <returns><see langword="true" />, if <paramref name="t" /> was found in the cache.</returns>
-    public bool TryGetItem(Type t, out IList<MemberWrapper> memberWrappers)
+    /// <returns><see langword="true" />, if <paramref name="to" /> was found in the cache.</returns>
+    public bool TryGetItem((Type type, SerializerOptions options) to, out IList<MemberWrapper> memberWrappers)
     {
         if (_instance is not null)
         {
             lock (Locker)
             {
-                if (CacheDictionary.TryGetValue(t, out var mw))
+                if (CacheDictionary.TryGetValue(to, out var mw))
                 {
                     memberWrappers = mw;
                     return true;

--- a/YAXLib/Caching/UdtWrapperCache.cs
+++ b/YAXLib/Caching/UdtWrapperCache.cs
@@ -10,7 +10,7 @@ namespace YAXLib.Caching;
 /// Implements a singleton cache for <see cref="UdtWrapper" />s
 /// to prevent creation of <see cref="UdtWrapper" />s for the same type repetitively.
 /// </summary>
-internal class UdtWrapperCache : TypeCacheBase<UdtWrapper>
+internal class UdtWrapperCache : CacheBase<(Type type, SerializerOptions options), UdtWrapper>
 {
     public const int DefaultCacheSize = 500;
 
@@ -48,15 +48,15 @@ internal class UdtWrapperCache : TypeCacheBase<UdtWrapper>
     {
         lock (Locker)
         {
-            if (!CacheDictionary.TryGetValue(t, out var udtWrapper))
+            if (CacheDictionary.TryGetValue((t, serializerOptions), out var udtWrapper))
             {
-                udtWrapper = new UdtWrapper(t, serializerOptions);
-                Add(t, udtWrapper);
+                return udtWrapper;
             }
-            else
-                udtWrapper.SetSerializationOptions(serializerOptions.SerializationOptions);
 
+            udtWrapper = new UdtWrapper(t, serializerOptions);
+            Add((t, serializerOptions), udtWrapper);
             return udtWrapper;
+
         }
     }
 }

--- a/YAXLib/Customization/IMemberContext.cs
+++ b/YAXLib/Customization/IMemberContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+using System;
 using System.Reflection;
 
 namespace YAXLib.Customization;
@@ -13,17 +14,25 @@ public interface IMemberContext
     /// <summary>
     /// The member's <see cref="MemberInfo" /> for member serialization, else <see langword="null" />.
     /// </summary>
+    [Obsolete("Will be removed in a future version, please use the MemberDescriptor property instead.")]
     MemberInfo MemberInfo { get; }
 
     /// <summary>
     /// The member's <see cref="FieldInfo" /> for field serialization, else <see langword="null" />.
     /// </summary>
+    [Obsolete("Will be removed in a future version, please use the MemberDescriptor property instead.")]
     FieldInfo? FieldInfo { get; }
 
     /// <summary>
     /// The member's <see cref="PropertyInfo" /> for property serialization, else <see langword="null" />.
     /// </summary>
+    [Obsolete("Will be removed in a future version, please use the MemberDescriptor property instead.")]
     PropertyInfo? PropertyInfo { get; }
+
+    /// <summary>
+    /// The member's <see cref="IMemberDescriptor" /> for member serialization, else <see langword="null" />.
+    /// </summary>
+    IMemberDescriptor MemberDescriptor { get; }
 
     /// <summary>
     /// The member's <see cref="Customization.TypeContext" /> for member serialization./>.
@@ -34,11 +43,7 @@ public interface IMemberContext
     /// Gets value of this member in the specified object.
     /// </summary>
     /// <param name="obj">The object from which the value must be retrieved.</param>
-    /// <param name="index">
-    /// Optional index values for indexed properties.
-    /// The indexes of indexed properties are zero-based. This value should be <see langword="null" /> for non-indexed
-    /// properties.
-    /// </param>
+    /// <param name="index">Optional index parameters for indexed properties.</param>
     /// <returns>The value for this member.</returns>
     object? GetValue(object? obj, object[]? index = null);
 }

--- a/YAXLib/Customization/MemberContext.cs
+++ b/YAXLib/Customization/MemberContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
+using System;
 using System.Reflection;
 using YAXLib.Caching;
 
@@ -21,25 +22,41 @@ public class MemberContext : IMemberContext
     internal MemberContext(MemberWrapper memberWrapper, YAXSerializer serializer)
     {
         _memberWrapper = memberWrapper;
+        MemberDescriptor = memberWrapper.MemberDescriptor;
 
-        MemberInfo = memberWrapper.MemberInfo;
-        FieldInfo = memberWrapper.FieldInfo;
-        PropertyInfo = memberWrapper.PropertyInfo;
-        TypeContext =
-            new TypeContext(UdtWrapperCache.Instance.GetOrAddItem(memberWrapper.MemberType, serializer.Options),
-                serializer);
+        // todo remove this code block along with obsolete properties on next major release
+        // todo and do PropertyWrapper.WrappedProperty and FieldWrapper.WrappedField private
+#pragma warning disable CS0618
+        switch (MemberDescriptor)
+        {
+            case PropertyWrapper prop:
+
+                MemberInfo = PropertyInfo = prop.WrappedProperty;
+                break;
+            case FieldWrapper field:
+                MemberInfo = FieldInfo = field.WrappedField;
+                break;
+        }
+#pragma warning restore CS0618
+
+        var udtWrapper = UdtWrapperCache.Instance.GetOrAddItem(memberWrapper.MemberType, serializer.Options);
+        TypeContext = new TypeContext(udtWrapper, serializer);
     }
 
     /// <inheritdoc />
-    public MemberInfo MemberInfo { get; }
+    [Obsolete("Will be removed in a future version, please use the MemberDescriptor property instead.")]
+    public MemberInfo MemberInfo { get; } = null!;
 
     /// <inheritdoc />
+    [Obsolete("Will be removed in a future version, please use the MemberDescriptor property instead.")]
     public FieldInfo? FieldInfo { get; }
 
-    /// <summary>
-    /// The member's <see cref="PropertyInfo" /> for property serialization, else <see langword="null" />.
-    /// </summary>
+    /// <inheritdoc />
+    [Obsolete("Will be removed in a future version, please use the MemberDescriptor property instead.")]
     public PropertyInfo? PropertyInfo { get; }
+
+    /// <inheritdoc />
+    public IMemberDescriptor MemberDescriptor { get; }
 
     /// <inheritdoc />
     public TypeContext TypeContext { get; }

--- a/YAXLib/DefaultTypeInspector.cs
+++ b/YAXLib/DefaultTypeInspector.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using YAXLib.Options;
+
+namespace YAXLib;
+
+/// <inheritdoc />
+public class DefaultTypeInspector : ITypeInspector
+{
+    internal static ITypeInspector Instance { get; } = new DefaultTypeInspector();
+
+    /// <inheritdoc />
+    public virtual IEnumerable<IMemberDescriptor> GetMembers(Type type, SerializerOptions options, bool includePrivateMembersFromBaseTypes)
+    {
+#pragma warning disable S3011 // disable sonar accessibility bypass warning
+        foreach (var member in type.GetMembers(
+                     BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+                     includePrivateMembersFromBaseTypes))
+#pragma warning restore S3011 // enable sonar accessibility bypass warning
+        {
+            if (!IsValidPropertyOrField(member)) continue;
+            if (member is PropertyInfo prop && !CanSerializeProperty(prop)) continue;
+
+            if ((ReflectionUtils.IsCollectionType(type) || ReflectionUtils.IsIDictionary(type))
+                && ReflectionUtils.IsPartOfNetFx(member))
+                continue;
+
+            yield return member.Wrap();
+        }
+    }
+
+    /// <inheritdoc />
+    public virtual string GetTypeName(Type type, SerializerOptions options)
+    {
+        return ReflectionUtils.GetTypeFriendlyName(type);
+    }
+
+    private static bool IsValidPropertyOrField(MemberInfo member)
+    {
+        // Exclude names of compiler-generated backing fields like "<my_member>k__BackingField"
+        var name0 = member.Name[0];
+        return (char.IsLetter(name0) || name0 == '_') &&
+               (member.MemberType == MemberTypes.Property || member.MemberType == MemberTypes.Field);
+    }
+
+    private static bool CanSerializeProperty(PropertyInfo prop)
+    {
+        // ignore indexers; if member is an indexer property, do not serialize it
+        if (prop.GetIndexParameters().Length > 0)
+            return false;
+
+        // don't serialize delegates as well
+        if (ReflectionUtils.IsTypeEqualOrInheritedFromType(prop.PropertyType, typeof(Delegate)))
+            return false;
+
+        return true;
+    }
+}

--- a/YAXLib/Deserialization.cs
+++ b/YAXLib/Deserialization.cs
@@ -371,7 +371,8 @@ internal class Deserialization
                 }
             }
         }
-        else if (_serializer.UdtWrapper.IsNotAllowedNullObjectSerialization && member.DefaultValue is null)
+        else if ((_serializer.UdtWrapper.IsNotAllowedNullObjectSerialization && member.DefaultValue is null) ||
+                 _serializer.UdtWrapper.IsNotAllowedDefaultValueSerialization)
         {
             // Any missing elements are allowed for deserialization:
             // * Don't set a value - uses default or initial value

--- a/YAXLib/Enums/YAXSerializationOptions.cs
+++ b/YAXLib/Enums/YAXSerializationOptions.cs
@@ -57,5 +57,10 @@ public enum YAXSerializationOptions
     /// Default: disabled.
     /// </para>
     /// </summary>
-    StripInvalidXmlChars = 64
+    StripInvalidXmlChars = 64,
+
+    /// <summary>
+    /// Prevents serialization of default values.
+    /// </summary>
+    DoNotSerializeDefaultValues = 128
 }

--- a/YAXLib/FieldWrapper.cs
+++ b/YAXLib/FieldWrapper.cs
@@ -39,7 +39,7 @@ internal sealed class FieldWrapper : IMemberDescriptor
         WrappedField.SetValue(obj, value);
     }
 
-    public override string ToString()
+    public override string? ToString()
     {
         return WrappedField.ToString();
     }

--- a/YAXLib/FieldWrapper.cs
+++ b/YAXLib/FieldWrapper.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Reflection;
+
+namespace YAXLib;
+
+internal sealed class FieldWrapper : IMemberDescriptor
+{
+    internal FieldInfo WrappedField { get; }
+    public bool CanRead => true;
+    public bool CanWrite => true;
+    public bool IsPublic { get; }
+    public MemberTypes MemberType => MemberTypes.Field;
+    public string Name { get; }
+    public Type Type { get; }
+
+    public FieldWrapper(FieldInfo fieldInfo)
+    {
+        WrappedField = fieldInfo;
+        IsPublic = fieldInfo.IsPublic;
+        Type = fieldInfo.FieldType;
+        Name = fieldInfo.Name;
+    }
+
+    public Attribute[] GetCustomAttributes()
+    {
+        return Attribute.GetCustomAttributes(WrappedField);
+    }
+
+    public object? GetValue(object? obj, object[]? index = null)
+    {
+        return WrappedField.GetValue(obj);
+    }
+
+    public void SetValue(object? obj, object? value, object[]? index = null)
+    {
+        WrappedField.SetValue(obj, value);
+    }
+
+    public override string ToString()
+    {
+        return WrappedField.ToString();
+    }
+}

--- a/YAXLib/IMemberDescriptor.cs
+++ b/YAXLib/IMemberDescriptor.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Reflection;
+
+namespace YAXLib;
+
+/// <summary>
+/// Provides information about a member.
+/// </summary>
+public interface IMemberDescriptor
+{
+    /// <summary>
+    /// Gets a value indicating whether the member can be read.
+    /// </summary>
+    bool CanRead { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the member can be written to.
+    /// </summary>
+    bool CanWrite { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the member is public.
+    /// </summary>
+    bool IsPublic { get; }
+
+    /// <summary>
+    /// Gets the type of the member.
+    /// </summary>
+    MemberTypes MemberType { get; }
+
+    /// <summary>
+    /// Gets the name of the member.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the data type of the member.
+    /// </summary>
+    Type Type { get; }
+
+    /// <summary>
+    /// Retrieves an array of all custom attributes applied to the member.
+    /// </summary>
+    /// <returns>An array of all custom attributes applied to the member.</returns>
+    Attribute[] GetCustomAttributes();
+
+    /// <summary>
+    /// Gets the value of the member for the specified object.
+    /// </summary>
+    /// <param name="obj">The object from which to retrieve the member value.</param>
+    /// <param name="index">Optional index parameters for indexed properties.</param>
+    /// <returns>The value of the member.</returns>
+    object? GetValue(object? obj, object[]? index = null);
+
+    /// <summary>
+    /// Sets the value of the member for the specified object.
+    /// </summary>
+    /// <param name="obj">The object on which to set the member value.</param>
+    /// <param name="value">The value to be assigned to the member.</param>
+    /// <param name="index">Optional index parameters for indexed properties.</param>
+    void SetValue(object? obj, object? value, object[]? index = null);
+}

--- a/YAXLib/ITypeInspector.cs
+++ b/YAXLib/ITypeInspector.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using YAXLib.Attributes;
+using YAXLib.Options;
+
+namespace YAXLib;
+
+/// <summary>
+/// Provides type-specific information during serialization/deserialization.
+/// </summary>
+public interface ITypeInspector
+{
+    /// <summary>
+    /// Retrieves the members to be serialized for the given type.
+    /// </summary>
+    /// <param name="type">The type for which to retrieve the member information.</param>
+    /// <param name="options">Serializer options for controlling the serialization process.</param>
+    /// <param name="includePrivateMembersFromBaseTypes" cref="YAXSerializableTypeAttribute.IncludePrivateMembersFromBaseTypes">
+    /// Specifies whether to include private members from base types in the collection.
+    /// </param>
+    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="IMemberDescriptor"/> containing the member information for the specified type.</returns>
+    IEnumerable<IMemberDescriptor> GetMembers(Type type, SerializerOptions options, bool includePrivateMembersFromBaseTypes);
+
+    /// <summary>
+    /// Gets the custom type name for the given type during serialization.
+    /// </summary>
+    /// <param name="type">The type for which to retrieve the type name.</param>
+    /// <param name="options">Serializer options for controlling the serialization process.</param>
+    /// <returns>A string representing the type name for the specified type.</returns>
+    string GetTypeName(Type type, SerializerOptions options);
+}

--- a/YAXLib/ITypeInspector.cs
+++ b/YAXLib/ITypeInspector.cs
@@ -10,6 +10,11 @@ namespace YAXLib;
 
 /// <summary>
 /// Provides type-specific information during serialization/deserialization.
+/// <para/>
+/// It is recommended to derive a custom <see cref="ITypeInspector"/> from the <see cref="DefaultTypeInspector"/>.
+/// <see cref="DefaultTypeInspector.GetMembers"/> will then return the default members for further processing.
+/// <see cref="DefaultTypeInspector.GetTypeName"/> lets you define the type names.
+/// customization.
 /// </summary>
 public interface ITypeInspector
 {

--- a/YAXLib/KnownTypes/ExceptionKnownBaseType.cs
+++ b/YAXLib/KnownTypes/ExceptionKnownBaseType.cs
@@ -65,8 +65,8 @@ internal class ExceptionKnownBaseType : KnownBaseTypeBase<Exception>
 
         var exceptionElement = member.TypeContext.Serialize(value, new SerializerOptions { MaxRecursion = 1 });
 
-        exceptionElement.Name = member.MemberInfo.Name == nameof(Exception.InnerException)
-            ? XName.Get(member.MemberInfo.Name)
+        exceptionElement.Name = member.MemberDescriptor.Name == nameof(Exception.InnerException)
+            ? XName.Get(member.MemberDescriptor.Name)
             : XName.Get(nameof(Exception));
 
         if (value is Exception exceptionValue)
@@ -86,16 +86,16 @@ internal class ExceptionKnownBaseType : KnownBaseTypeBase<Exception>
 
         if (value == null || ReflectionUtils.IsBasicType(value.GetType()))
         {
-            elem.Add(new XElement(XName.Get(member.MemberInfo.Name), overridingNamespace, value));
+            elem.Add(new XElement(XName.Get(member.MemberDescriptor.Name), overridingNamespace, value));
         }
-        else if (member.MemberInfo.Name == nameof(Exception.TargetSite))
+        else if (member.MemberDescriptor.Name == nameof(Exception.TargetSite))
         {
-            elem.Add(new XElement(XName.Get(member.MemberInfo.Name), overridingNamespace, value));
+            elem.Add(new XElement(XName.Get(member.MemberDescriptor.Name), overridingNamespace, value));
         }
         else
         {
             // The serializer does not call this method recursively
-            var parent = new XElement(XName.Get(member.MemberInfo.Name), overridingNamespace);
+            var parent = new XElement(XName.Get(member.MemberDescriptor.Name), overridingNamespace);
             var element = member.TypeContext.Serialize(value, new SerializerOptions { MaxRecursion = 4 }).Document!.Root;
             if (!XMLUtils.IsElementCompletelyEmpty(element)) parent.Add(element);
             elem.Add(parent);

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -447,7 +447,7 @@ internal class MemberWrapper
     /// properties.
     /// </param>
     /// <returns>the original value of this member in the specified object</returns>
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
     public object? GetOriginalValue([NotNullIfNotNull(nameof(obj))]object? obj, object[]? index)
 #else
     public object? GetOriginalValue(object? obj, object[]? index)

--- a/YAXLib/Options/SerializerOptions.cs
+++ b/YAXLib/Options/SerializerOptions.cs
@@ -31,6 +31,7 @@ public class SerializerOptions
         SerializationOptions = YAXSerializationOptions.SerializeNullObjects;
         AttributeName = new YAXAttributeName { Dimensions = "dims", RealType = "realtype" };
         Namespace = new YAXNameSpace { Prefix = "yaxlib", Uri = XNamespace.Get("http://www.sinairv.com/yaxlib/") };
+        TypeInspector = DefaultTypeInspector.Instance;
     }
 
     /// <summary>
@@ -73,7 +74,15 @@ public class SerializerOptions
     public CultureInfo Culture { get; set; }
 
     /// <summary>
-    /// Allows override default type naming and member list for given type
+    /// Gets or sets the <see cref="ITypeInspector"/>. Is set to <see cref="DefaultTypeInspector"/> by default.
+    /// <para/>
+    /// With a custom <see cref="ITypeInspector"/> it is possible to control
+    /// which members are serialized/deserialized, and which type names are used for a given type.
+    /// <para/>
+    /// It is recommended to derive a custom <see cref="ITypeInspector"/> from the <see cref="DefaultTypeInspector"/>.
+    /// <see cref="DefaultTypeInspector.GetMembers"/> will then return the default members for further processing.
+    /// <see cref="DefaultTypeInspector.GetTypeName"/> lets you define the type names.
+    /// customization.
     /// </summary>
-    public ITypeInspector? TypeInspector { get; set; }
+    public ITypeInspector TypeInspector { get; set; }
 }

--- a/YAXLib/Options/SerializerOptions.cs
+++ b/YAXLib/Options/SerializerOptions.cs
@@ -71,4 +71,9 @@ public class SerializerOptions
     /// Default is <see cref="CultureInfo.CurrentCulture" />.
     /// </summary>
     public CultureInfo Culture { get; set; }
+
+    /// <summary>
+    /// Allows override default type naming and member list for given type
+    /// </summary>
+    public ITypeInspector? TypeInspector { get; set; }
 }

--- a/YAXLib/Pooling/PoolRegistry.cs
+++ b/YAXLib/Pooling/PoolRegistry.cs
@@ -17,12 +17,11 @@ internal static class PoolRegistry
     /// Adds a pool to the registry.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    /// <param name="pool"></param>
+    /// <param name="poolFunc"></param>
     /// <returns>The instance of pool which was added.</returns>
-    public static T Add<T>(T pool) where T : class
+    public static T GetOrAdd<T>(Func<T> poolFunc) where T : class
     {
-        Items.TryAdd(pool.GetType(), pool);
-        return pool;
+        return (T) Items.GetOrAdd(typeof(T), _ => poolFunc());
     }
 
     /// <summary>

--- a/YAXLib/Pooling/SpecializedPools/CollectionPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/CollectionPool.cs
@@ -1,9 +1,7 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace YAXLib.Pooling.SpecializedPools;
 
@@ -17,9 +15,6 @@ namespace YAXLib.Pooling.SpecializedPools;
 internal class CollectionPool<TCollection, TItem> : SpecializedPoolBase<TCollection>
     where TCollection : class, ICollection<TItem>, new()
 {
-    private static readonly Lazy<CollectionPool<TCollection, TItem>> Lazy =
-        new(() => new CollectionPool<TCollection, TItem>(), LazyThreadSafetyMode.PublicationOnly);
-
     /// <summary>
     /// CTOR.
     /// </summary>
@@ -35,6 +30,5 @@ internal class CollectionPool<TCollection, TItem> : SpecializedPoolBase<TCollect
     /// <summary>
     /// Gets a singleton instance of the pool.
     /// </summary>
-    public static CollectionPool<TCollection, TItem> Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static CollectionPool<TCollection, TItem> Instance => PoolRegistry.GetOrAdd(() => new CollectionPool<TCollection, TItem>());
 }

--- a/YAXLib/Pooling/SpecializedPools/DictionaryPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/DictionaryPool.cs
@@ -1,9 +1,7 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace YAXLib.Pooling.SpecializedPools;
 
@@ -14,10 +12,6 @@ internal sealed class
     DictionaryPool<TKey, TValue> : CollectionPool<Dictionary<TKey, TValue>, KeyValuePair<TKey, TValue>>
     where TKey : notnull
 {
-    private static readonly Lazy<DictionaryPool<TKey, TValue>> Lazy = new(() => new DictionaryPool<TKey, TValue>(),
-        LazyThreadSafetyMode.PublicationOnly
-    );
-
     /// <summary>
     /// CTOR.
     /// </summary>
@@ -32,6 +26,5 @@ internal sealed class
     /// <summary>
     /// Gets a singleton instance of the pool.
     /// </summary>
-    public static new DictionaryPool<TKey, TValue> Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static new DictionaryPool<TKey, TValue> Instance => PoolRegistry.GetOrAdd(() => new DictionaryPool<TKey, TValue>());
 }

--- a/YAXLib/Pooling/SpecializedPools/HashSetPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/HashSetPool.cs
@@ -1,9 +1,7 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace YAXLib.Pooling.SpecializedPools;
 
@@ -12,9 +10,6 @@ namespace YAXLib.Pooling.SpecializedPools;
 /// </summary>
 internal sealed class HashSetPool<T> : CollectionPool<HashSet<T>, T>
 {
-    private static readonly Lazy<HashSetPool<T>> Lazy = new(() => new HashSetPool<T>(),
-        LazyThreadSafetyMode.PublicationOnly);
-
     /// <summary>
     /// CTOR.
     /// </summary>
@@ -29,6 +24,5 @@ internal sealed class HashSetPool<T> : CollectionPool<HashSet<T>, T>
     /// <summary>
     /// Gets a singleton instance of the pool.
     /// </summary>
-    public static new HashSetPool<T> Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static new HashSetPool<T> Instance => PoolRegistry.GetOrAdd(() => new HashSetPool<T>());
 }

--- a/YAXLib/Pooling/SpecializedPools/ListPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/ListPool.cs
@@ -1,9 +1,7 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace YAXLib.Pooling.SpecializedPools;
 
@@ -12,9 +10,6 @@ namespace YAXLib.Pooling.SpecializedPools;
 /// </summary>
 internal sealed class ListPool<T> : CollectionPool<List<T>, T>
 {
-    private static readonly Lazy<ListPool<T>> Lazy = new(() => new ListPool<T>(),
-        LazyThreadSafetyMode.PublicationOnly);
-
     /// <summary>
     /// CTOR.
     /// </summary>
@@ -29,6 +24,5 @@ internal sealed class ListPool<T> : CollectionPool<List<T>, T>
     /// <summary>
     /// Gets a singleton instance of the pool.
     /// </summary>
-    public static new ListPool<T> Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static new ListPool<T> Instance => PoolRegistry.GetOrAdd(() => new ListPool<T>());
 }

--- a/YAXLib/Pooling/SpecializedPools/StringBuilderPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/StringBuilderPool.cs
@@ -1,9 +1,7 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-using System;
 using System.Text;
-using System.Threading;
 
 namespace YAXLib.Pooling.SpecializedPools;
 
@@ -12,9 +10,6 @@ namespace YAXLib.Pooling.SpecializedPools;
 /// </summary>
 internal sealed class StringBuilderPool : SpecializedPoolBase<StringBuilder>
 {
-    private static readonly Lazy<StringBuilderPool> Lazy = new(() => new StringBuilderPool(),
-        LazyThreadSafetyMode.PublicationOnly);
-
     /// <summary>
     /// CTOR.
     /// </summary>
@@ -41,6 +36,5 @@ internal sealed class StringBuilderPool : SpecializedPoolBase<StringBuilder>
     /// <summary>
     /// Gets a singleton instance of the pool.
     /// </summary>
-    public static StringBuilderPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static StringBuilderPool Instance => PoolRegistry.GetOrAdd(() => new StringBuilderPool());
 }

--- a/YAXLib/Pooling/YAXLibPools/SerializerPool.cs
+++ b/YAXLib/Pooling/YAXLibPools/SerializerPool.cs
@@ -1,8 +1,6 @@
 // Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
 // Licensed under the MIT license.
 
-using System;
-using System.Threading;
 using YAXLib.Pooling.SpecializedPools;
 
 namespace YAXLib.Pooling.YAXLibPools;
@@ -12,9 +10,6 @@ namespace YAXLib.Pooling.YAXLibPools;
 /// </summary>
 internal sealed class SerializerPool : PoolBase<YAXSerializer>
 {
-    private static readonly Lazy<SerializerPool> Lazy = new(() => new SerializerPool(),
-        LazyThreadSafetyMode.PublicationOnly);
-
     /// <summary>
     /// CTOR.
     /// </summary>
@@ -34,6 +29,5 @@ internal sealed class SerializerPool : PoolBase<YAXSerializer>
     /// <summary>
     /// Gets a singleton instance of the pool.
     /// </summary>
-    public static SerializerPool Instance =>
-        Lazy.IsValueCreated ? Lazy.Value : PoolRegistry.Add(Lazy.Value);
+    public static SerializerPool Instance => PoolRegistry.GetOrAdd(() => new SerializerPool());
 }

--- a/YAXLib/PropertyWrapper.cs
+++ b/YAXLib/PropertyWrapper.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Reflection;
+
+namespace YAXLib;
+internal sealed class PropertyWrapper: IMemberDescriptor
+{
+    internal PropertyInfo WrappedProperty { get; }
+    public bool CanRead { get; }
+    public bool CanWrite { get; }
+    public bool IsPublic { get; }
+    public MemberTypes MemberType => MemberTypes.Property;
+    public string Name { get; }
+    public Type Type { get; }
+
+    public PropertyWrapper(PropertyInfo propertyInfo)
+    {
+        WrappedProperty = propertyInfo;
+        Name = propertyInfo.Name;
+        Type = propertyInfo.PropertyType;
+        CanRead = propertyInfo.CanRead;
+        CanWrite = propertyInfo.CanWrite;
+        IsPublic = ReflectionUtils.IsPublicProperty(propertyInfo);
+    }
+
+    public Attribute[] GetCustomAttributes()
+    {
+        return Attribute.GetCustomAttributes(WrappedProperty);
+    }
+
+    public object? GetValue(object? obj, object[]? index = null)
+    {
+        return WrappedProperty.GetValue(obj, index);
+    }
+
+    public void SetValue(object? obj, object? value, object[]? index = null)
+    {
+        WrappedProperty.SetValue(obj, value, index);
+    }
+
+    public override string ToString()
+    {
+        return WrappedProperty.ToString();
+    }
+}

--- a/YAXLib/PropertyWrapper.cs
+++ b/YAXLib/PropertyWrapper.cs
@@ -40,7 +40,7 @@ internal sealed class PropertyWrapper: IMemberDescriptor
         WrappedProperty.SetValue(obj, value, index);
     }
 
-    public override string ToString()
+    public override string? ToString()
     {
         return WrappedProperty.ToString();
     }

--- a/YAXLib/ReflectionExtensions.cs
+++ b/YAXLib/ReflectionExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Reflection;
+
+namespace YAXLib;
+internal static class ReflectionExtensions
+{
+    public static IMemberDescriptor Wrap(this MemberInfo memberInfo)
+    {
+        return memberInfo.MemberType switch
+        {
+            MemberTypes.Field => new FieldWrapper((FieldInfo) memberInfo),
+            MemberTypes.Property => new PropertyWrapper((PropertyInfo) memberInfo),
+            _ => throw new ArgumentOutOfRangeException($"MemberType: {memberInfo.MemberType} is not supported. Property and Field are only supported."),
+        };
+    }
+}

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -820,7 +820,7 @@ internal static class ReflectionUtils
         if (assemblyName == null) return false;
 
 #pragma warning disable S2681  // conditional execution
-#if NETSTANDARD || NET6_0_OR_GREATER
+#if NETSTANDARD || NET
             return assemblyName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("mscorlib.", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase);

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -597,11 +597,6 @@ internal static class ReflectionUtils
     /// </returns>
     public static object? GetDefaultValue(Type type)
     {
-        if (!type.IsValueType)
-        {
-            return null;
-        }
-
         if (type == typeof(BigInteger))
         {
             return BigInteger.Zero;
@@ -622,24 +617,40 @@ internal static class ReflectionUtils
             case TypeCode.Boolean:
                 return false;
             case TypeCode.Char:
+                return (char) 0;
             case TypeCode.SByte:
+                return (sbyte) 0;
             case TypeCode.Byte:
+                return (byte) 0;
             case TypeCode.Int16:
+                return (short) 0;
             case TypeCode.UInt16:
+                return (ushort) 0;
             case TypeCode.Int32:
-            case TypeCode.UInt32:
                 return 0;
+            case TypeCode.UInt32:
+                return 0U;
             case TypeCode.Int64:
-            case TypeCode.UInt64:
                 return 0L;
+            case TypeCode.UInt64:
+                return 0UL;
             case TypeCode.Single:
-                return 0f;
+                return 0F;
             case TypeCode.Double:
-                return 0.0;
+                return 0D;
             case TypeCode.Decimal:
-                return 0m;
+                return 0M;
             case TypeCode.DateTime:
                 return DateTime.MinValue;
+            case TypeCode.DBNull:
+                return DBNull.Value;
+            case TypeCode.Empty:
+                return null;
+        }
+
+        if (!type.IsValueType)
+        {
+            return null;
         }
 
         if (IsNullable(type))

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Numerics;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
@@ -585,6 +586,68 @@ internal static class ReflectionUtils
 
         valueType = null;
         return false;
+    }
+
+    /// <summary>
+    /// Gets the default value for the specified type.
+    /// </summary>
+    /// <param name="type">The <see cref="Type"/> for which to retrieve the default value.</param>
+    /// <returns>
+    /// The default value for the specified type. If the type is a reference type or a nullable value type, returns <c>null</c>.
+    /// </returns>
+    public static object? GetDefaultValue(Type type)
+    {
+        if (!type.IsValueType)
+        {
+            return null;
+        }
+
+        if (type == typeof(BigInteger))
+        {
+            return BigInteger.Zero;
+        }
+
+        if (type == typeof(Guid))
+        {
+            return Guid.Empty;
+        }
+
+        if (type == typeof(DateTimeOffset))
+        {
+            return DateTimeOffset.MinValue;
+        }
+
+        switch (Type.GetTypeCode(type))
+        {
+            case TypeCode.Boolean:
+                return false;
+            case TypeCode.Char:
+            case TypeCode.SByte:
+            case TypeCode.Byte:
+            case TypeCode.Int16:
+            case TypeCode.UInt16:
+            case TypeCode.Int32:
+            case TypeCode.UInt32:
+                return 0;
+            case TypeCode.Int64:
+            case TypeCode.UInt64:
+                return 0L;
+            case TypeCode.Single:
+                return 0f;
+            case TypeCode.Double:
+                return 0.0;
+            case TypeCode.Decimal:
+                return 0m;
+            case TypeCode.DateTime:
+                return DateTime.MinValue;
+        }
+
+        if (IsNullable(type))
+        {
+            return null;
+        }
+
+        return Activator.CreateInstance(type);
     }
 
     /// <summary>

--- a/YAXLib/StringExtensions.cs
+++ b/YAXLib/StringExtensions.cs
@@ -16,7 +16,7 @@ internal static class StringExtensions
     /// <param name="encoding">Default is <see cref="Encoding.UTF8" />.</param>
     /// <param name="insertLineBreaks">Inserts line breaks after every 76 characters in the string representation.</param>
     /// <returns>The encoded string.</returns>
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
     public static string? ToBase64([System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(textToEncode))] this string? textToEncode, Encoding? encoding
         = null, bool insertLineBreaks = true)
     {
@@ -60,7 +60,7 @@ internal static class StringExtensions
     /// <param name="encodedText"></param>
     /// <param name="encoding">Default is <see cref="Encoding.UTF8" />.</param>
     /// <returns>The decoded string.</returns>
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
     public static string? FromBase64([System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(encodedText))] this string? encodedText, Encoding? encoding
         = null)
     {

--- a/YAXLib/StringUtils.cs
+++ b/YAXLib/StringUtils.cs
@@ -69,7 +69,7 @@ internal static class StringUtils
     /// </summary>
     /// <param name="elemName">Name of the element.</param>
     /// <returns>the refined element name</returns>
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
     public static string? RefineSingleElement([NotNullIfNotNull(nameof(elemName))] string? elemName)
 #else
     public static string? RefineSingleElement(string? elemName)
@@ -93,7 +93,7 @@ internal static class StringUtils
             // Leave namespace part alone, refine localname part.
             var closingBrace = elemName.IndexOf('}');
             var refinedLocalname = RefineSingleElement(elemName.Substring(closingBrace + 1));
-#if NET6_0_OR_GREATER
+#if NET
             return string.Concat(elemName.AsSpan(0, closingBrace + 1), refinedLocalname);
 #else
             return elemName.Substring(0, closingBrace + 1) + refinedLocalname;

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -69,7 +69,7 @@ internal class UdtWrapper
 
         _ = WellKnownTypes.TryGetKnownType(_udtType, out var knownType);
         KnownType = knownType;
-        _typeInspector = serializerOptions.TypeInspector ?? DefaultTypeInspector.Instance;
+        _typeInspector = serializerOptions.TypeInspector;
 
         _alias = Alias = StringUtils.RefineSingleElement(_typeInspector.GetTypeName(_udtType, serializerOptions))!;
 

--- a/YAXLibTests/Caching/MemberWrapperCacheTests.cs
+++ b/YAXLibTests/Caching/MemberWrapperCacheTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using YAXLib;
 using YAXLib.Caching;
+using YAXLib.Options;
 using YAXLibTests.SampleClasses;
 
 namespace YAXLibTests.Caching;
@@ -22,7 +23,7 @@ public class MemberWrapperCacheTests
 
         Assert.That(countAfterClear, Is.EqualTo(0));
         Assert.That(MemberWrapperCache.Instance.CacheDictionary.Count, Is.GreaterThan(0));
-        Assert.That(MemberWrapperCache.Instance.CacheDictionary[typeof(Book)].Count, Is.GreaterThan(0));
+        Assert.That(MemberWrapperCache.Instance.CacheDictionary[(typeof(Book), s.Options)].Count, Is.GreaterThan(0));
     }
 
     [Test]
@@ -39,7 +40,7 @@ public class MemberWrapperCacheTests
 
         Assert.That(countAfterClear, Is.EqualTo(0));
         Assert.That(MemberWrapperCache.Instance.CacheDictionary.Count, Is.GreaterThan(0));
-        Assert.That(MemberWrapperCache.Instance.CacheDictionary[typeof(Book)].Count, Is.GreaterThan(0));
+        Assert.That(MemberWrapperCache.Instance.CacheDictionary[(typeof(Book), s.Options)].Count, Is.GreaterThan(0));
     }
 
     [Test]
@@ -56,18 +57,18 @@ public class MemberWrapperCacheTests
     {
         MemberWrapperCache.Instance.Clear();
         MemberWrapperCache.Instance.MaxCacheSize = 5;
-
-        MemberWrapperCache.Instance.Add(typeof(string), new List<MemberWrapper>());
-        var dupeAdded = MemberWrapperCache.Instance.TryAdd(typeof(string), new List<MemberWrapper>());
-        MemberWrapperCache.Instance.Add(typeof(int), new List<MemberWrapper>());
-        MemberWrapperCache.Instance.Add(typeof(uint), new List<MemberWrapper>());
-        MemberWrapperCache.Instance.Add(typeof(long), new List<MemberWrapper>());
-        MemberWrapperCache.Instance.Add(typeof(ulong), new List<MemberWrapper>());
-        MemberWrapperCache.Instance.Add(typeof(char), new List<MemberWrapper>());
+        var so = new SerializerOptions();
+        MemberWrapperCache.Instance.Add((typeof(string), so), new List<MemberWrapper>());
+        var dupeAdded = MemberWrapperCache.Instance.TryAdd((typeof(string), so), new List<MemberWrapper>());
+        MemberWrapperCache.Instance.Add((typeof(int), so), new List<MemberWrapper>());
+        MemberWrapperCache.Instance.Add((typeof(uint), so), new List<MemberWrapper>());
+        MemberWrapperCache.Instance.Add((typeof(long), so), new List<MemberWrapper>());
+        MemberWrapperCache.Instance.Add((typeof(ulong), so), new List<MemberWrapper>());
+        MemberWrapperCache.Instance.Add((typeof(char), so), new List<MemberWrapper>());
 
         Assert.That(dupeAdded, Is.False);
         Assert.That(MemberWrapperCache.Instance.CacheDictionary.Count, Is.EqualTo(5));
-        Assert.That(MemberWrapperCache.Instance.CacheDictionary.ContainsKey(typeof(string)), Is.False); // FIFO
+        Assert.That(MemberWrapperCache.Instance.CacheDictionary.ContainsKey((typeof(string), so)), Is.False); // FIFO
 
         MemberWrapperCache.Instance.MaxCacheSize = MemberWrapperCache.DefaultCacheSize;
     }

--- a/YAXLibTests/Caching/UdtWrapperCacheTests.cs
+++ b/YAXLibTests/Caching/UdtWrapperCacheTests.cs
@@ -21,7 +21,7 @@ public class UdtWrapperCacheTests
         _ = s.Serialize(Book.GetSampleInstance());
 
         Assert.That(countAfterClear, Is.EqualTo(0));
-        Assert.That(UdtWrapperCache.Instance.CacheDictionary, Contains.Key(typeof(Book)));
+        Assert.That(UdtWrapperCache.Instance.CacheDictionary, Contains.Key((typeof(Book), s.Options)));
     }
 
     [Test]
@@ -37,7 +37,7 @@ public class UdtWrapperCacheTests
         _ = s.Deserialize(xml);
 
         Assert.That(countAfterClear, Is.EqualTo(0));
-        Assert.That(UdtWrapperCache.Instance.CacheDictionary, Contains.Key(typeof(Book)));
+        Assert.That(UdtWrapperCache.Instance.CacheDictionary, Contains.Key((typeof(Book), s.Options)));
     }
 
     [Test]
@@ -65,7 +65,7 @@ public class UdtWrapperCacheTests
         UdtWrapperCache.Instance.GetOrAddItem(typeof(char), serializerOptions);
 
         Assert.That(UdtWrapperCache.Instance.CacheDictionary.Count, Is.EqualTo(5));
-        Assert.That(UdtWrapperCache.Instance.CacheDictionary.ContainsKey(typeof(string)), Is.False); // FIFO
+        Assert.That(UdtWrapperCache.Instance.CacheDictionary.ContainsKey((typeof(string), serializerOptions)), Is.False); // FIFO
 
         UdtWrapperCache.Instance.MaxCacheSize = UdtWrapperCache.DefaultCacheSize;
     }

--- a/YAXLibTests/CustomTypeInspectorTests.cs
+++ b/YAXLibTests/CustomTypeInspectorTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using YAXLib;
+using YAXLib.Enums;
 using YAXLib.Options;
 using YAXLibTests.SampleClasses;
 
@@ -15,6 +16,16 @@ public class CustomTypeInspectorTests
     internal class CustomTypeInspector : DefaultTypeInspector
     {
         public override IEnumerable<IMemberDescriptor> GetMembers(Type type, SerializerOptions options, bool includePrivateMembersFromBaseTypes)
+        {
+            if (base.GetTypeName(type, options) == nameof(Book))
+                return GetMembersForBookType(type, options, includePrivateMembersFromBaseTypes);
+
+            // Different handling for other types could be added here
+            
+            return base.GetMembers(type, options, includePrivateMembersFromBaseTypes);
+        }
+
+        private IEnumerable<IMemberDescriptor> GetMembersForBookType(Type type, SerializerOptions options, bool includePrivateMembersFromBaseTypes)
         {
             var members = base.GetMembers(type, options, includePrivateMembersFromBaseTypes);
             return members.Where(member => !string.Equals("PublishYear", member.Name, StringComparison.OrdinalIgnoreCase));
@@ -41,5 +52,29 @@ public class CustomTypeInspectorTests
               <Price>30.5</Price>
             </Book>
             """, result);
+    }
+
+    [Test]
+    public void SkipPublishYearPropertyDeserializationTest()
+    {
+        var serializer = new YAXSerializer<Book>(
+            new SerializerOptions
+            {
+                TypeInspector = new CustomTypeInspector()
+            });
+
+        var result = serializer.Deserialize("""
+            <!-- This example demonstrates serializing a very simple class -->
+            <Book>
+              <Title>Inside C#</Title>
+              <Author>Tom Archer &amp; Andrew Whitechapel</Author>
+              <Price>30.5</Price>
+              <!-- Won't be deserialized -->
+              <PublishYear>2023</PublishYear>
+            </Book>
+            """);
+
+        // The PublishYear property is not deserialized, so the property has its default value
+        Assert.That(result!.PublishYear, Is.EqualTo(0));
     }
 }

--- a/YAXLibTests/CustomTypeInspectorTests.cs
+++ b/YAXLibTests/CustomTypeInspectorTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using YAXLib;
+using YAXLib.Options;
+using YAXLibTests.SampleClasses;
+
+namespace YAXLibTests;
+public class CustomTypeInspectorTests
+{
+    internal class CustomTypeInspector : DefaultTypeInspector
+    {
+        public override IEnumerable<IMemberDescriptor> GetMembers(Type type, SerializerOptions options, bool includePrivateMembersFromBaseTypes)
+        {
+            var members = base.GetMembers(type, options, includePrivateMembersFromBaseTypes);
+            return members.Where(member => !string.Equals("PublishYear", member.Name, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    [Test]
+    public void SkipPublishYearPropertySerializationTest()
+    {
+        var serializer = new YAXSerializer<Book>(
+            new SerializerOptions
+            {
+                TypeInspector = new CustomTypeInspector()
+            });
+
+        var result = serializer.Serialize(Book.GetSampleInstance());
+
+        Assert.AreEqual(
+            """
+            <!-- This example demonstrates serializing a very simple class -->
+            <Book>
+              <Title>Inside C#</Title>
+              <Author>Tom Archer &amp; Andrew Whitechapel</Author>
+              <Price>30.5</Price>
+            </Book>
+            """, result);
+    }
+}

--- a/YAXLibTests/DeserializationTestBase.cs
+++ b/YAXLibTests/DeserializationTestBase.cs
@@ -779,6 +779,23 @@ public abstract class DeserializationTestBase
     }
 
     [Test]
+    public void Attribute_Option_DontSerializeDefaultValues_Should_Serialize_And_Deserialize()
+    {
+        var serializer =
+            CreateSerializer<SerializationOptionsSample.MissingElementsSample3>();
+
+        var record = new SerializationOptionsSample.MissingElementsSample3
+        { Id = 1234 }; // leave count property zero and count2 property null
+        var xml = serializer.Serialize(record);
+        var deserializedRecord = serializer.Deserialize(xml);
+
+        xml.Should().NotContain("rec_cnt", "0 integer should not be serialized");
+        xml.Should().NotContain("rec_cnt2", "null int? should not be serialized");
+        deserializedRecord.Should()
+            .BeEquivalentTo(record, "Missing elements should deserialize with default values");
+    }
+
+    [Test]
     public void DeserializeFromFile()
     {
         var book = Book.GetSampleInstance();

--- a/YAXLibTests/ReflectionUtilsTest.cs
+++ b/YAXLibTests/ReflectionUtilsTest.cs
@@ -199,4 +199,25 @@ public class ReflectionUtilsTest
         Assert.That(baseClassProperty1AfterSet, Is.EqualTo(113));
         Assert.That(baseClassProperty2AfterSet, Is.EqualTo(123));
     }
+
+    [Test]
+    public void GetDefaultValueTest()
+    {
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(string)), null));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(bool)), default(bool)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(char)), default(char)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(sbyte)), default(sbyte)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(byte)), default(byte)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(short)), default(short)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(ushort)), default(ushort)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(int)), default(int)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(uint)), default(uint)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(long)), default(long)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(ulong)), default(ulong)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(float)), default(float)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(double)), default(double)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(decimal)), default(decimal)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(DateTime)), default(DateTime)));
+        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(DBNull)), DBNull.Value));
+    }
 }

--- a/YAXLibTests/SampleClasses/SerializationOptionsSample.cs
+++ b/YAXLibTests/SampleClasses/SerializationOptionsSample.cs
@@ -93,4 +93,13 @@ in the serializer itself")]
         [YAXSerializeAs("cust_name")] public string? Name { get; set; }
         [YAXSerializeAs("option")] public int? Optional { get; set; }
     }
+
+    [YAXSerializeAs("my_record")]
+    [YAXSerializableType(Options = YAXSerializationOptions.DoNotSerializeDefaultValues)]
+    public class MissingElementsSample3
+    {
+        [YAXSerializeAs("rec_id")] public int Id { get; set; }
+        [YAXSerializeAs("rec_cnt")] public int Count { get; set; }
+        [YAXSerializeAs("rec_cnt2")] public int? Count2 { get; set; }
+    }
 }

--- a/YAXLibTests/SerializationContextTests.cs
+++ b/YAXLibTests/SerializationContextTests.cs
@@ -22,18 +22,14 @@ public class SerializationContextTests
         const string memberName = "Title";
         var serializer = new YAXSerializer(sampleType);
         var udtWrapper = serializer.UdtWrapper;
-        var memberInfo = udtWrapper.UnderlyingType.GetMember(memberName)[0];
+        var memberInfo = udtWrapper.UnderlyingType.GetMember(memberName)[0].Wrap();
         var memberWrapper = new MemberWrapper(memberInfo, serializer.Options);
         var sc = new SerializationContext(memberWrapper, udtWrapper, serializer);
 
         Assert.That(sc.SerializerOptions, Is.EqualTo(serializer.Options));
         Assert.That(sc.TypeContext.Type!.Name, Is.EqualTo(sampleType.Name));
         Assert.That(sc.MemberContext!.TypeContext!.Type.Name, Is.EqualTo(nameof(String)));
-        Assert.That(sc.MemberContext!.MemberInfo!.Name, Is.EqualTo(memberName));
-        Assert.That(
-            sc.MemberContext!.PropertyInfo != null
-                ? sc.MemberContext!.PropertyInfo!.Name
-                : sc.MemberContext!.FieldInfo!.Name, Is.EqualTo(memberName));
+        Assert.That(sc.MemberContext!.MemberDescriptor!.Name, Is.EqualTo(memberName));
     }
 
     [Test]
@@ -60,11 +56,11 @@ public class SerializationContextTests
 
         // Get the member context for the "Title" field
         var titleCtx = sc.TypeContext.GetFieldsForSerialization()
-            .FirstOrDefault(f => f.FieldInfo!.Name == nameof(FieldLevelSample.Title));
+            .FirstOrDefault(f => f.MemberDescriptor.Name == nameof(FieldLevelSample.Title));
 
         // Get the member context for the "Length" property of the "Title" field
         var lengthCtx = titleCtx!.TypeContext.GetFieldsForSerialization()
-            .FirstOrDefault(p => p.PropertyInfo!.Name == nameof(string.Length));
+            .FirstOrDefault(p => p.MemberDescriptor.Name == nameof(string.Length));
 
         Assert.That(sc.TypeContext.GetFieldsForSerialization().Count(), Is.EqualTo(3));
         Assert.That(sc.TypeContext.GetFieldsForDeserialization().Count(), Is.EqualTo(3));
@@ -90,7 +86,7 @@ public class SerializationContextTests
         var sampleType = typeof(ClassLevelSample);
         var serializer = new YAXSerializer(sampleType);
         var udtWrapper = serializer.UdtWrapper;
-        var memberInfo = udtWrapper.UnderlyingType.GetMember(memberName)[0];
+        var memberInfo = udtWrapper.UnderlyingType.GetMember(memberName)[0].Wrap();
         var memberWrapper = new MemberWrapper(memberInfo, serializer.Options);
         var data = new ClassLevelSample { Title = "The Title" };
         var sc = new SerializationContext(memberWrapper, udtWrapper, serializer);

--- a/YAXLibTests/SerializationTestBase.cs
+++ b/YAXLibTests/SerializationTestBase.cs
@@ -80,29 +80,29 @@ public abstract class SerializationTestBase
     {
         var options = new ParallelOptions { MaxDegreeOfParallelism = 10 };
 
+        var serializerOptions = new SerializerOptions
+        {
+            ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.DoNotThrow,
+            ExceptionBehavior = YAXExceptionTypes.Warning,
+            SerializationOptions = YAXSerializationOptions.SerializeNullObjects
+        };
+
         Assert.That(() =>
             Parallel.For(0L, 1000, options, (i, loopState) =>
             {
                 MemberWrapperCache.Instance.Clear();
                 UdtWrapperCache.Instance.Clear();
-                var serializer = CreateSerializer<Book>(new SerializerOptions {
-                    ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.DoNotThrow,
-                    ExceptionBehavior = YAXExceptionTypes.Warning,
-                    SerializationOptions = YAXSerializationOptions.SerializeNullObjects
-                });
+
+                var serializer = CreateSerializer<Book>();
                 var got = serializer.Serialize(Book.GetSampleInstance());
 
-                var deserializer = CreateSerializer<Book>(new SerializerOptions {
-                    ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.DoNotThrow,
-                    ExceptionBehavior = YAXExceptionTypes.Warning,
-                    SerializationOptions = YAXSerializationOptions.SerializeNullObjects
-                });
+                var deserializer = CreateSerializer<Book>(serializerOptions);
                 var book = deserializer.Deserialize(got) as Book;
                 Assert.That(book, Is.Not.Null);
             }), Throws.Nothing);
 
-        Assert.That(MemberWrapperCache.Instance.CacheDictionary, Contains.Key(typeof(Book)));
-        Assert.That(UdtWrapperCache.Instance.CacheDictionary, Contains.Key(typeof(Book)));
+        Assert.That(MemberWrapperCache.Instance.CacheDictionary, Contains.Key((typeof(Book), serializerOptions)));
+        Assert.That(UdtWrapperCache.Instance.CacheDictionary, Contains.Key((typeof(Book), serializerOptions)));
     }
 
     [Test]
@@ -123,6 +123,34 @@ public abstract class SerializationTestBase
         });
         var got = serializer.Serialize(SimpleBookClassWithDecimalPrice.GetSampleInstance());
         Assert.That(got, Is.EqualTo(result));
+    }
+
+    [Test]
+    public void BookWithDefaultValue()
+    {
+        var book = Book.GetSampleInstance();
+        book.PublishYear = 0;
+
+        var serializer = CreateSerializer<Book>(new SerializerOptions
+        {
+            ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.DoNotThrow,
+            ExceptionBehavior = YAXExceptionTypes.Warning,
+            SerializationOptions = YAXSerializationOptions.DoNotSerializeDefaultValues
+        });
+
+        var got = serializer.Serialize(book);
+        var gotDes = (Book?) serializer.Deserialize(got);
+
+        Assert.AreEqual(book, gotDes);
+        Assert.AreEqual(
+            """
+            <!-- This example demonstrates serializing a very simple class -->
+            <Book>
+              <Title>Inside C#</Title>
+              <Author>Tom Archer &amp; Andrew Whitechapel</Author>
+              <Price>30.5</Price>
+            </Book>
+            """, got);
     }
 
     [TestCase("fr-FR")]

--- a/YAXLibTests/SerializationTestBase.cs
+++ b/YAXLibTests/SerializationTestBase.cs
@@ -129,7 +129,7 @@ public abstract class SerializationTestBase
     public void BookWithDefaultValue()
     {
         var book = Book.GetSampleInstance();
-        book.PublishYear = 0;
+        book.PublishYear = 0; // this default value should not get serialized
 
         var serializer = CreateSerializer<Book>(new SerializerOptions
         {
@@ -141,8 +141,8 @@ public abstract class SerializationTestBase
         var got = serializer.Serialize(book);
         var gotDes = (Book?) serializer.Deserialize(got);
 
-        Assert.AreEqual(book, gotDes);
-        Assert.AreEqual(
+        Assert.That(book, Is.EqualTo(gotDes));
+        Assert.That(got, Is.EqualTo(
             """
             <!-- This example demonstrates serializing a very simple class -->
             <Book>
@@ -150,7 +150,7 @@ public abstract class SerializationTestBase
               <Author>Tom Archer &amp; Andrew Whitechapel</Author>
               <Price>30.5</Price>
             </Book>
-            """, got);
+            """));
     }
 
     [TestCase("fr-FR")]

--- a/YAXLibTests/TestHelpers/PoolingHelpers.cs
+++ b/YAXLibTests/TestHelpers/PoolingHelpers.cs
@@ -35,7 +35,7 @@ public class PoolingHelpers
         // get pools
         var poolTypes = GetSubclassesOf(typeof(PoolBase<>).Assembly, typeof(PoolBase<>));
 
-        foreach (var poolType in poolTypes)
+        foreach (var poolType in poolTypes.Concat(PoolRegistry.Items.Keys).Distinct())
         {
             dynamic? instance = poolType.GetProperty("Instance")?.GetValue(null, null);
             instance?.Pool.Clear();

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -4,7 +4,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../Key/YAXLib.Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <nullable>enable</nullable>
   </PropertyGroup>


### PR DESCRIPTION
### What's Changed

1. Add the **DoNotSerializeDefaultValues** option to **YAXSerializationOptions**.
2. Add the **TypeInspector** property to **SerializerOptions**.
3. Mark **PropertyInfo**, **FieldInfo**, and **MemberInfo** properties as obsolete in **IMemberContext**.
4. Add the **MemberDescriptor** property to **IMemberContext** as a replacement for deprecated properties.
5. Miscellaneous:
   * Update MemberWrapperCache and UdtWrapperCache: cache the type by type and SerializerOptions.
   * Remove usage of Lazy<T> & ThreadLocal<T> as they complicate using serializer in Debug mode [ "The function evaluation requires all threads to run"](https://stackoverflow.com/questions/4460206/lazyt-the-function-evaluation-requires-all-threads-to-run).
