### PR TITLE
Add option MarkNullOrEmpty to enhance the nullRef

### DIFF
--- a/YAXLib.lutconfig
+++ b/YAXLib.lutconfig
@@ -1,0 +1,6 @@
+<LUTConfig Version="1.0">
+  <Repository />
+  <ParallelBuilds>true</ParallelBuilds>
+  <ParallelTestRuns>true</ParallelTestRuns>
+  <TestCaseTimeout>180000</TestCaseTimeout>
+</LUTConfig>

--- a/YAXLib/Enums/YAXSerializationOptions.cs
+++ b/YAXLib/Enums/YAXSerializationOptions.cs
@@ -62,5 +62,10 @@ public enum YAXSerializationOptions
     /// <summary>
     /// Prevents serialization of default values.
     /// </summary>
-    DoNotSerializeDefaultValues = 128
+    DoNotSerializeDefaultValues = 128,
+    /// <summary>
+    /// Add attribut to Null object :  _MarkNullOrEmpty="NULL"
+    /// Add attribut to Empty Array:  _MarkNullOrEmpty="EMPTY"
+    /// </summary>
+    MarkNullOrEmpty = 256,
 }

--- a/YAXLib/Exceptions/YAXOptionConflictException.cs
+++ b/YAXLib/Exceptions/YAXOptionConflictException.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace YAXLib.Exceptions;
+/// <summary>
+/// Raised When the YAXSerializationOptions conflictes
+/// </summary>
+public class YAXOptionConflictException : YAXException
+{
+    string _msg;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="YAXOptionConflictException" /> class.
+    /// </summary>
+    /// <param name="message"></param>
+    public YAXOptionConflictException(string message) : base(message)
+    {
+        _msg = message;
+    }
+    /// <summary>
+    /// Gets a message that describes the current exception.
+    /// </summary>
+    public override string Message => _msg;
+}

--- a/YAXLib/Serialization.cs
+++ b/YAXLib/Serialization.cs
@@ -772,13 +772,15 @@ internal class Serialization
             {
                 elemToAdd.Add(new XAttribute("_MarkNullOrEmpty", "NULL"));
             }
-            if (elementValue is ICollection ValueAsIColl)
+
+            if (member.UdtWrapper.IsTreatedAsCollection)
             {
-                if (ValueAsIColl.Count == 0)
+                var ValueAsIColl = elementValue as ICollection;
+                if (ValueAsIColl?.Count == 0)
                 {
                     elemToAdd.Add(new XAttribute("_MarkNullOrEmpty", "EMPTY"));
                 }
-            } 
+            }
         }
 
         return elemToAdd;

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -197,6 +197,10 @@ internal class UdtWrapper
         (SerializationOptions & YAXSerializationOptions.DontSerializeNullObjects) ==
         YAXSerializationOptions.DontSerializeNullObjects;
 
+    public bool IsMarkNullOrEmpty =>
+        (SerializationOptions & YAXSerializationOptions.MarkNullOrEmpty) ==
+        YAXSerializationOptions.MarkNullOrEmpty;
+
     /// <summary>
     /// Determines whether serialization of default values is not allowed.
     /// </summary>

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -54,6 +54,7 @@ public class YAXSerializer : IYAXSerializer<object>, IRecursionCounter
     internal void Initialize(Type t, SerializerOptions options)
     {
         Type = t;
+        CheckOption(options);
         Options = options;
         DocumentDefaultNamespace = XNamespace.None;
 
@@ -64,7 +65,23 @@ public class YAXSerializer : IYAXSerializer<object>, IRecursionCounter
         if (UdtWrapper.HasNamespace)
             TypeNamespace = UdtWrapper.Namespace;
     }
-
+    internal void CheckOption(SerializerOptions options)
+    {
+        if (OptContains(YAXSerializationOptions.MarkNullOrEmpty))
+        {
+            if (OptContains(YAXSerializationOptions.DontSerializeNullObjects))
+            {
+                var errmsg = $"YAXSerializationOptions.MarkNullOrEmpty  confilicts with YAXSerializationOptions.DontSerializeNullObjects";
+                throw new YAXOptionConflictException(errmsg);
+            }
+        }
+        return;
+        bool OptContains(YAXSerializationOptions target)
+        {
+            var rst = (options.SerializationOptions & target) == target;
+            return rst;
+        }
+    }
     /// <summary>
     /// Pre-initializes this instance so that it prepared for calling
     /// <see cref="Initialize(System.Type,SerializerOptions)" /> after it is

--- a/YAXLibTests/OptionMarkNullOrEmptyTests.cs
+++ b/YAXLibTests/OptionMarkNullOrEmptyTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions.Execution;
 using NUnit.Framework;
 using YAXLib;
 using YAXLib.Customization;
@@ -25,6 +27,10 @@ public class OptionMarkNullOrEmptyTests
         public List<int> TheCollection01 { get; set; }
         public List<int> TheCollection02 { get; set; }
 
+        public int[] IntArr01 { get; set; } = new int[0];
+        public int[] IntArr02 { get; set; } = null;
+
+
         public static NullableSample4 GetSampleInstance()
         {
             return new()
@@ -33,8 +39,11 @@ public class OptionMarkNullOrEmptyTests
                 Text02 = null,
                 TheCollection01 = new List<int> { },
                 TheCollection02 = null,
+                IntArr01 = new int[0],
+                IntArr02 = null,
             };
         }
+
     }
     [Test]
     public void Serialize01()
@@ -45,6 +54,8 @@ public class OptionMarkNullOrEmptyTests
                   <Text02 _MarkNullOrEmpty="NULL" />
                   <TheCollection01 _MarkNullOrEmpty="EMPTY" />
                   <TheCollection02 _MarkNullOrEmpty="NULL" />
+                  <IntArr01 _MarkNullOrEmpty="EMPTY" />
+                  <IntArr02 _MarkNullOrEmpty="NULL" />
                 </NullableSample4>
                 """;
 
@@ -53,9 +64,9 @@ public class OptionMarkNullOrEmptyTests
             SerializationOptions = YAXSerializationOptions.MarkNullOrEmpty
         });
         var instance = NullableSample4.GetSampleInstance();
-        var got = serializer.Serialize(instance); 
+        var got = serializer.Serialize(instance);
         Assert.AreEqual(got, result);
     }
 
- 
+
 }

--- a/YAXLibTests/OptionMarkNullOrEmptyTests.cs
+++ b/YAXLibTests/OptionMarkNullOrEmptyTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using YAXLib;
 using YAXLib.Customization;
 using YAXLib.Enums;
+using YAXLib.Exceptions;
 using YAXLib.Options;
 using YAXLibTests.SampleClasses;
 
@@ -67,6 +68,61 @@ public class OptionMarkNullOrEmptyTests
         var got = serializer.Serialize(instance);
         Assert.AreEqual(got, result);
     }
+
+    [Test]
+    public void Deserialize01()
+    {
+        const string xmlInput = """
+                <NullableSample4>
+                  <Text01/>
+                  <Text02 _MarkNullOrEmpty="NULL"/>
+                  <TheCollection01 _MarkNullOrEmpty="EMPTY" />
+                  <TheCollection02 _MarkNullOrEmpty="NULL" />
+                  <IntArr01 _MarkNullOrEmpty="EMPTY" />
+                  <IntArr02 _MarkNullOrEmpty="NULL" />
+                </NullableSample4>
+                """;
+
+        var serializer = new YAXSerializer<NullableSample4>(new SerializerOptions
+        {
+            SerializationOptions = YAXSerializationOptions.MarkNullOrEmpty
+        });
+        var got = serializer.Deserialize(xmlInput); 
+        Assert.AreEqual("",got.Text01,  nameof(got.Text01));
+        Assert.AreEqual(null, got.Text02,  nameof(got.Text02));
+        Assert.AreEqual(0, got.TheCollection01?.Count, nameof(got.TheCollection01));
+        Assert.AreEqual(null, got.TheCollection02, nameof(got.TheCollection02));
+        Assert.AreEqual(0, got.IntArr01?.Length,  nameof(got.IntArr01));
+        Assert.AreEqual(null, got.IntArr02, nameof(got.IntArr02));
+    }
+    [Test]
+    public void Deserialize02()
+    {
+        const string xmlInput = """
+                <NullableSample4>
+                  <Text01></Text01>
+                  <Text02 _MarkNullOrEmpty="NULL" > </Text02>
+                  <TheCollection01 _MarkNullOrEmpty="EMPTY"></TheCollection01>
+                  <TheCollection02 _MarkNullOrEmpty="NULL" ></TheCollection02>
+                  <IntArr01 _MarkNullOrEmpty="EMPTY"></IntArr01>
+                  <IntArr02 _MarkNullOrEmpty="NULL" ></IntArr02>
+                </NullableSample4>
+                """;
+
+        var serializer = new YAXSerializer<NullableSample4>(new SerializerOptions
+        {
+            SerializationOptions = YAXSerializationOptions.MarkNullOrEmpty
+        });
+        var got = serializer.Deserialize(xmlInput);
+        Assert.IsNotNull(got);
+        Assert.AreEqual("", got.Text01, nameof(got.Text01));
+        Assert.AreEqual(null, got.Text02, nameof(got.Text02));
+        Assert.AreEqual(0, got.TheCollection01?.Count, nameof(got.TheCollection01));
+        Assert.AreEqual(null, got.TheCollection02, nameof(got.TheCollection02));
+        Assert.AreEqual(0, got.IntArr01?.Length, nameof(got.IntArr01));
+        Assert.AreEqual(null, got.IntArr02, nameof(got.IntArr02));
+    }
+
 
     [Test] 
     public void TestOptionConflictCheck()

--- a/YAXLibTests/OptionMarkNullOrEmptyTests.cs
+++ b/YAXLibTests/OptionMarkNullOrEmptyTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using YAXLib;
+using YAXLib.Customization;
+using YAXLib.Enums;
+using YAXLib.Options;
+using YAXLibTests.SampleClasses;
+
+namespace YAXLibTests;
+
+[TestFixture]
+public class OptionMarkNullOrEmptyTests
+{
+    /// <summary>
+    /// Testing for  option of YAXSerializationOptions.MarkNullOrEmpty
+    /// </summary> 
+    public class NullableSample4
+    {
+        public string? Text01 { get; set; }
+        public string? Text02 { get; set; }
+        public List<int> TheCollection01 { get; set; }
+        public List<int> TheCollection02 { get; set; }
+
+        public static NullableSample4 GetSampleInstance()
+        {
+            return new()
+            {
+                Text01 = "",
+                Text02 = null,
+                TheCollection01 = new List<int> { },
+                TheCollection02 = null,
+            };
+        }
+    }
+    [Test]
+    public void Serialize01()
+    {
+        const string result = """
+                <NullableSample4>
+                  <Text01></Text01>
+                  <Text02 _MarkNullOrEmpty="NULL" />
+                  <TheCollection01 _MarkNullOrEmpty="EMPTY" />
+                  <TheCollection02 _MarkNullOrEmpty="NULL" />
+                </NullableSample4>
+                """;
+
+        var serializer = new YAXSerializer<NullableSample4>(new SerializerOptions
+        {
+            SerializationOptions = YAXSerializationOptions.MarkNullOrEmpty
+        });
+        var instance = NullableSample4.GetSampleInstance();
+        var got = serializer.Serialize(instance); 
+        Assert.AreEqual(got, result);
+    }
+
+ 
+}

--- a/YAXLibTests/OptionMarkNullOrEmptyTests.cs
+++ b/YAXLibTests/OptionMarkNullOrEmptyTests.cs
@@ -68,5 +68,20 @@ public class OptionMarkNullOrEmptyTests
         Assert.AreEqual(got, result);
     }
 
+    [Test] 
+    public void TestOptionConflictCheck()
+    {
+        var instance = NullableSample4.GetSampleInstance();
+
+        Assert.Throws<YAXOptionConflictException>(() =>
+        {
+            var serializer = new YAXSerializer<NullableSample4>(new SerializerOptions
+            {
+                SerializationOptions = YAXSerializationOptions.MarkNullOrEmpty | YAXSerializationOptions.DontSerializeNullObjects
+            });
+            var got = serializer.Serialize(instance);
+        });
+
+    }
 
 }


### PR DESCRIPTION
null or empty   element will be marked  to enhance the prev solution "Preserving Null-References Identity"

```csharp
    public class NullableSample4
    {
        public string? Text01 { get; set; }
        public string? Text02 { get; set; }
        public List<int> TheCollection01 { get; set; }
        public List<int> TheCollection02 { get; set; }

        public int[] IntArr01 { get; set; } = new int[0];
        public int[] IntArr02 { get; set; } = null;


        public static NullableSample4 GetSampleInstance()
        {
            return new()
            {
                Text01 = "",
                Text02 = null,
                TheCollection01 = new List<int> { },
                TheCollection02 = null,
                IntArr01 = new int[0],
                IntArr02 = null,
            };
        }

    }
```
Using it
```csharp
        var serializer = new YAXSerializer<NullableSample4>(new SerializerOptions
        {
            SerializationOptions = YAXSerializationOptions.MarkNullOrEmpty
        });
        var instance = NullableSample4.GetSampleInstance();
        var got = serializer.Serialize(instance);
```

The result will be
```xml

<NullableSample4>
    <Text01></Text01>
    <Text02 _MarkNullOrEmpty="NULL" />
    <TheCollection01 _MarkNullOrEmpty="EMPTY" />
    <TheCollection02 _MarkNullOrEmpty="NULL" />
    <IntArr01 _MarkNullOrEmpty="EMPTY" />
    <IntArr02 _MarkNullOrEmpty="NULL" />
</NullableSample4>

```