### PR TITLE
Bump version to v4.2.1

### DIFF
--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -18,22 +18,22 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '17'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0   # Shallow clones should be disabled for a better relevancy of analysis
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner

--- a/YAXLib/ReflectionUtils.cs
+++ b/YAXLib/ReflectionUtils.cs
@@ -833,7 +833,7 @@ internal static class ReflectionUtils
 #pragma warning disable S2681  // conditional execution
 #if NETSTANDARD || NET
             return assemblyName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
-                   assemblyName.StartsWith("mscorlib.", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.Equals("mscorlib", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase);
 #else
         return assemblyName.Equals("mscorlib", StringComparison.OrdinalIgnoreCase)

--- a/YAXLib/YAXLib.csproj
+++ b/YAXLib/YAXLib.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/YAXLibTests/CustomTypeInspectorTests.cs
+++ b/YAXLibTests/CustomTypeInspectorTests.cs
@@ -43,15 +43,15 @@ public class CustomTypeInspectorTests
 
         var result = serializer.Serialize(Book.GetSampleInstance());
 
-        Assert.AreEqual(
-            """
+        Assert.That(
+result, Is.EqualTo("""
             <!-- This example demonstrates serializing a very simple class -->
             <Book>
               <Title>Inside C#</Title>
               <Author>Tom Archer &amp; Andrew Whitechapel</Author>
               <Price>30.5</Price>
             </Book>
-            """, result);
+            """));
     }
 
     [Test]

--- a/YAXLibTests/DeserializationTestBase.cs
+++ b/YAXLibTests/DeserializationTestBase.cs
@@ -37,8 +37,8 @@ public abstract class DeserializationTestBase
     private void PerformTestWithEquals(object obj)
     {
         var serializer = SerializeDeserialize(obj, out var gottonObject);
-        Assert.AreEqual(0, serializer.ParsingErrors.Count);
-        Assert.AreEqual(obj, gottonObject);
+        Assert.That(serializer.ParsingErrors.Count, Is.EqualTo(0));
+        Assert.That(gottonObject, Is.EqualTo(obj));
     }
 
     private object? GetTheTwoStringsAndReturn(object obj, out string originalString, out string? gottonString,
@@ -371,7 +371,7 @@ public abstract class DeserializationTestBase
             { ExceptionHandlingPolicies = YAXExceptionHandlingPolicies.DoNotThrow });
         serializer.SetDeserializationBaseObject(book);
         var bookResult = (MoreComplexBook2?) serializer.Deserialize(result);
-        Assert.AreNotEqual(bookResult?.ToString(), initialToString);
+        Assert.That(bookResult?.ToString(), Is.Not.EqualTo(initialToString));
     }
 
     [Test]
@@ -531,11 +531,8 @@ public abstract class DeserializationTestBase
 
         var deserializedContainer = (DictionaryContainerSample?) ser.Deserialize(input);
 
-        Assert.IsNotNull(deserializedContainer?.Items);
-        Assert.IsTrue(deserializedContainer?.Items.Count == container.Items.Count,
-            "Expected Count: {0}. Actual Count: {1}",
-            container.Items.Count,
-            deserializedContainer?.Items.Count);
+        Assert.That(deserializedContainer?.Items, Is.Not.Null);
+        Assert.That(deserializedContainer?.Items.Count == container.Items.Count, $"Expected Count: {container.Items.Count}. Actual Count: {deserializedContainer?.Items.Count}");
     }
 
     [Test]
@@ -550,10 +547,7 @@ public abstract class DeserializationTestBase
         var deserializedInstance = (DictionarySample?) ser.Deserialize(input);
 
         Assert.That(deserializedInstance, Is.Not.Null);
-        Assert.IsTrue(deserializedInstance?.Count == inst.Count,
-            "Expected Count: {0}. Actual Count: {1}",
-            inst.Count,
-            deserializedInstance?.Count);
+        Assert.That(deserializedInstance?.Count == inst.Count, $"Expected Count: {inst.Count}. Actual Count: {deserializedInstance?.Count}");
     }
 
     [Test]
@@ -620,7 +614,7 @@ public abstract class DeserializationTestBase
         var deserializedInstance = (IndirectSelfReferringObject?) ser.Deserialize(input);
 
         Assert.That(deserializedInstance, Is.Not.Null);
-        Assert.IsNull(deserializedInstance?.Child?.Parent);
+        Assert.That(deserializedInstance?.Child?.Parent, Is.Null);
     }
 
     [Test]
@@ -638,7 +632,7 @@ public abstract class DeserializationTestBase
         var deserializedInstance = (DirectSelfReferringObject?) ser.Deserialize(input);
 
         Assert.That(deserializedInstance, Is.Not.Null);
-        Assert.IsNull(deserializedInstance?.Next?.Next);
+        Assert.That(deserializedInstance?.Next?.Next, Is.Null);
     }
 
     [Test]
@@ -656,7 +650,7 @@ public abstract class DeserializationTestBase
         var deserializedInstance = (DirectSelfReferringObject?) ser.Deserialize(input);
 
         Assert.That(deserializedInstance, Is.Not.Null);
-        Assert.IsNull(deserializedInstance?.Next);
+        Assert.That(deserializedInstance?.Next, Is.Null);
     }
 
     [Test]
@@ -670,7 +664,7 @@ public abstract class DeserializationTestBase
         var result = ser.Serialize(CalculatedPropertiesCanCauseInfiniteLoop.GetSampleInstance());
 
         var deserializedInstance = ser.Deserialize(result);
-        Assert.IsNotNull(deserializedInstance);
+        Assert.That(deserializedInstance, Is.Not.Null);
     }
 
     [Test]
@@ -680,7 +674,7 @@ public abstract class DeserializationTestBase
         var ser = CreateSerializer<CalculatedPropertiesCanCauseInfiniteLoop>(options);
         var result = ser.Serialize(CalculatedPropertiesCanCauseInfiniteLoop.GetSampleInstance());
         var deserializedInstance = ser.Deserialize(result) as CalculatedPropertiesCanCauseInfiniteLoop;
-        Assert.IsNotNull(deserializedInstance);
+        Assert.That(deserializedInstance, Is.Not.Null);
         Assert.That(ser.Options.MaxRecursion, Is.EqualTo(10));
         Assert.That(deserializedInstance?.Data, Is.EqualTo(2.0M));
         Assert.That(ser.GetRecursionCount(), Is.EqualTo(0));

--- a/YAXLibTests/ExceptionTests.cs
+++ b/YAXLibTests/ExceptionTests.cs
@@ -28,8 +28,8 @@ internal class ExceptionTests
             serializer.Serialize(ClassWithDuplicateYaxAttribute.GetSampleInstance());
         });
 
-        Assert.AreEqual("test", ex?.AttrName);
-        StringAssert.Contains("'test'", ex?.Message);
+        Assert.That(ex?.AttrName, Is.EqualTo("test"));
+        Assert.That(ex?.Message, Does.Contain("'test'"));
     }
 
     [Test]
@@ -54,7 +54,7 @@ internal class ExceptionTests
         });
 
         // YAXBadlyFormedXML exception doesn't need YAXSerializationOptions.DisplayLineInfoInExceptions to get the line numbers
-        Assert.True(ex!.HasLineInfo);
+        Assert.That(ex!.HasLineInfo, Is.True);
         Assert.That(ex.LineNumber, Is.EqualTo(7));
         Assert.That(ex.LinePosition, Is.EqualTo(3));
         Assert.That(ex.Message, Does.Contain("not properly formatted"));
@@ -194,10 +194,10 @@ internal class ExceptionTests
             });
             serializer.Deserialize(bookXml);
         });
-        Assert.True(ex?.HasLineInfo);
-        Assert.AreEqual(6, ex?.LineNumber);
-        Assert.AreEqual(4, ex?.LinePosition);
-        StringAssert.Contains("The format of the value specified for the property", ex?.Message);
+        Assert.That(ex?.HasLineInfo, Is.True);
+        Assert.That(ex?.LineNumber, Is.EqualTo(6));
+        Assert.That(ex?.LinePosition, Is.EqualTo(4));
+        Assert.That(ex?.Message, Does.Contain("The format of the value specified for the property"));
     }
 
     [Test]
@@ -222,10 +222,10 @@ internal class ExceptionTests
             });
             serializer.Deserialize(bookXml);
         });
-        Assert.False(ex?.HasLineInfo);
-        Assert.AreEqual(0, ex?.LineNumber);
-        Assert.AreEqual(0, ex?.LinePosition);
-        StringAssert.Contains("The format of the value specified for the property", ex?.Message);
+        Assert.That(ex?.HasLineInfo, Is.False);
+        Assert.That(ex?.LineNumber, Is.EqualTo(0));
+        Assert.That(ex?.LinePosition, Is.EqualTo(0));
+        Assert.That(ex?.Message, Does.Contain("The format of the value specified for the property"));
     }
 
     [Test]
@@ -239,10 +239,10 @@ internal class ExceptionTests
             serializer.Serialize(new ClassWithDuplicateYaxAttribute());
         });
 
-        Assert.AreEqual(typeof(Book), ex?.ExpectedType);
-        Assert.AreEqual(typeof(ClassWithDuplicateYaxAttribute), ex?.ReceivedType);
-        StringAssert.Contains("'Book'", ex?.Message);
-        StringAssert.Contains("'ClassWithDuplicateYaxAttribute'", ex?.Message);
+        Assert.That(ex?.ExpectedType, Is.EqualTo(typeof(Book)));
+        Assert.That(ex?.ReceivedType, Is.EqualTo(typeof(ClassWithDuplicateYaxAttribute)));
+        Assert.That(ex?.Message, Does.Contain("'Book'"));
+        Assert.That(ex?.Message, Does.Contain("'ClassWithDuplicateYaxAttribute'"));
     }
 
 
@@ -268,9 +268,9 @@ internal class ExceptionTests
             });
             serializer.Deserialize(bookXml);
         });
-        Assert.True(ex?.HasLineInfo);
-        Assert.AreEqual(2, ex?.LineNumber);
-        Assert.AreEqual(2, ex?.LinePosition);
+        Assert.That(ex?.HasLineInfo, Is.True);
+        Assert.That(ex?.LineNumber, Is.EqualTo(2));
+        Assert.That(ex?.LinePosition, Is.EqualTo(2));
     }
 
     [Test]
@@ -296,9 +296,9 @@ internal class ExceptionTests
             });
             serializer.Deserialize(collectionXml);
         });
-        Assert.True(ex?.HasLineInfo);
-        Assert.AreEqual(2, ex?.LineNumber);
-        Assert.AreEqual(2, ex?.LinePosition);
+        Assert.That(ex?.HasLineInfo, Is.True);
+        Assert.That(ex?.LineNumber, Is.EqualTo(2));
+        Assert.That(ex?.LinePosition, Is.EqualTo(2));
     }
 
     [Test]
@@ -322,9 +322,9 @@ internal class ExceptionTests
             });
             serializer.Deserialize(bookXml);
         });
-        Assert.True(ex?.HasLineInfo);
-        Assert.AreEqual(1, ex?.LineNumber);
-        Assert.AreEqual(2, ex?.LinePosition);
+        Assert.That(ex?.HasLineInfo, Is.True);
+        Assert.That(ex?.LineNumber, Is.EqualTo(1));
+        Assert.That(ex?.LinePosition, Is.EqualTo(2));
     }
 
     [Test]
@@ -334,7 +334,7 @@ internal class ExceptionTests
 
         Exception? ex =
             Assert.Throws<YAXBadLocationException>(code: () => throw new YAXBadLocationException(testName));
-        StringAssert.Contains(testName, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
     }
 
     [Test]
@@ -343,7 +343,7 @@ internal class ExceptionTests
         var testName = "Test";
         var ex = Assert.Throws<YAXAttributeAlreadyExistsException>(code: () =>
             throw new YAXAttributeAlreadyExistsException(testName));
-        StringAssert.Contains(testName, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
     }
 
     [Test]
@@ -352,7 +352,7 @@ internal class ExceptionTests
         var testName = "Test";
         var ex = Assert.Throws<YAXAttributeMissingException>(code: () =>
             throw new YAXAttributeMissingException(testName));
-        StringAssert.Contains(testName, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
     }
 
     [Test]
@@ -361,7 +361,7 @@ internal class ExceptionTests
         var testName = "Test";
         var ex = Assert.Throws<YAXElementValueMissingException>(code: () =>
             throw new YAXElementValueMissingException(testName));
-        StringAssert.Contains(testName, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
     }
 
     [Test]
@@ -370,7 +370,7 @@ internal class ExceptionTests
         var testName = "Test";
         var ex = Assert.Throws<YAXElementMissingException>(code: () =>
             throw new YAXElementMissingException(testName));
-        StringAssert.Contains(testName, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
     }
 
     [Test]
@@ -380,8 +380,8 @@ internal class ExceptionTests
         var testInput = "BadInput";
         var ex = Assert.Throws<YAXBadlyFormedInput>(code: () =>
             throw new YAXBadlyFormedInput(testName, testInput));
-        StringAssert.Contains(testName, ex?.Message);
-        StringAssert.Contains(testInput, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
+        Assert.That(ex?.Message, Does.Contain(testInput));
     }
 
     [Test]
@@ -390,7 +390,7 @@ internal class ExceptionTests
         var testName = "Test";
         var ex = Assert.Throws<YAXPropertyCannotBeAssignedTo>(code: () =>
             throw new YAXPropertyCannotBeAssignedTo(testName));
-        StringAssert.Contains(testName, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
     }
 
     [Test]
@@ -400,8 +400,8 @@ internal class ExceptionTests
         var testValue = 1;
         var ex = Assert.Throws<YAXCannotAddObjectToCollection>(code: () =>
             throw new YAXCannotAddObjectToCollection(testName, testValue));
-        StringAssert.Contains(testName, ex?.Message);
-        StringAssert.Contains(testValue.ToString(), ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
+        Assert.That(ex?.Message, Does.Contain(testValue.ToString()));
     }
 
     [Test]
@@ -411,8 +411,8 @@ internal class ExceptionTests
         var testValue = 1;
         var ex = Assert.Throws<YAXDefaultValueCannotBeAssigned>(code: () =>
             throw new YAXDefaultValueCannotBeAssigned(testName, testValue, CultureInfo.InvariantCulture));
-        StringAssert.Contains(testName, ex?.Message);
-        StringAssert.Contains(testValue.ToString(), ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
+        Assert.That(ex?.Message, Does.Contain(testValue.ToString()));
     }
 
     [Test]
@@ -420,7 +420,7 @@ internal class ExceptionTests
     {
         var testName = "Test";
         var ex = Assert.Throws<YAXBadlyFormedXML>(() => { throw new YAXBadlyFormedXML(new Exception(testName)); });
-        StringAssert.Contains(testName, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
     }
 
     [Test]
@@ -429,7 +429,7 @@ internal class ExceptionTests
         var testType = typeof(string);
         var ex = Assert.Throws<YAXCannotSerializeSelfReferentialTypes>(code: () =>
             throw new YAXCannotSerializeSelfReferentialTypes(testType));
-        StringAssert.Contains(testType.Name, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testType.Name));
     }
 
     [Test]
@@ -439,8 +439,8 @@ internal class ExceptionTests
         var testType2 = typeof(int);
         var ex = Assert.Throws<YAXObjectTypeMismatch>(code: () =>
             throw new YAXObjectTypeMismatch(testType, testType2));
-        StringAssert.Contains(testType.Name, ex?.Message);
-        StringAssert.Contains(testType2.Name, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testType.Name));
+        Assert.That(ex?.Message, Does.Contain(testType2.Name));
     }
 
     [Test]
@@ -448,6 +448,6 @@ internal class ExceptionTests
     {
         var testName = "Test";
         var ex = Assert.Throws<YAXPolymorphicException>(code: () => throw new YAXPolymorphicException(testName));
-        StringAssert.Contains(testName, ex?.Message);
+        Assert.That(ex?.Message, Does.Contain(testName));
     }
 }

--- a/YAXLibTests/GenericDeserializationTests.cs
+++ b/YAXLibTests/GenericDeserializationTests.cs
@@ -57,7 +57,7 @@ public class GenericDeserializationTests : DeserializationTestBase
                 """;
         var serializer = new YAXSerializer<Book>();
         var got = serializer.Deserialize(xml);
-        Assert.NotNull(got);
-        Assert.AreEqual(got, Book.GetSampleInstance());
+        Assert.That(got, Is.Not.Null);
+        Assert.That(Book.GetSampleInstance(), Is.EqualTo(got));
     }
 }

--- a/YAXLibTests/GenericSerializationTests.cs
+++ b/YAXLibTests/GenericSerializationTests.cs
@@ -75,7 +75,7 @@ public class GenericSerializationTests : SerializationTestBase
                 """;
         var serializer = new YAXSerializer<Book>();
         var got = serializer.Deserialize(xml);
-        Assert.NotNull(got);
-        Assert.AreEqual(got, Book.GetSampleInstance());
+        Assert.That(got, Is.Not.Null);
+        Assert.That(Book.GetSampleInstance(), Is.EqualTo(got));
     }
 }

--- a/YAXLibTests/NumericMinMaxTests.cs
+++ b/YAXLibTests/NumericMinMaxTests.cs
@@ -29,13 +29,13 @@ public class NumericMinMaxTests
             var d = 0.55;
             var xml = ser.Serialize(d);
             var deserializedInstance = ser.Deserialize(xml);
-            Assert.AreEqual(d, deserializedInstance);
+            Assert.That(deserializedInstance, Is.EqualTo(d));
 
             d = double.MaxValue;
             xml = ser.Serialize(d);
             deserializedInstance = ser.Deserialize(xml);
             // Causes a System.OverflowException {"Value was either too large or too small for a Double."}
-            Assert.AreEqual(d, deserializedInstance);
+            Assert.That(deserializedInstance, Is.EqualTo(d));
         }
         catch (Exception ex)
         {
@@ -56,7 +56,7 @@ public class NumericMinMaxTests
             var d = double.MinValue;
             var xml = ser.Serialize(d);
             var deserializedInstance = ser.Deserialize(xml);
-            Assert.AreEqual(d, deserializedInstance);
+            Assert.That(deserializedInstance, Is.EqualTo(d));
         }
         catch (Exception ex)
         {
@@ -78,7 +78,7 @@ public class NumericMinMaxTests
             var f = float.MaxValue;
             var xml = ser.Serialize(f);
             var deserializedInstance = ser.Deserialize(xml);
-            Assert.AreEqual(f, deserializedInstance);
+            Assert.That(deserializedInstance, Is.EqualTo(f));
         }
         catch (Exception ex)
         {
@@ -99,7 +99,7 @@ public class NumericMinMaxTests
             var f = float.MinValue;
             var xml = ser.Serialize(f);
             var deserializedInstance = ser.Deserialize(xml);
-            Assert.AreEqual(f, deserializedInstance);
+            Assert.That(deserializedInstance, Is.EqualTo(f));
         }
         catch (Exception ex)
         {

--- a/YAXLibTests/Pooling/CollectionPoolTests.cs
+++ b/YAXLibTests/Pooling/CollectionPoolTests.cs
@@ -49,7 +49,7 @@ public class CollectionPoolTests
         var list = cp.Get();
         cp.Return(list);
         cp.Get(out var list2);
-        Assert.AreSame(list, list2);
+        Assert.That(list2, Is.SameAs(list));
     }
 
     [Test]

--- a/YAXLibTests/Pooling/SerializerPoolTests.cs
+++ b/YAXLibTests/Pooling/SerializerPoolTests.cs
@@ -51,7 +51,7 @@ public class SerializerPoolTests
         var serializer = sp.Get();
         sp.Return(serializer);
         sp.Get(out var sb2);
-        Assert.AreSame(serializer, sb2);
+        Assert.That(sb2, Is.SameAs(serializer));
     }
 
     [Test]

--- a/YAXLibTests/ReflectionUtilsTest.cs
+++ b/YAXLibTests/ReflectionUtilsTest.cs
@@ -203,21 +203,21 @@ public class ReflectionUtilsTest
     [Test]
     public void GetDefaultValueTest()
     {
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(string)), null));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(bool)), default(bool)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(char)), default(char)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(sbyte)), default(sbyte)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(byte)), default(byte)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(short)), default(short)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(ushort)), default(ushort)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(int)), default(int)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(uint)), default(uint)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(long)), default(long)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(ulong)), default(ulong)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(float)), default(float)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(double)), default(double)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(decimal)), default(decimal)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(DateTime)), default(DateTime)));
-        Assert.IsTrue(Equals(ReflectionUtils.GetDefaultValue(typeof(DBNull)), DBNull.Value));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(string)), null));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(bool)), default(bool)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(char)), default(char)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(sbyte)), default(sbyte)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(byte)), default(byte)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(short)), default(short)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(ushort)), default(ushort)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(int)), default(int)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(uint)), default(uint)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(long)), default(long)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(ulong)), default(ulong)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(float)), default(float)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(double)), default(double)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(decimal)), default(decimal)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(DateTime)), default(DateTime)));
+        Assert.That(Equals(ReflectionUtils.GetDefaultValue(typeof(DBNull)), DBNull.Value));
     }
 }

--- a/YAXLibTests/SerializationTestBase.cs
+++ b/YAXLibTests/SerializationTestBase.cs
@@ -392,7 +392,7 @@ public abstract class SerializationTestBase
 
         var got = serializer.Serialize(d);
         var gotDes = (Dictionary<string, object>?) serializer.Deserialize(got);
-        Assert.AreEqual(d[theKey], gotDes?[theKey]);
+        Assert.That(gotDes?[theKey], Is.EqualTo(d[theKey]));
     }
 
     /// <summary>
@@ -410,14 +410,14 @@ public abstract class SerializationTestBase
         });
 
         var got = serializer.Serialize(d);
-        Assert.AreEqual("""
+        Assert.That(got, Is.EqualTo("""
             <DictionaryOfStringObject>
               <KeyValuePairOfStringObject>
                 <Key>TheKey</Key>
                 <Value />
               </KeyValuePairOfStringObject>
             </DictionaryOfStringObject>
-            """, got);
+            """));
     }
 
     [Test]
@@ -2269,7 +2269,7 @@ public abstract class SerializationTestBase
                 </container>
                 """;
 
-        Assert.That(expectedResult, Is.EqualTo(result));
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2316,7 +2316,7 @@ public abstract class SerializationTestBase
                   </DicValueAsContentKeyAsElement>
                 </DictionaryKeyValueAsContent>
                 """;
-        Assert.That(expectedResult, Is.EqualTo(result));
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2334,7 +2334,7 @@ public abstract class SerializationTestBase
                 </TheItems>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2354,7 +2354,7 @@ public abstract class SerializationTestBase
                 </container>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2376,7 +2376,7 @@ public abstract class SerializationTestBase
                 </CollectionWithExtraProperties>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2394,7 +2394,7 @@ public abstract class SerializationTestBase
                 </CollectionWithExtraPropertiesAttributedAsNotCollection>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2424,7 +2424,7 @@ public abstract class SerializationTestBase
                 </DictionaryWithExtraProperties>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2442,7 +2442,7 @@ public abstract class SerializationTestBase
                 </DictionaryWithExtraPropertiesAttributedAsNotCollection>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2500,7 +2500,7 @@ public abstract class SerializationTestBase
                   <sample yaxlib:realtype="YAXLibTests.SampleClasses.PolymorphicTwoSample" />
                 </samples>
                 """;
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2517,7 +2517,7 @@ public abstract class SerializationTestBase
                 </OneLetterAlias>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2534,7 +2534,7 @@ public abstract class SerializationTestBase
                 </IndexerSample>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2561,7 +2561,7 @@ public abstract class SerializationTestBase
                 </SingleLetterPropertyNames>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2577,7 +2577,7 @@ public abstract class SerializationTestBase
                 </DelegateInstances>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2597,7 +2597,7 @@ public abstract class SerializationTestBase
                   </RefB>
                 </RepetitiveReferenceIsNotLoop>
                 """;
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2617,7 +2617,7 @@ public abstract class SerializationTestBase
                 </DirectSelfReferringObject>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2650,7 +2650,7 @@ public abstract class SerializationTestBase
                 </IndirectSelfReferringObject>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2686,7 +2686,7 @@ public abstract class SerializationTestBase
                 </IndirectSelfReferringObject>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2727,7 +2727,7 @@ public abstract class SerializationTestBase
                 </DirectSelfReferringObject>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2764,7 +2764,7 @@ public abstract class SerializationTestBase
                 </DirectSelfReferringObject>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]
@@ -2800,7 +2800,7 @@ public abstract class SerializationTestBase
                 </CalculatedPropertiesCanCauseInfiniteLoop>
                 """;
 
-        Assert.AreEqual(expectedResult, result);
+        Assert.That(result, Is.EqualTo(expectedResult));
     }
 
     [Test]

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ for:
     build_script:
       - ps: dotnet restore --verbosity quiet
       - ps: |
-          $version = "4.2.0"
+          $version = "4.2.1"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {


### PR DESCRIPTION
Closes https://github.com/YAXLib/YAXLib/issues/246

Correct filtering for properties that are part of the .NET framework, when the runtime framework is not the same as the YAXLib target framework (e.g. reference to NetStandard2.0 from NET481).

Update unit test packages
* Nunit 3.13.3
* NUinit3TestAdapter 4.3.1
* FluentAssertions 6.8.0
* Microsoft.NET.Test.Sdk 17.4.1

Convert NUnit Classic Assert to the Constraint model
Add package reference NUnit.Analyzers