### PR TITLE
Fix: Returning a StringBuilder exceeding default capacity to StringBuilderPool

### DIFF
--- a/YAXLib/Pooling/SpecializedPools/StringBuilderPool.cs
+++ b/YAXLib/Pooling/SpecializedPools/StringBuilderPool.cs
@@ -21,8 +21,8 @@ internal sealed class StringBuilderPool : SpecializedPoolBase<StringBuilder>
         Policy.FunctionOnCreate = () => new StringBuilder(DefaultStringBuilderCapacity);
         Policy.ActionOnReturn = sb =>
         {
+            sb.Clear(); // Clear the StringBuilder before setting the new capacity
             sb.Capacity = DefaultStringBuilderCapacity;
-            sb.Clear();
         };
     }
 

--- a/YAXLibTests/Pooling/StringBuilderPoolTests.cs
+++ b/YAXLibTests/Pooling/StringBuilderPoolTests.cs
@@ -35,10 +35,11 @@ public class StringBuilderPoolTests
         sbp.DefaultStringBuilderCapacity = 1234;
 
         var sb = sbp.Get();
-        sb.Append("something");
 
         Assert.That(sbp.Pool.CountActive, Is.EqualTo(1));
         Assert.That(sb.Capacity, Is.EqualTo(sbp.DefaultStringBuilderCapacity));
+
+        sb.Append(new string('x', sbp.DefaultStringBuilderCapacity * 2)); // Exceed the default capacity
 
         // Returning an item should clear the StringBuilder
         Assert.That(() => sbp.Return(sb), Throws.Nothing);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   - job_name: windows
     appveyor_build_worker_image: Visual Studio 2022
   - job_name: linux
-    appveyor_build_worker_image: Ubuntu
+    appveyor_build_worker_image: Ubuntu2204
 matrix:
   fast_finish: true
 
@@ -23,7 +23,7 @@ for:
     build_script:
       - ps: dotnet restore --verbosity quiet
       - ps: |
-          $version = "4.2.1"
+          $version = "4.2.2"
           $versionFile = $version + "." + ${env:APPVEYOR_BUILD_NUMBER}
 
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {


### PR DESCRIPTION
* Closes #248
* Use Ubuntu2204 as AppVeyor build worker image
* Bump version to v4.2.2