### PR TITLE
Update dependencies

### DIFF
--- a/YAXLib/YAXLib.csproj
+++ b/YAXLib/YAXLib.csproj
@@ -33,17 +33,17 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.0" />
+    <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.1" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.0" />
+    <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.1" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -4,7 +4,7 @@
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>../Key/YAXLib.Key.snk</AssemblyOriginatorKeyFile>
         <DelaySign>false</DelaySign>
-        <TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net48;net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <nullable>enable</nullable>
         <!-- Ensure all transitive package assets from referenced projects are copied for netstandard2.x -->
@@ -12,15 +12,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="8.3.0" />
+        <PackageReference Include="FluentAssertions" Version="8.8.0" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="NUnit" Version="4.3.2" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
+        <PackageReference Include="NUnit" Version="4.5.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     </ItemGroup>
 
     <!-- Run test on YAXLib netstandard2.x assemblies: -->


### PR DESCRIPTION
- Bump package versions in YAXLib.csproj:, Portable.System.DateTimeOnly, System.ValueTuple, Microsoft.SourceLink.GitHub.
- In YAXLibTests.csproj, update FluentAssertions, NUnit, NUnit.Analyzers, NUnit3TestAdapter, and Microsoft.NET.Test.Sdk.
- Remove net6.0 from test target frameworks, now supporting only net48 and net8.0.