### PR TITLE
Preserve instance reference relationships by tagging instance IDs

### DIFF
--- a/YAXLib/Deserialization.cs
+++ b/YAXLib/Deserialization.cs
@@ -154,8 +154,8 @@ internal class Deserialization
         var resultObject = _deserializationObject ?? Activator.CreateInstance(_serializer.Type, Array.Empty<object>());
 
         if (_serializer.UdtWrapper.IsMarkObjId2AvertSefRef)
-        {
-            var objId = baseElement.GetObjIdFromAttribute();
+        { 
+            var objId = baseElement.GetRefObjId() ?? baseElement.GetMarkObjId();
             if (objId != null)
             {
                 if (_serializer.Session.ObjDict.TryGetObj(objId.Value, out object savedInstance))

--- a/YAXLib/Enums/YAXSerializationOptions.cs
+++ b/YAXLib/Enums/YAXSerializationOptions.cs
@@ -62,5 +62,9 @@ public enum YAXSerializationOptions
     /// <summary>
     /// Prevents serialization of default values.
     /// </summary>
-    DoNotSerializeDefaultValues = 128
+    DoNotSerializeDefaultValues = 128,
+    /// <summary>
+    /// Each object is marked number to Prevents that cycle references from child to parent objects cause an infinite loop.
+    /// </summary>
+    MarkObjId2AvertSefRef = 512,
 }

--- a/YAXLib/MarkObjWithId/DictObjWithId.cs
+++ b/YAXLib/MarkObjWithId/DictObjWithId.cs
@@ -13,11 +13,7 @@ using System.Xml.Linq;
 
 namespace YAXLib.MarkObjWithId;
 internal class DictObjWithId
-{
-    public const string ATTR_FLAG_OBJID = "_ObjId";
-
-
-
+{ 
     public Dictionary<int, object> _dict = new();
 
     internal int NextObjIdx = 1000;

--- a/YAXLib/MarkObjWithId/DictObjWithId.cs
+++ b/YAXLib/MarkObjWithId/DictObjWithId.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization.Formatters;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml.Linq;
+
+namespace YAXLib.MarkObjWithId;
+internal class DictObjWithId
+{
+    public const string ATTR_FLAG_OBJID = "_ObjId";
+
+
+
+    public Dictionary<int, object> _dict = new();
+
+    internal int NextObjIdx = 1000;
+    public int GetOrNewIdx(object objTarget)
+    {
+        Debug.Assert(objTarget != null);
+        var kv = _dict.SingleOrDefault(x => ReferenceEquals(x.Value, objTarget));
+        if (kv.Value != null)
+            return kv.Key;
+        var newidx = NextObjIdx++;
+        _dict.Add(newidx, objTarget);
+        return newidx;
+    }
+    public int? GetObjIdx(object objTarget)
+    {
+        Debug.Assert(objTarget != null);
+        var kv = _dict.SingleOrDefault(x => ReferenceEquals(x.Value, objTarget));
+        if (kv.Value != null)
+            return kv.Key;
+        return null;
+    }
+
+    internal void Clear()
+    {
+        _dict.Clear();
+    }
+
+    internal bool TryGetObj(int objId, out object resultObject) => _dict.TryGetValue(objId, out resultObject);
+
+    internal void SaveObj(int objId, object resultObject)
+    {
+        _dict.Add(objId, resultObject);
+    }
+
+}

--- a/YAXLib/MarkObjWithId/SerSession.cs
+++ b/YAXLib/MarkObjWithId/SerSession.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+namespace YAXLib.MarkObjWithId;
+
+internal class SerSession
+{
+    public readonly DictObjWithId ObjDict = new DictObjWithId();
+
+    public void Reset()
+    {
+        ObjDict.Clear();
+    }
+}

--- a/YAXLib/MarkObjWithId/Xmlhelper.cs
+++ b/YAXLib/MarkObjWithId/Xmlhelper.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace YAXLib.MarkObjWithId;
+
+internal static class Xmlhelper
+{
+
+
+    public static string ATTR_FLAG_OBJID => DictObjWithId.ATTR_FLAG_OBJID;
+    /// <summary>
+    /// Only the repeated ObjId is keept
+    /// </summary>
+    /// <param name="mainDocument"></param>
+    /// <returns></returns>
+    internal static XDocument ClearUnNecessaryObjId(this XDocument mainDocument)
+    {
+        var root = mainDocument.Root;
+        var ItemArr = CollectItems(root, new List<ObjIdItem>());
+        var group = ItemArr.GroupBy(x => x.ObjId, (idx, parents) => (ID: idx, CNT: parents.Count())).ToList();
+        var IdToDelArr = group.Where(x => x.CNT == 1).Select(x => x.ID).ToList();
+        ItemArr.Where(item => IdToDelArr.Exists(id => id == item.ObjId))
+            .ToList()
+            .ForEach(item => item.Parent.Attribute(ATTR_FLAG_OBJID).Remove());
+
+        return mainDocument;
+
+
+        List<ObjIdItem> CollectItems(XElement xelement, List<ObjIdItem> ItemArr)
+        {
+            var attr = xelement.Attribute(ATTR_FLAG_OBJID);
+            if (attr != null)
+                ItemArr.Add(new ObjIdItem { Parent = xelement, ObjId = int.Parse(attr.Value) });
+            foreach (var xe in xelement.Elements())
+                ItemArr = CollectItems(xe, ItemArr);
+            return ItemArr;
+        }
+    }
+
+    class ObjIdItem
+    {
+        public int ObjId { get; set; }
+        public XElement Parent { get; set; }
+
+    }
+
+
+    static public bool ShouldMarkObjId(this MemberWrapper member)
+    {
+        var memtype = member.MemberType;
+        if (memtype.IsValueType)
+            return false;
+        if (!member.IsSerializedAsElement)
+            return false;
+
+        if (memtype.FullName == "System.String")
+            return false;
+        return true;
+
+    }
+    static public bool ShouldMarkObjId(this Type memtype)
+    { 
+        if (memtype.IsValueType)
+            return false; 
+
+        if (memtype.FullName == "System.String")
+            return false;
+        return true;
+
+    }
+
+    public static int? GetObjIdFromAttribute(this XElement? xe)
+    {
+        var attr = xe?.Attribute(DictObjWithId.ATTR_FLAG_OBJID);
+        if (attr == null)
+        {
+            return null;
+        }
+        var rst = Int32.Parse(attr.Value);
+        return rst;
+    }
+
+    public static bool IsNullXmlNode(this XElement xe)
+    {
+        var attributCnt = xe.Attributes().Select(x => x.Name.LocalName)
+            .Except(new List<string> { ATTR_FLAG_OBJID }).Count();
+        var isEmpty = xe.IsEmpty;
+        var HasElements = xe.HasElements;
+
+        return attributCnt == 0 && isEmpty && !HasElements;
+    }
+}
+

--- a/YAXLib/MarkObjWithId/Xmlhelper.cs
+++ b/YAXLib/MarkObjWithId/Xmlhelper.cs
@@ -10,7 +10,11 @@ namespace YAXLib.MarkObjWithId;
 
 internal static class Xmlhelper
 {
-    public static string ATTR_FLAG_OBJID ="_ObjId";
+//    public static string ATTR_FLAG_MARK_OBJID = "yaxlib:id";
+//    public static string ATTR_FLAG_REF_OBJID = "yaxlib:ref";
+    public readonly static XNamespace YaxlibNamespace = "http://www.sinairv.com/yaxlib/";
+    public readonly static string PrefixNamespace = "yaxlib";
+    readonly static XName OBJID_ELEMENT_NAME = XName.Get("id", YaxlibNamespace.ToString());
 
     /// <summary>
     /// Only the repeated ObjId is keept
@@ -19,20 +23,22 @@ internal static class Xmlhelper
     /// <returns></returns>
     internal static XDocument ClearUnNecessaryObjId(this XDocument mainDocument)
     {
+
+
         var root = mainDocument.Root;
         var ItemArr = CollectItems(root, new List<ObjIdItem>());
         var group = ItemArr.GroupBy(x => x.ObjId, (idx, parents) => (ID: idx, CNT: parents.Count())).ToList();
         var IdToDelArr = group.Where(x => x.CNT == 1).Select(x => x.ID).ToList();
         ItemArr.Where(item => IdToDelArr.Exists(id => id == item.ObjId))
             .ToList()
-            .ForEach(item => item.Parent.Attribute(ATTR_FLAG_OBJID).Remove());
+            .ForEach(item => item.Parent.Attribute(OBJID_ELEMENT_NAME).Remove());
 
         return mainDocument;
 
 
         List<ObjIdItem> CollectItems(XElement xelement, List<ObjIdItem> ItemArr)
         {
-            var attr = xelement.Attribute(ATTR_FLAG_OBJID);
+            var attr = xelement.Attribute(OBJID_ELEMENT_NAME);
             if (attr != null)
                 ItemArr.Add(new ObjIdItem { Parent = xelement, ObjId = int.Parse(attr.Value) });
             foreach (var xe in xelement.Elements())
@@ -63,9 +69,9 @@ internal static class Xmlhelper
 
     }
     static public bool ShouldMarkObjId(this Type memtype)
-    { 
+    {
         if (memtype.IsValueType)
-            return false; 
+            return false;
 
         if (memtype.FullName == "System.String")
             return false;
@@ -73,9 +79,19 @@ internal static class Xmlhelper
 
     }
 
-    public static int? GetObjIdFromAttribute(this XElement? xe)
+    public static int? GetRefObjId(this XElement? xe)
     {
-        var attr = xe?.Attribute(Xmlhelper.ATTR_FLAG_OBJID);
+        var attr = xe?.Attribute(OBJID_ELEMENT_NAME);
+        if (attr == null)
+        {
+            return null;
+        }
+        var rst = Int32.Parse(attr.Value);
+        return rst;
+    }
+    public static int? GetMarkObjId(this XElement? xe)
+    {
+        var attr = xe?.Attribute(OBJID_ELEMENT_NAME);
         if (attr == null)
         {
             return null;
@@ -84,10 +100,87 @@ internal static class Xmlhelper
         return rst;
     }
 
+    public static void AddAttribute_MarkObjId(this XElement xe, int objId, YAXSerializer _serializer)
+    {
+        _serializer.XmlNamespaceManager.RegisterNamespace(YaxlibNamespace, PrefixNamespace);
+        xe.Add(new XAttribute(YaxlibNamespace + "id", objId));
+
+        /*
+        //_serializer.XmlNamespaceManager.RegisterNamespace(YaxlibNamespace, PrefixNamespace);
+
+
+        XElement root = xe;
+        {
+
+            while (root.Parent != null)
+            {
+                root = root.Parent;
+            }
+        }
+
+        root.Add(new XAttribute(XNamespace.Xmlns + "yaxlib", YaxlibNamespace.ToString()));
+
+        xe.Add(
+               new XAttribute(YaxlibNamespace + "id", objId)
+            );
+
+        Console.WriteLine(xe);
+        */
+
+
+        /*
+        XNamespace ns = "http://www.sinairv.com/yaxlib/";
+
+         
+
+        xe.Add(new XAttribute(XNamespace.Xmlns + "yaxlib", ns.ToString()),
+               new XAttribute(ns + "id", objId)
+            ); 
+
+        Console.WriteLine(xe);
+        */
+
+        /*
+        XNamespace aw = "http://www.adventure-works.com";
+        XElement root = new XElement(aw + "Root",
+            new XAttribute(XNamespace.Xmlns + "aw", "http://www.adventure-works.com"),
+            new XElement(aw + "Child", "child content")
+        );
+        Console.WriteLine(root);
+        */
+        /*
+
+        XNamespace ns = "http://www.sinairv.com/yaxlib/";      
+        xmlNamespaceManager.RegisterNamespace(ns, "yaxlib");
+
+        XElement root = xe;
+        {
+            
+            while (root.Parent != null)
+            {
+                root = root.Parent;
+            }
+        }
+        xe.Add(new XAttribute(XNamespace.Xmlns + "yaxlib", "http://www.adventure-works.com"),
+               new XAttribute(ns + "id", $"{objId}")            
+            );
+
+        //elem.Add(new XAttribute(Xmlhelper.ATTR_FLAG_MARK_OBJID, id));
+       // var xatt = new XAttribute(ns + "id", $"{objId}");
+      //  xe.Add(xatt);
+
+        */
+    }
+    public static void Attribute_RefObjId(this XElement xe, int objId)
+    {
+
+    }
     public static bool IsNullXmlNode(this XElement xe)
     {
-        var attributCnt = xe.Attributes().Select(x => x.Name.LocalName)
-            .Except(new List<string> { ATTR_FLAG_OBJID }).Count();
+       // var debug = xe.Attributes().Select(x => x.Name.NamespaceName).ToList();
+        var attributCnt = xe.Attributes()
+            .Where(x=>x.Name.NamespaceName!= YaxlibNamespace)
+            .Count();
         var isEmpty = xe.IsEmpty;
         var HasElements = xe.HasElements;
 

--- a/YAXLib/MarkObjWithId/Xmlhelper.cs
+++ b/YAXLib/MarkObjWithId/Xmlhelper.cs
@@ -10,8 +10,6 @@ namespace YAXLib.MarkObjWithId;
 
 internal static class Xmlhelper
 {
-//    public static string ATTR_FLAG_MARK_OBJID = "yaxlib:id";
-//    public static string ATTR_FLAG_REF_OBJID = "yaxlib:ref";
     public readonly static XNamespace YaxlibNamespace = "http://www.sinairv.com/yaxlib/";
     public readonly static string PrefixNamespace = "yaxlib";
     readonly static XName OBJID_ELEMENT_NAME = XName.Get("id", YaxlibNamespace.ToString());
@@ -103,73 +101,7 @@ internal static class Xmlhelper
     public static void AddAttribute_MarkObjId(this XElement xe, int objId, YAXSerializer _serializer)
     {
         _serializer.XmlNamespaceManager.RegisterNamespace(YaxlibNamespace, PrefixNamespace);
-        xe.Add(new XAttribute(YaxlibNamespace + "id", objId));
-
-        /*
-        //_serializer.XmlNamespaceManager.RegisterNamespace(YaxlibNamespace, PrefixNamespace);
-
-
-        XElement root = xe;
-        {
-
-            while (root.Parent != null)
-            {
-                root = root.Parent;
-            }
-        }
-
-        root.Add(new XAttribute(XNamespace.Xmlns + "yaxlib", YaxlibNamespace.ToString()));
-
-        xe.Add(
-               new XAttribute(YaxlibNamespace + "id", objId)
-            );
-
-        Console.WriteLine(xe);
-        */
-
-
-        /*
-        XNamespace ns = "http://www.sinairv.com/yaxlib/";
-
-         
-
-        xe.Add(new XAttribute(XNamespace.Xmlns + "yaxlib", ns.ToString()),
-               new XAttribute(ns + "id", objId)
-            ); 
-
-        Console.WriteLine(xe);
-        */
-
-        /*
-        XNamespace aw = "http://www.adventure-works.com";
-        XElement root = new XElement(aw + "Root",
-            new XAttribute(XNamespace.Xmlns + "aw", "http://www.adventure-works.com"),
-            new XElement(aw + "Child", "child content")
-        );
-        Console.WriteLine(root);
-        */
-        /*
-
-        XNamespace ns = "http://www.sinairv.com/yaxlib/";      
-        xmlNamespaceManager.RegisterNamespace(ns, "yaxlib");
-
-        XElement root = xe;
-        {
-            
-            while (root.Parent != null)
-            {
-                root = root.Parent;
-            }
-        }
-        xe.Add(new XAttribute(XNamespace.Xmlns + "yaxlib", "http://www.adventure-works.com"),
-               new XAttribute(ns + "id", $"{objId}")            
-            );
-
-        //elem.Add(new XAttribute(Xmlhelper.ATTR_FLAG_MARK_OBJID, id));
-       // var xatt = new XAttribute(ns + "id", $"{objId}");
-      //  xe.Add(xatt);
-
-        */
+        xe.Add(new XAttribute(OBJID_ELEMENT_NAME, objId));
     }
     public static void Attribute_RefObjId(this XElement xe, int objId)
     {

--- a/YAXLib/MarkObjWithId/Xmlhelper.cs
+++ b/YAXLib/MarkObjWithId/Xmlhelper.cs
@@ -10,9 +10,8 @@ namespace YAXLib.MarkObjWithId;
 
 internal static class Xmlhelper
 {
+    public static string ATTR_FLAG_OBJID ="_ObjId";
 
-
-    public static string ATTR_FLAG_OBJID => DictObjWithId.ATTR_FLAG_OBJID;
     /// <summary>
     /// Only the repeated ObjId is keept
     /// </summary>
@@ -76,7 +75,7 @@ internal static class Xmlhelper
 
     public static int? GetObjIdFromAttribute(this XElement? xe)
     {
-        var attr = xe?.Attribute(DictObjWithId.ATTR_FLAG_OBJID);
+        var attr = xe?.Attribute(Xmlhelper.ATTR_FLAG_OBJID);
         if (attr == null)
         {
             return null;

--- a/YAXLib/Serialization.cs
+++ b/YAXLib/Serialization.cs
@@ -67,6 +67,7 @@ internal class Serialization
         if (_serializer.UdtWrapper.IsMarkObjId2AvertSefRef)
         {
             _mainDocument = _mainDocument.ClearUnNecessaryObjId();
+            _mainDocument = _mainDocument.FixObjIdToRef();
             _serializer.Session.Reset();
         }
 

--- a/YAXLib/Serialization.cs
+++ b/YAXLib/Serialization.cs
@@ -1247,7 +1247,7 @@ internal class Serialization
             if (id != null && value != null)
             {
                 XElement nullElem = new XElement(name);
-                nullElem.Add(new XAttribute(DictObjWithId.ATTR_FLAG_OBJID, id));
+                nullElem.Add(new XAttribute(Xmlhelper.ATTR_FLAG_OBJID, id));
                 return nullElem;
             }
         }
@@ -1273,7 +1273,7 @@ internal class Serialization
             if (value != null && value.GetType().ShouldMarkObjId())
             {
                 var id = _serializer.Session.ObjDict.GetOrNewIdx(value);
-                elem.Add(new XAttribute(DictObjWithId.ATTR_FLAG_OBJID, id));
+                elem.Add(new XAttribute(Xmlhelper.ATTR_FLAG_OBJID, id));
             }
         }
 

--- a/YAXLib/Serialization.cs
+++ b/YAXLib/Serialization.cs
@@ -1247,7 +1247,8 @@ internal class Serialization
             if (id != null && value != null)
             {
                 XElement nullElem = new XElement(name);
-                nullElem.Add(new XAttribute(Xmlhelper.ATTR_FLAG_OBJID, id));
+          //      nullElem.Add(new XAttribute(Xmlhelper.ATTR_FLAG_REF_OBJID, id));
+                nullElem.AddAttribute_MarkObjId(id.Value, _serializer);
                 return nullElem;
             }
         }
@@ -1272,8 +1273,9 @@ internal class Serialization
         {
             if (value != null && value.GetType().ShouldMarkObjId())
             {
+                
                 var id = _serializer.Session.ObjDict.GetOrNewIdx(value);
-                elem.Add(new XAttribute(Xmlhelper.ATTR_FLAG_OBJID, id));
+                elem.AddAttribute_MarkObjId(id, _serializer );
             }
         }
 

--- a/YAXLib/Serialization.cs
+++ b/YAXLib/Serialization.cs
@@ -12,6 +12,7 @@ using YAXLib.Caching;
 using YAXLib.Customization;
 using YAXLib.Enums;
 using YAXLib.Exceptions;
+using YAXLib.MarkObjWithId;
 using YAXLib.Pooling.SpecializedPools;
 
 namespace YAXLib;
@@ -62,6 +63,13 @@ internal class Serialization
         _serializer.IsSerializing = true;
         _mainDocument = new XDocument();
         _mainDocument.Add(SerializeBase(obj));
+
+        if (_serializer.UdtWrapper.IsMarkObjId2AvertSefRef)
+        {
+            _mainDocument = _mainDocument.ClearUnNecessaryObjId();
+            _serializer.Session.Reset();
+        }
+
         return _mainDocument;
     }
 
@@ -283,7 +291,7 @@ internal class Serialization
             var hasCustomSerializer =
                 member.HasCustomSerializer || member.UdtWrapper.HasCustomSerializer;
             var isCollectionSerially = member.CollectionAttributeInstance is
-                { SerializationType: YAXCollectionSerializationTypes.Serially };
+            { SerializationType: YAXCollectionSerializationTypes.Serially };
             var isKnownType = member.IsKnownType;
 
             var serializationLocation = member.SerializationLocation;
@@ -372,7 +380,7 @@ internal class Serialization
 
         if (elementValue == null || ValueEquals(elementValue, ReflectionUtils.GetDefaultValue(member.MemberType)))
         {
-           return true;
+            return true;
         }
 
         return false;
@@ -757,13 +765,16 @@ internal class Serialization
         if (member.PreservesWhitespace)
             XMLUtils.AddPreserveSpaceAttribute(elemToAdd, _serializer.Options.Culture);
 
+ 
+
         return elemToAdd;
     }
 
     private static (bool alreadyAdded, bool moveDescOnly) HandleRecursiveCollection(XElement insertionLocation,
         MemberWrapper member, XElement elemToAdd)
     {
-        var moveDescOnly = member.CollectionAttributeInstance is {
+        var moveDescOnly = member.CollectionAttributeInstance is
+        {
             SerializationType: YAXCollectionSerializationTypes.RecursiveWithNoContainingElement
         } && !elemToAdd.HasAttributes;
 
@@ -1028,35 +1039,44 @@ internal class Serialization
         switch (udt)
         {
             case { IsTreatedAsDictionary: true }:
-            {
-                elemToAdd = MakeDictionaryElement(elem, alias, obj, null, null,
-                    udt.IsNotAllowedNullObjectSerialization);
-                if (elemToAdd.Parent != elem)
-                    elem.Add(elemToAdd);
-                break;
-            }
+                {
+                    elemToAdd = MakeDictionaryElement(elem, alias, obj, null, null,
+                        udt.IsNotAllowedNullObjectSerialization);
+                    if (elemToAdd.Parent != elem)
+                        elem.Add(elemToAdd);
+                    break;
+                }
             case { IsTreatedAsCollection: true }:
-            {
-                elemToAdd = MakeCollectionElement(elem, alias, obj, null, null);
-                if (elemToAdd.Parent != elem)
-                    elem.Add(elemToAdd);
-                break;
-            }
+                {
+                    elemToAdd = MakeCollectionElement(elem, alias, obj, null, null);
+                    if (elemToAdd.Parent != elem)
+                        elem.Add(elemToAdd);
+                    break;
+                }
             case { IsEnum: true }:
-            {
-                elemToAdd = MakeBaseElement(elem, alias, udt.EnumWrapper!.GetAlias(obj!), out var alreadyAdded);
-                if (!alreadyAdded)
-                    elem.Add(elemToAdd);
-                break;
-            }
+                {
+                    elemToAdd = MakeBaseElement(elem, alias, udt.EnumWrapper!.GetAlias(obj!), out var alreadyAdded);
+                    if (!alreadyAdded)
+                        elem.Add(elemToAdd);
+                    break;
+                }
             default: // udt is null or none of the cases
-            {
-                elemToAdd = MakeBaseElement(elem, alias, obj, out var alreadyAdded);
-                if (!alreadyAdded)
-                    elem.Add(elemToAdd);
-                break;
-            }
+                {
+                    elemToAdd = MakeBaseElement(elem, alias, obj, out var alreadyAdded);
+                    if (!alreadyAdded)
+                        elem.Add(elemToAdd);
+                    break;
+                }
         }
+
+        //if (_serializer.UdtWrapper.IsMarkObjId2AvertSefRef)
+        //{
+        //    if (elemToAdd != null)
+        //    {
+        //        var id = _serializer.Session.ObjDict.GetOrNewIdx(obj);
+        //        elemToAdd.Add(new XAttribute(DictObjWithId.ATTR_FLAG_OBJID, id));
+        //    }
+        //}
 
         return elemToAdd;
     }
@@ -1220,6 +1240,18 @@ internal class Serialization
     private XElement MakeBaseElement(XElement? insertionLocation, XName name, object? value, out bool alreadyAdded)
     {
         alreadyAdded = false;
+
+        if (_serializer.UdtWrapper.IsMarkObjId2AvertSefRef)
+        {
+            var id = _serializer.Session.ObjDict.GetObjIdx(value);
+            if (id != null && value != null)
+            {
+                XElement nullElem = new XElement(name);
+                nullElem.Add(new XAttribute(DictObjWithId.ATTR_FLAG_OBJID, id));
+                return nullElem;
+            }
+        }
+
         if (value == null || ReflectionUtils.IsBasicType(value.GetType()))
         {
             value = value?.ToXmlValue(_serializer.Options.Culture).StripInvalidXmlChars(_stripInvalidXmlChars);
@@ -1235,7 +1267,18 @@ internal class Serialization
         }
 
         var elem = SerializeUsingInternalSerializer(insertionLocation, name, value);
+
+        if (_serializer.UdtWrapper.IsMarkObjId2AvertSefRef)
+        {
+            if (value != null && value.GetType().ShouldMarkObjId())
+            {
+                var id = _serializer.Session.ObjDict.GetOrNewIdx(value);
+                elem.Add(new XAttribute(DictObjWithId.ATTR_FLAG_OBJID, id));
+            }
+        }
+
         alreadyAdded = true;
+
         return elem;
     }
 
@@ -1260,10 +1303,10 @@ internal class Serialization
             case TextEmbedding.Base64:
                 elem.Add(new XText(value.ToBase64(System.Text.Encoding.UTF8)!));
                 break;
-            /*
-                TextEmbedding.None and null values uses standard element serialization,
-                which is not handled in this method.
-            */
+                /*
+                    TextEmbedding.None and null values uses standard element serialization,
+                    which is not handled in this method.
+                */
         }
 
         return elem;

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -215,6 +215,12 @@ internal class UdtWrapper
         YAXSerializationOptions.ThrowUponSerializingCyclingReferences;
 
     /// <summary>
+    /// Determines whether  Each object is marked number to Prevents that cycle references from child to parent objects cause an infinite loop.
+    /// </summary>
+    public bool IsMarkObjId2AvertSefRef => (SerializationOptions & YAXSerializationOptions.MarkObjId2AvertSefRef) ==
+        YAXSerializationOptions.MarkObjId2AvertSefRef;
+
+    /// <summary>
     /// Determines whether properties with no setters should be serialized
     /// </summary>
     public bool DoNotSerializePropertiesWithNoSetter =>

--- a/YAXLib/YAXSerializer.cs
+++ b/YAXLib/YAXSerializer.cs
@@ -10,6 +10,7 @@ using System.Xml.Linq;
 using YAXLib.Caching;
 using YAXLib.Enums;
 using YAXLib.Exceptions;
+using YAXLib.MarkObjWithId;
 using YAXLib.Options;
 using YAXLib.Pooling.ObjectPools;
 using YAXLib.Pooling.YAXLibPools;
@@ -39,6 +40,8 @@ public class YAXSerializer : IYAXSerializer<object>, IRecursionCounter
         DocumentDefaultNamespace = XNamespace.None;
         TypeNamespace = XNamespace.None;
         UdtWrapper = UdtWrapperCache.Instance.GetOrAddItem(Type, Options);
+
+        Session = new SerSession();
 
         Serialization = new Serialization(this);
         Deserialization = new Deserialization(this);
@@ -329,6 +332,7 @@ public class YAXSerializer : IYAXSerializer<object>, IRecursionCounter
 
         // Get a standard serializer from the pool
         var serializerPoolObject = SerializerPool.Instance.Get(out serializer);
+        serializer.Session = this.Session;
         serializer.Initialize(type, Options);
         // Make it a child serializer
         InitializeAsChildSerializer(serializer, namespaceToOverride, insertionLocation);
@@ -446,6 +450,7 @@ public class YAXSerializer : IYAXSerializer<object>, IRecursionCounter
     internal XmlNamespaceManager XmlNamespaceManager { get; private set; }
 
     internal XNamespace TypeNamespace { get; set; }
+    internal SerSession Session { get; set; }
 
     #endregion
 

--- a/YAXLibTests/MarkObjId2AvertSefRef.cs
+++ b/YAXLibTests/MarkObjId2AvertSefRef.cs
@@ -10,8 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using YAXLib;
-using YAXLib.Options;
-using static YAXLibTests.CustomTypeInspectorTests;
+using YAXLib.Options; 
 
 namespace YAXLibTests;
 [TestFixture]
@@ -56,10 +55,10 @@ public class MarkObjId2AvertSefRef01
     public void Se01()
     {
         var result = """
-            <CPack>
+            <CPack xmlns:yaxlib="http://www.sinairv.com/>
               <Int01>666</Int01>
               <Name>PackLoop</Name>
-              <ItWillLoop _ObjId="1000">
+              <ItWillLoop yaxlib:id="1000">
                 <Int02>333</Int02>
                 <Name>AAA</Name>
                 <Child>
@@ -68,7 +67,7 @@ public class MarkObjId2AvertSefRef01
                   <Child>
                     <Int02>555</Int02>
                     <Name>CCC</Name>
-                    <Child _ObjId="1000" />
+                    <Child yaxlib:ref="1000" />
                   </Child>
                 </Child>
               </ItWillLoop>
@@ -92,10 +91,10 @@ public class MarkObjId2AvertSefRef01
     public void De01()
     {
         var xmlInput = """
-            <CPack>
+            <CPack xmlns:yaxlib="http://www.sinairv.com/>
               <Int01>666</Int01>
               <Name>PackLoop</Name>
-              <ItWillLoop _ObjId="1000">
+              <ItWillLoop yaxlib:id="1000">
                 <Int02>333</Int02>
                 <Name>AAA</Name>
                 <Child>
@@ -104,7 +103,7 @@ public class MarkObjId2AvertSefRef01
                   <Child>
                     <Int02>555</Int02>
                     <Name>CCC</Name>
-                    <Child _ObjId="1000" />
+                    <Child yaxlib:ref="1000" />
                   </Child>
                 </Child>
               </ItWillLoop>
@@ -161,19 +160,19 @@ public class MarkObjId2AvertSefRef01
     public void Se02()
     {
         var result = """
-         <CPack02>
+         <CPack02 xmlns:yaxlib="http://www.sinairv.com/>
            <BoxList>
-             <CBox _ObjId="1000">
+             <CBox yaxlib:id="1000">
                <Name>Node2</Name>
              </CBox>
              <CBox>
                <Name>Node1</Name>
              </CBox>
-             <CBox _ObjId="1000" />
+             <CBox yaxlib:ref="1000" />
              <CBox>
                <Name>Node3</Name>
              </CBox>
-             <CBox _ObjId="1000" />
+             <CBox yaxlib:ref="1000" />
            </BoxList>
          </CPack02>
          """;
@@ -195,19 +194,19 @@ public class MarkObjId2AvertSefRef01
     public void De02()
     {
         var xmlInput = """
-            <CPack02>
+            <CPack02 xmlns:yaxlib="http://www.sinairv.com/>
               <BoxList>
-                <CBox _ObjId="1000">
+                <CBox yaxlib:id="1000">
                   <Name>Node2</Name>
                 </CBox>
                 <CBox>
                   <Name>Node1</Name>
                 </CBox>
-                <CBox _ObjId="1000" />
+                <CBox yaxlib:ref="1000" />
                 <CBox>
                   <Name>Node3</Name>
                 </CBox>
-                <CBox _ObjId="1000" />
+                <CBox yaxlib:ref="1000" />
               </BoxList>
             </CPack02>
             """;

--- a/YAXLibTests/MarkObjId2AvertSefRef.cs
+++ b/YAXLibTests/MarkObjId2AvertSefRef.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using YAXLib;
+using YAXLib.Options;
+using static YAXLibTests.CustomTypeInspectorTests;
+
+namespace YAXLibTests;
+[TestFixture]
+public class MarkObjId2AvertSefRef01
+{
+    #region Test01
+    public class CPack
+    {
+        public class CBoxA
+        {
+            public int Int02 { get; set; } = 333;
+            public string Name { get; set; }
+            public CBoxB Child { get; set; }
+        }
+        public class CBoxB
+        {
+            public int Int01 { get; set; } = 444;
+            public string Name { get; set; }
+            public CBoxC Child { get; set; }
+        }
+        public class CBoxC
+        {
+            public int Int02 { get; set; } = 555;
+            public string Name { get; set; }
+            public CBoxA Child { get; set; }
+        }
+        public int Int01 { get; set; } = 666;
+        public string Name { get; set; }
+        public CBoxA ItWillLoop { get; set; }
+        public static CPack GetSampleInstance()
+        {
+            CBoxA boxa = new() { Name = "AAA" };
+            CBoxB boxb = new() { Name = "BBB" };
+            CBoxC boxc = new() { Name = "CCC" };
+            boxa.Child = boxb;
+            boxb.Child = boxc;
+            boxc.Child = boxa;
+            return new CPack { Name = "PackLoop", ItWillLoop = boxa };
+        }
+    }
+    [Test]
+    public void Se01()
+    {
+        var result = """
+            <CPack>
+              <Int01>666</Int01>
+              <Name>PackLoop</Name>
+              <ItWillLoop _ObjId="1000">
+                <Int02>333</Int02>
+                <Name>AAA</Name>
+                <Child>
+                  <Int01>444</Int01>
+                  <Name>BBB</Name>
+                  <Child>
+                    <Int02>555</Int02>
+                    <Name>CCC</Name>
+                    <Child _ObjId="1000" />
+                  </Child>
+                </Child>
+              </ItWillLoop>
+            </CPack>
+            """;
+
+
+        var serializer = new YAXSerializer<CPack>(
+        new SerializerOptions
+        {
+            SerializationOptions = YAXLib.Enums.YAXSerializationOptions.MarkObjId2AvertSefRef
+        });
+
+
+        var got = serializer.Serialize(CPack.GetSampleInstance());
+        Console.WriteLine("got:" + got);
+        Console.WriteLine("result:" + result);
+        Assert.AreEqual(got, result);
+    }
+    [Test]
+    public void De01()
+    {
+        var xmlInput = """
+            <CPack>
+              <Int01>666</Int01>
+              <Name>PackLoop</Name>
+              <ItWillLoop _ObjId="1000">
+                <Int02>333</Int02>
+                <Name>AAA</Name>
+                <Child>
+                  <Int01>444</Int01>
+                  <Name>BBB</Name>
+                  <Child>
+                    <Int02>555</Int02>
+                    <Name>CCC</Name>
+                    <Child _ObjId="1000" />
+                  </Child>
+                </Child>
+              </ItWillLoop>
+            </CPack>
+            """;
+
+
+        var serializer = new YAXSerializer<CPack>(
+            new SerializerOptions
+            {
+                SerializationOptions = YAXLib.Enums.YAXSerializationOptions.MarkObjId2AvertSefRef
+            });
+
+
+        var got = serializer.Deserialize(xmlInput);
+        Console.WriteLine(got);
+        Assert.AreSame(got.ItWillLoop, got.ItWillLoop.Child.Child.Child);
+    }
+
+    #endregion Test01
+
+    public class CPack02
+    {
+        public class CBox
+        {
+            public string Name { get; set; }
+        }
+
+        public List<CBox> BoxList { get; set; }
+
+
+        public static CPack02 GetSampleInstance()
+        {
+            var newone = new CPack02() { BoxList = new List<CBox>() };
+
+            for (int i = 0; i < 5; i++)
+            {
+                newone.BoxList.Add(new CBox
+                {
+                    Name = $"Node{i}",
+                });
+            }
+
+            newone.BoxList[0] = newone.BoxList[2];
+            newone.BoxList[4] = newone.BoxList[2];
+
+            return newone;
+        }
+
+
+    }
+
+    [Test]
+    public void Se02()
+    {
+        var result = """
+         <CPack02>
+           <BoxList>
+             <CBox _ObjId="1000">
+               <Name>Node2</Name>
+             </CBox>
+             <CBox>
+               <Name>Node1</Name>
+             </CBox>
+             <CBox _ObjId="1000" />
+             <CBox>
+               <Name>Node3</Name>
+             </CBox>
+             <CBox _ObjId="1000" />
+           </BoxList>
+         </CPack02>
+         """;
+
+
+        var serializer = new YAXSerializer<CPack02>(
+        new SerializerOptions
+        {
+            SerializationOptions = YAXLib.Enums.YAXSerializationOptions.MarkObjId2AvertSefRef
+        });
+
+
+        var got = serializer.Serialize(CPack02.GetSampleInstance());
+        Console.WriteLine("got:" + got);
+        Console.WriteLine("result:" + result);
+        Assert.AreEqual(got, result);
+    }
+    [Test]
+    public void De02()
+    {
+        var xmlInput = """
+            <CPack02>
+              <BoxList>
+                <CBox _ObjId="1000">
+                  <Name>Node2</Name>
+                </CBox>
+                <CBox>
+                  <Name>Node1</Name>
+                </CBox>
+                <CBox _ObjId="1000" />
+                <CBox>
+                  <Name>Node3</Name>
+                </CBox>
+                <CBox _ObjId="1000" />
+              </BoxList>
+            </CPack02>
+            """;
+
+
+        var serializer = new YAXSerializer<CPack02>(
+            new SerializerOptions
+            {
+                SerializationOptions = YAXLib.Enums.YAXSerializationOptions.MarkObjId2AvertSefRef
+            });
+
+
+        var got = serializer.Deserialize(xmlInput);
+        Console.WriteLine(got);
+
+        Assert.AreSame(got.BoxList[0], got.BoxList[2]);
+        Assert.AreSame(got.BoxList[4], got.BoxList[2]);
+    }
+}

--- a/YAXLibTests/MarkObjId2AvertSefRef.cs
+++ b/YAXLibTests/MarkObjId2AvertSefRef.cs
@@ -67,7 +67,7 @@ public class MarkObjId2AvertSefRef01
                   <Child>
                     <Int02>555</Int02>
                     <Name>CCC</Name>
-                    <Child yaxlib:id="1000" />
+                    <Child yaxlib:ref="1000" />
                   </Child>
                 </Child>
               </ItWillLoop>
@@ -103,7 +103,7 @@ public class MarkObjId2AvertSefRef01
                   <Child>
                     <Int02>555</Int02>
                     <Name>CCC</Name>
-                    <Child yaxlib:id="1000" />
+                    <Child yaxlib:ref="1000" />
                   </Child>
                 </Child>
               </ItWillLoop>
@@ -168,11 +168,11 @@ public class MarkObjId2AvertSefRef01
              <CBox>
                <Name>Node1</Name>
              </CBox>
-             <CBox yaxlib:id="1000" />
+             <CBox yaxlib:ref="1000" />
              <CBox>
                <Name>Node3</Name>
              </CBox>
-             <CBox yaxlib:id="1000" />
+             <CBox yaxlib:ref="1000" />
            </BoxList>
          </CPack02>
          """;
@@ -202,11 +202,11 @@ public class MarkObjId2AvertSefRef01
                 <CBox>
                   <Name>Node1</Name>
                 </CBox>
-                <CBox yaxlib:id="1000" />
+                <CBox yaxlib:ref="1000" />
                 <CBox>
                   <Name>Node3</Name>
                 </CBox>
-                <CBox yaxlib:id="1000" />
+                <CBox yaxlib:ref="1000" />
               </BoxList>
             </CPack02>
             """;

--- a/YAXLibTests/MarkObjId2AvertSefRef.cs
+++ b/YAXLibTests/MarkObjId2AvertSefRef.cs
@@ -55,7 +55,7 @@ public class MarkObjId2AvertSefRef01
     public void Se01()
     {
         var result = """
-            <CPack xmlns:yaxlib="http://www.sinairv.com/>
+            <CPack xmlns:yaxlib="http://www.sinairv.com/yaxlib/">
               <Int01>666</Int01>
               <Name>PackLoop</Name>
               <ItWillLoop yaxlib:id="1000">
@@ -67,7 +67,7 @@ public class MarkObjId2AvertSefRef01
                   <Child>
                     <Int02>555</Int02>
                     <Name>CCC</Name>
-                    <Child yaxlib:ref="1000" />
+                    <Child yaxlib:id="1000" />
                   </Child>
                 </Child>
               </ItWillLoop>
@@ -91,7 +91,7 @@ public class MarkObjId2AvertSefRef01
     public void De01()
     {
         var xmlInput = """
-            <CPack xmlns:yaxlib="http://www.sinairv.com/>
+            <CPack xmlns:yaxlib="http://www.sinairv.com/yaxlib/">
               <Int01>666</Int01>
               <Name>PackLoop</Name>
               <ItWillLoop yaxlib:id="1000">
@@ -103,7 +103,7 @@ public class MarkObjId2AvertSefRef01
                   <Child>
                     <Int02>555</Int02>
                     <Name>CCC</Name>
-                    <Child yaxlib:ref="1000" />
+                    <Child yaxlib:id="1000" />
                   </Child>
                 </Child>
               </ItWillLoop>
@@ -160,7 +160,7 @@ public class MarkObjId2AvertSefRef01
     public void Se02()
     {
         var result = """
-         <CPack02 xmlns:yaxlib="http://www.sinairv.com/>
+         <CPack02 xmlns:yaxlib="http://www.sinairv.com/yaxlib/">
            <BoxList>
              <CBox yaxlib:id="1000">
                <Name>Node2</Name>
@@ -168,11 +168,11 @@ public class MarkObjId2AvertSefRef01
              <CBox>
                <Name>Node1</Name>
              </CBox>
-             <CBox yaxlib:ref="1000" />
+             <CBox yaxlib:id="1000" />
              <CBox>
                <Name>Node3</Name>
              </CBox>
-             <CBox yaxlib:ref="1000" />
+             <CBox yaxlib:id="1000" />
            </BoxList>
          </CPack02>
          """;
@@ -194,7 +194,7 @@ public class MarkObjId2AvertSefRef01
     public void De02()
     {
         var xmlInput = """
-            <CPack02 xmlns:yaxlib="http://www.sinairv.com/>
+            <CPack02 xmlns:yaxlib="http://www.sinairv.com/yaxlib/">
               <BoxList>
                 <CBox yaxlib:id="1000">
                   <Name>Node2</Name>
@@ -202,11 +202,11 @@ public class MarkObjId2AvertSefRef01
                 <CBox>
                   <Name>Node1</Name>
                 </CBox>
-                <CBox yaxlib:ref="1000" />
+                <CBox yaxlib:id="1000" />
                 <CBox>
                   <Name>Node3</Name>
                 </CBox>
-                <CBox yaxlib:ref="1000" />
+                <CBox yaxlib:id="1000" />
               </BoxList>
             </CPack02>
             """;


### PR DESCRIPTION
For instance tag ObjId, realize the  serialization of circular reference or multiple references.


在几乎序列化类库中,  都没有指出相同的实例引用在xml中的对应关系. 这就造成了两个问题:
In almost all serialized class libraries, the correspondence of the same instance reference in XML is not indicated. This creates two problems.

1. A->B->C->A 会造成序列化时无限循环, 即使我们的实例是有限的.
 A->B->C->A will cause an infinite loop when serializing, even if our instances are finite.
2. 对同一个实例多次引用后, 经过序列化和反序列化,  结果并没有还原他们的相同引用关系. 比如[A1, A1] 经过序列化和反序列化会变成[A1,A2]
After multiple references to the same instance, serialized and deserialized, the result is that their same reference relationship is not restored. For example, [A1, A1] becomes [A1,A2] after serialization and deserialization

I tagged the instance with the ID, which solved the problem. 

The test samples illustrates the functionality more clearly.  Note the _ObjId=XXX.
Example1:
```csharp
      public static CPack GetSampleInstance()
        {
            CBoxA boxa = new() { Name = "AAA" };
            CBoxB boxb = new() { Name = "BBB" };
            CBoxC boxc = new() { Name = "CCC" };
            boxa.Child = boxb;
            boxb.Child = boxc;
            boxc.Child = boxa;
            return new CPack { Name = "PackLoop", ItWillLoop = boxa };
        }


```
The result of serialization is
```xml
            <CPack xmlns:yaxlib="http://www.sinairv.com/yaxlib/">
              <Int01>666</Int01>
              <Name>PackLoop</Name>
              <ItWillLoop yaxlib:id="1000">
                <Int02>333</Int02>
                <Name>AAA</Name>
                <Child>
                  <Int01>444</Int01>
                  <Name>BBB</Name>
                  <Child>
                    <Int02>555</Int02>
                    <Name>CCC</Name>
                    <Child yaxlib:ref="1000" />
                  </Child>
                </Child>
              </ItWillLoop>
            </CPack>

``` 
Deserialization can also pass
```csharp
  Assert.AreSame(got.ItWillLoop, got.ItWillLoop.Child.Child.Child);
```
Example2:
```csharp
     public static CPack02 GetSampleInstance()
        {
            var newone = new CPack02() { BoxList = new List<CBox>() };

            for (int i = 0; i < 5; i++)
            {
                newone.BoxList.Add(new CBox
                {
                    Name = $"Node{i}",
                });
            }
            newone.BoxList[0] = newone.BoxList[2];
            newone.BoxList[4] = newone.BoxList[2];
            return newone;
        }
```
The result of serialization is
```xml
          <CPack02 xmlns:yaxlib="http://www.sinairv.com/yaxlib/">
              <BoxList>
                <CBox yaxlib:id="1000">
                  <Name>Node2</Name>
                </CBox>
                <CBox>
                  <Name>Node1</Name>
                </CBox>
                <CBox yaxlib:ref="1000" />
                <CBox>
                  <Name>Node3</Name>
                </CBox>
                <CBox yaxlib:ref="1000" />
              </BoxList>
            </CPack02>
```
Deserialization can also pass
```csharp
     Assert.AreSame(got.BoxList[0], got.BoxList[2]);
     Assert.AreSame(got.BoxList[4], got.BoxList[2]);
```
