### PR TITLE
Fix serialize to IEnumerable T without runtime type

### DIFF
--- a/YAXLib/Deserialization.cs
+++ b/YAXLib/Deserialization.cs
@@ -814,12 +814,10 @@ internal class Deserialization
         {
             return new List<object>();
         }
-        else
-        {
-            var listType = typeof(List<>).MakeGenericType(collectionItemType);
-            var result = (IList) Activator.CreateInstance(listType)!;
-            return result;
-        }
+
+        var listType = typeof(List<>).MakeGenericType(collectionItemType);
+        var result = (IList) Activator.CreateInstance(listType)!;
+        return result;
     }
 
     /// <summary>

--- a/YAXLib/Deserialization.cs
+++ b/YAXLib/Deserialization.cs
@@ -816,16 +816,9 @@ internal class Deserialization
         }
         else
         {
-            try
-            {
-                var listType = typeof(List<>).MakeGenericType(collectionItemType);
-                var result = (IList) Activator.CreateInstance(listType)!;
-                return result;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            var listType = typeof(List<>).MakeGenericType(collectionItemType);
+            var result = (IList) Activator.CreateInstance(listType)!;
+            return result;
         }
     }
 
@@ -863,7 +856,7 @@ internal class Deserialization
 
         // Now dataItems list is filled and will be processed
         
-        if (TryDataItemListDirect(collType, dataItems) is { } directList)
+        if (TryDataItemListDirect(collType, dataItems, out var directList))
             return directList;
 
         if (TryGetCollectionAsArray(xElement, collType, collItemType, memberAlias, dataItems, out var array))
@@ -886,14 +879,16 @@ internal class Deserialization
         return null;
     }
 
-    private object? TryDataItemListDirect(Type collType, IList dataItems)
+    private bool TryDataItemListDirect(Type collType, IList dataItems, out object? result)
     {
         if (collType.IsAssignableFrom(dataItems.GetType()))
         {
             //no copy / transformation needed - e.g. IEnumerable<ITem> - we can use the constructed data item list
-            return dataItems;
+            result = dataItems;
+            return true;
         }
-        return null;
+        result = null;
+        return false;
     }
 
     private bool TryGetCollectionAsEnumerable(XElement xElement, Type collType, XName memberAlias, object? containerObj,

--- a/YAXLib/Deserialization.cs
+++ b/YAXLib/Deserialization.cs
@@ -808,7 +808,7 @@ internal class Deserialization
         if (realType != null) memberType = realType;
     }
 
-    private IList? TryGetCollectionItemList(Type collectionItemType)
+    private IList GetCollectionItemList(Type collectionItemType)
     {
         if (collectionItemType == typeof(object))
         {
@@ -840,7 +840,7 @@ internal class Deserialization
 
         var collItemType = ReflectionUtils.GetCollectionItemType(collType);
 
-        IList dataItems = TryGetCollectionItemList(collItemType) ?? new List<object>(); // this will hold the actual data items
+        IList dataItems = GetCollectionItemList(collItemType); // this will hold the actual data items
         var isPrimitive = ReflectionUtils.IsBasicType(collItemType);
         if (isPrimitive && collAttrInstance is
                 { SerializationType: YAXCollectionSerializationTypes.Serially })

--- a/YAXLib/Deserialization.cs
+++ b/YAXLib/Deserialization.cs
@@ -862,11 +862,9 @@ internal class Deserialization
         }
 
         // Now dataItems list is filled and will be processed
-        if (collType.IsAssignableFrom(dataItems.GetType()))
-        {
-            //no copy / transformation needed - e.g. IEnumerable<ITem> - we can use the constructed data item list
-            return dataItems;
-        }
+        
+        if (TryDataItemListDirect(collType, dataItems) is { } directList)
+            return directList;
 
         if (TryGetCollectionAsArray(xElement, collType, collItemType, memberAlias, dataItems, out var array))
             return array;
@@ -885,6 +883,16 @@ internal class Deserialization
         if (TryGetCollectionAsEnumerable(xElement, collType, memberAlias, containerObj, dataItems, out var enumerable))
             return enumerable;
 
+        return null;
+    }
+
+    private object? TryDataItemListDirect(Type collType, IList dataItems)
+    {
+        if (collType.IsAssignableFrom(dataItems.GetType()))
+        {
+            //no copy / transformation needed - e.g. IEnumerable<ITem> - we can use the constructed data item list
+            return dataItems;
+        }
         return null;
     }
 

--- a/YAXLib/Deserialization.cs
+++ b/YAXLib/Deserialization.cs
@@ -853,20 +853,20 @@ internal class Deserialization
         }
 
         // Now dataItems list is filled and will be processed
-        
         if (TryDataItemListDirect(collType, dataItems, out var directList))
             return directList;
 
         if (TryGetCollectionAsArray(xElement, collType, collItemType, memberAlias, dataItems, out var array))
             return array;
 
-        if (TryGetCollectionAsDictionary(xElement, collType, collItemType, memberAlias, containerObj, dataItems,
-                out var dictionary)) return dictionary;
+        if (TryGetCollectionAsDictionary(xElement, collType, collItemType, memberAlias, containerObj, dataItems, out var dictionary))
+            return dictionary;
 
-        if (TryGetCollectionAsNonGenericDictionary(xElement, collType, memberAlias, containerObj, dataItems,
-                out var nonGenericDictionary)) return nonGenericDictionary;
+        if (TryGetCollectionAsNonGenericDictionary(xElement, collType, memberAlias, containerObj, dataItems, out var nonGenericDictionary))
+            return nonGenericDictionary;
 
-        if (TryGetCollectionAsBitArray(collType, dataItems, out var bitArray)) return bitArray;
+        if (TryGetCollectionAsBitArray(collType, dataItems, out var bitArray))
+            return bitArray;
 
         if (TryGetCollectionAsStack(xElement, collType, memberAlias, containerObj, dataItems, out var stack))
             return stack;

--- a/YAXLibTests/SampleClasses/IEnumerableHolderClass.cs
+++ b/YAXLibTests/SampleClasses/IEnumerableHolderClass.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace YAXLibTests.SampleClasses;
+
+public class IEnumerableHolderClass
+{
+    public IEnumerableHolderClass()
+    {
+        ListOfStrings = new List<Item>();
+    }
+
+    public IEnumerable<Item> ListOfStrings { get; set; }
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        foreach (var item in ListOfStrings) sb.AppendLine(item);
+
+        return sb.ToString();
+    }
+
+    public static ListHolderClass GetSampleInstance()
+    {
+        var inst = new ListHolderClass();
+
+        inst.ListOfStrings.Add("Hi");
+        inst.ListOfStrings.Add("Hello");
+
+        return inst;
+    }
+
+    public class Item
+    {
+        public string Name { get; set; }
+
+        public static implicit operator Item(string name) { return new Item() { Name = name }; }
+
+        public static implicit operator string(Item item) { return item.Name; }
+    }
+}
+


### PR DESCRIPTION
In an asp dot net Project I observed that the library produced a `List<object>` for `IEnumerable<Something>` - which causes an exception (it is not assignable).

The existing tests were not failing because there was no test which asked for an interface instance - only concrete types like List<Something> (because of `obj.GetType()`).