### PR TITLE
Publish to Nuget with Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
   windows:
     name: Windows Build, Test, Pack and Publish
     runs-on: windows-2022
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -72,11 +75,9 @@ jobs:
       - name: Publish to NuGet
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'YAXLib'
         shell: pwsh
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           $packagePath = "artifacts/YAXLib.$env:PACKAGE_VERSION.nupkg"
-          dotnet nuget push $packagePath --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push $packagePath --source https://api.nuget.org/v3/index.json --skip-duplicate
 
   linux:
     name: Linux Test .NET Standard Assets


### PR DESCRIPTION
Replaced the disabled push step with a NuGet login step and updated the push command to use the login output.

See https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing