### PR TITLE
Ensure that unit tests succeed for YAXLib netstandard2.x target assets

### DIFF
--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -1,27 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../Key/YAXLib.Key.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
-    <nullable>enable</nullable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>../Key/YAXLib.Key.snk</AssemblyOriginatorKeyFile>
+        <DelaySign>false</DelaySign>
+        <TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+        <nullable>enable</nullable>
+        <!-- Ensure all transitive package assets from referenced projects are copied for netstandard2.x -->
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.3.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="8.3.0" />
+        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageReference Include="NUnit" Version="4.3.2" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\YAXLib\YAXLib.csproj" />
-  </ItemGroup>
+    <!-- Run test on YAXLib netstandard2.x assemblies: -->
+    <!-- dotnet test YAXLibTests -f net8.0 -p:ForceYAXLibTFM=netstandard2.0 -p:CopyLocalLockFileAssemblies=true -v:diag -->
+
+    <!-- Force YAXLib to a specific TFM via -p:ForceYAXLibTFM=... -->
+    <ItemGroup>
+        <ProjectReference Include="..\YAXLib\YAXLib.csproj">
+            <AdditionalProperties Condition="'$(ForceYAXLibTFM)' != ''">TargetFramework=$(ForceYAXLibTFM)</AdditionalProperties>
+        </ProjectReference>
+    </ItemGroup>
+
+    <!-- When testing the netstandard2.0 asset under net6/net8, ensure its polyfill is present -->
+    <ItemGroup Condition="('$(ForceYAXLibTFM)' == 'netstandard2.0' or '$(ForceYAXLibTFM)' == 'netstandard2.1') and ('$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net8.0')">
+        <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.0" />
+    </ItemGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,9 @@ skip_commits:
   files:
     - '**/*.md'
 environment:
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true 
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  # Disable MSBuild terminal logger globally (prevents ESC[2F, ESC[1F, et al)
+  MSBUILDTERMINALLOGGER: false
   matrix:
   - job_name: windows
     appveyor_build_worker_image: Visual Studio 2022
@@ -47,11 +49,13 @@ for:
     matrix:
       only:
         - job_name: linux
+    # Run CI tests for YAXLib netstandard2.0, netstandard2.1 target frameworks
+    # See further entries and comments in YAXLibTests.csproj
     build_script:
       - dotnet --version
-      - dotnet restore YAXLib --verbosity quiet
-      - dotnet build YAXLib -f netstandard2.0 
     test_script:
-      - dotnet restore YAXLibTests --verbosity quiet
-      - dotnet build YAXLibTests -f net6.0
-      - dotnet test YAXLibTests -f net6.0
+      - echo "Testing YAXLibTests against netstandard2.0"
+      - dotnet test YAXLibTests -f net8.0 -p:ForceYAXLibTFM=netstandard2.0 -p:CopyLocalLockFileAssemblies=true -v:minimal
+      - dotnet clean YAXLibTests -f net8.0
+      - echo "Testing YAXLibTests against netstandard2.1"
+      - dotnet test YAXLibTests -f net8.0 -p:ForceYAXLibTFM=netstandard2.1 -p:CopyLocalLockFileAssemblies=true -v:minimal


### PR DESCRIPTION
Add CI unit tests for YAXLib `netstandard2.0` and `netstandard2.1` target frameworks
The tests run in the `Linux` job only.