### PR TITLE
chore: Update `Assert.Multiple` to `Assert.EnterMultipleScope` in unit tests

### DIFF
--- a/YAXLibTests/Caching/MemberWrapperCacheTests.cs
+++ b/YAXLibTests/Caching/MemberWrapperCacheTests.cs
@@ -21,12 +21,12 @@ public class MemberWrapperCacheTests
         var s = new YAXSerializer<Book>();
         _ = s.Serialize(Book.GetSampleInstance());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(countAfterClear, Is.EqualTo(0));
             Assert.That(MemberWrapperCache.Instance.CacheDictionary, Is.Not.Empty);
             Assert.That(MemberWrapperCache.Instance.CacheDictionary[(typeof(Book), s.Options)], Is.Not.Empty);
-        });
+        }
     }
 
     [Test]
@@ -41,12 +41,12 @@ public class MemberWrapperCacheTests
         s = new YAXSerializer<Book>();
         _ = s.Deserialize(xml);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(countAfterClear, Is.EqualTo(0));
             Assert.That(MemberWrapperCache.Instance.CacheDictionary, Is.Not.Empty);
             Assert.That(MemberWrapperCache.Instance.CacheDictionary[(typeof(Book), s.Options)], Is.Not.Empty);
-        });
+        }
     }
 
     [Test]
@@ -72,12 +72,12 @@ public class MemberWrapperCacheTests
         MemberWrapperCache.Instance.Add((typeof(ulong), so), new List<MemberWrapper>());
         MemberWrapperCache.Instance.Add((typeof(char), so), new List<MemberWrapper>());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dupeAdded, Is.False);
             Assert.That(MemberWrapperCache.Instance.CacheDictionary, Has.Count.EqualTo(5));
             Assert.That(MemberWrapperCache.Instance.CacheDictionary.ContainsKey((typeof(string), so)), Is.False); // FIFO
-        });
+        }
         
         MemberWrapperCache.Instance.MaxCacheSize = MemberWrapperCache.DefaultCacheSize;
     }

--- a/YAXLibTests/Caching/UdtWrapperCacheTests.cs
+++ b/YAXLibTests/Caching/UdtWrapperCacheTests.cs
@@ -20,11 +20,11 @@ public class UdtWrapperCacheTests
         var s = new YAXSerializer<Book>();
         _ = s.Serialize(Book.GetSampleInstance());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(countAfterClear, Is.EqualTo(0));
             Assert.That(UdtWrapperCache.Instance.CacheDictionary, Contains.Key((typeof(Book), s.Options)));
-        });
+        }
     }
 
     [Test]
@@ -39,11 +39,11 @@ public class UdtWrapperCacheTests
         s = new YAXSerializer<Book>();
         _ = s.Deserialize(xml);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(countAfterClear, Is.EqualTo(0));
             Assert.That(UdtWrapperCache.Instance.CacheDictionary, Contains.Key((typeof(Book), s.Options)));
-        });
+        }
     }
 
     [Test]

--- a/YAXLibTests/CustomSerializerTests.cs
+++ b/YAXLibTests/CustomSerializerTests.cs
@@ -42,7 +42,7 @@ public class CustomSerializerTests
         var xml = s.Serialize(original);
         var deserialized = (ClassLevelSampleAsElement?) s.Deserialize(xml);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // " CUSTOM" is added by the ClassLevelSerializer
             Assert.That(xml, Is.EqualTo("""
@@ -55,7 +55,7 @@ public class CustomSerializerTests
             """));
             // " CUSTOM" is removed by the ClassLevelSerializer
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()));
-        });
+        }
     }
 
     [Test]
@@ -69,12 +69,12 @@ public class CustomSerializerTests
         var xml = s.Serialize(original);
         var deserialized = (ClassLevelSampleAsAttribute?) s.Deserialize(xml);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(xml,
                     Is.EqualTo("<ClassLevelSampleAsAttribute ClassLevelSample=\"ATTR|The Title|The Message\" />"));
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()));
-        });
+        }
     }
 
     [Test]
@@ -88,12 +88,12 @@ public class CustomSerializerTests
         var xml = s.Serialize(original);
         var deserialized = (ClassLevelSampleAsValue?) s.Deserialize(xml);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(xml,
                     Is.EqualTo("<ClassLevelSampleAsValue>VAL|The Title|The Message</ClassLevelSampleAsValue>"));
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()));
-        });
+        }
     }
 
     [Test]
@@ -107,7 +107,7 @@ public class CustomSerializerTests
         var xml = s.Serialize(original);
         var deserialized = (ClassLevelCtxSampleAsElement?) s.Deserialize(xml);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // " CUSTOM" is added by the ClassLevelSerializer
             Assert.That(xml, Is.EqualTo("""
@@ -120,7 +120,7 @@ public class CustomSerializerTests
             """));
             // " CUSTOM" is removed by the ClassLevelSerializer
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()));
-        });
+        }
     }
 
     [Test]
@@ -132,12 +132,12 @@ public class CustomSerializerTests
         var xml = s.Serialize(original);
         var deserialized = (ClassLevelCtxSampleAsAttribute?) s.Deserialize(xml);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(xml,
                     Is.EqualTo("<ClassLevelCtxSampleAsAttribute ClassLevelCtxSample=\"ATTR|The Title|The Message\" />"));
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()));
-        });
+        }
     }
 
     [Test]
@@ -149,12 +149,12 @@ public class CustomSerializerTests
         var xml = s.Serialize(original);
         var deserialized = (ClassLevelCtxSampleAsValue?) s.Deserialize(xml);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(xml,
                     Is.EqualTo("<ClassLevelCtxSampleAsValue>VAL|The Title|The Message</ClassLevelCtxSampleAsValue>"));
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()));
-        });
+        }
     }
 
     [Test]
@@ -179,11 +179,11 @@ public class CustomSerializerTests
                 </PropertyLevelSample>
                 """;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(xml, Is.EqualTo(expectedXml));
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()));
-        });
+        }
     }
 
     [Test]
@@ -209,11 +209,11 @@ public class CustomSerializerTests
                 </FieldLevelSample>
                 """;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(xml, Is.EqualTo(expectedXml));
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()));
-        });
+        }
     }
 
     [Test]
@@ -236,11 +236,11 @@ public class CustomSerializerTests
                   <Title>ELE__This is the title</Title>VAL__Just a short message body</FieldLevelCombinedSample>
                 """;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(xml, Is.EqualTo(expectedXml));
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()));
-        });
+        }
     }
 
     [Test]
@@ -265,13 +265,13 @@ public class CustomSerializerTests
                 </ISampleInterface>
                 """;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Note: Prefix "C_" is evidence for custom serializer was invoked
             // during serialization and deserialization
             Assert.That(xml, Does.Contain(expectedXmlPart), "Serialized XML");
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()), "Deserialized Object");
-        });
+        }
     }
 
     [Test]
@@ -302,12 +302,12 @@ public class CustomSerializerTests
                 </ISampleInterface>
                 """;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Note: Prefix "C_" is evidence for custom serializer was invoked
             // during serialization and deserialization
             Assert.That(xml, Does.Contain(expectedXmlPart), "Serialized XML");
             Assert.That(deserialized?.ToString(), Is.EqualTo(original.ToString()), "Deserialized Object");
-        });
+        }
     }
 }

--- a/YAXLibTests/DeserializationTestBase.cs
+++ b/YAXLibTests/DeserializationTestBase.cs
@@ -44,11 +44,11 @@ public abstract class DeserializationTestBase
     private void PerformTestWithEquals(object obj, Type? objType = null)
     {
         var serializer = SerializeDeserialize(obj, out var gottonObject, objType);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serializer.ParsingErrors.Count, Is.EqualTo(0));
             Assert.That(gottonObject, Is.EqualTo(obj));
-        });
+        }
     }
 
     private object? GetTheTwoStringsAndReturn(object obj, out string originalString, out string? gottonString,
@@ -78,16 +78,16 @@ public abstract class DeserializationTestBase
     {
         var result =
             GetTheTwoStringsAndReturn(obj, out var originalString, out var gottonString, out var errorCounts, objType);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(originalString, Is.Not.Null);
             Assert.That(gottonString, Is.Not.Null);
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(gottonString, Is.EqualTo(originalString));
             Assert.That(errorCounts, Is.EqualTo(0));
-        });
+        }
         return result;
     }
 
@@ -216,7 +216,7 @@ public abstract class DeserializationTestBase
             });
         var got = (NullableSample2?) serializer.Deserialize(xml);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(got, Is.Not.Null);
             Assert.That(got?.Boolean, Is.Null);
@@ -224,7 +224,7 @@ public abstract class DeserializationTestBase
             Assert.That(got?.Decimal, Is.Null);
             Assert.That(got?.Enum, Is.Null);
             Assert.That(got?.Number, Is.Null);
-        });
+        }
     }
 
     [Test]
@@ -465,13 +465,13 @@ public abstract class DeserializationTestBase
         });
         var gottonObject = (SerializationOptionsSample?) serializer.Deserialize(input1);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(gottonObject?.ObjectWithOptionsSet.SomeValueType, Is.EqualTo(123),
                     "Missing element: DefaultValue from attribute should be used");
             Assert.That(gottonObject?.ObjectWithOptionsSet.StrNull, Is.Null, "Empty element: Deserializes as null");
             Assert.That(serializer.ParsingErrors.Count, Is.EqualTo(1));
-        });
+        }
     }
 
     [Test]
@@ -730,16 +730,16 @@ public abstract class DeserializationTestBase
         var ser = CreateSerializer<CalculatedPropertiesCanCauseInfiniteLoop>(options);
         var result = ser.Serialize(CalculatedPropertiesCanCauseInfiniteLoop.GetSampleInstance());
         var deserializedInstance = ser.Deserialize(result) as CalculatedPropertiesCanCauseInfiniteLoop;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserializedInstance, Is.Not.Null);
             Assert.That(ser.Options.MaxRecursion, Is.EqualTo(10));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserializedInstance?.Data, Is.EqualTo(2.0M));
             Assert.That(ser.GetRecursionCount(), Is.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -755,7 +755,7 @@ public abstract class DeserializationTestBase
         obj.DecentralizationOrder.TryGetValue(4, out var fifth);
         obj.DecentralizationOrder.TryGetValue(5, out var sixth);
         obj.DecentralizationOrder.TryGetValue(6, out var seventh);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(first, Is.EqualTo("Author"));
             Assert.That(second, Is.EqualTo("Title"));
@@ -764,7 +764,7 @@ public abstract class DeserializationTestBase
             Assert.That(fifth, Is.EqualTo("Review"));
             Assert.That(sixth, Is.EqualTo("Publisher"));
             Assert.That(seventh, Is.EqualTo("Editor"));
-        });
+        }
     }
 
     [Test]
@@ -779,11 +779,11 @@ public abstract class DeserializationTestBase
         var result = ser.Serialize(container);
         var deserializedInstance = (BaseContainer?) ser.Deserialize(result);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserializedInstance?.Items?[0].Data, Is.EqualTo("Some Data"));
             Assert.That(deserializedInstance?.Items?.Length, Is.EqualTo(1));
-        });
+        }
     }
 
     [Test]
@@ -799,11 +799,11 @@ public abstract class DeserializationTestBase
         var deserializedInstance = (BaseContainer?) ser.Deserialize(result);
 
         Assert.That(deserializedInstance?.Items?[0], Is.InstanceOf<DerivedItem>());
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserializedInstance?.Items?[0].Data, Is.EqualTo("Some Data"));
             Assert.That(deserializedInstance?.Items?.Length, Is.EqualTo(1));
-        });
+        }
     }
 
     [Test]

--- a/YAXLibTests/ExceptionTests.cs
+++ b/YAXLibTests/ExceptionTests.cs
@@ -28,11 +28,11 @@ internal class ExceptionTests
             serializer.Serialize(ClassWithDuplicateYaxAttribute.GetSampleInstance());
         });
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ex?.AttrName, Is.EqualTo("test"));
             Assert.That(ex?.Message, Does.Contain("'test'"));
-        });
+        }
     }
 
     [Test]
@@ -56,14 +56,14 @@ internal class ExceptionTests
             serializer.Deserialize(badXml);
         });
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // YAXBadlyFormedXML exception doesn't need YAXSerializationOptions.DisplayLineInfoInExceptions to get the line numbers
             Assert.That(ex!.HasLineInfo, Is.True);
             Assert.That(ex.LineNumber, Is.EqualTo(7));
             Assert.That(ex.LinePosition, Is.EqualTo(3));
             Assert.That(ex.Message, Does.Contain("not properly formatted"));
-        });
+        }
     }
 
     [Test]
@@ -79,11 +79,11 @@ internal class ExceptionTests
 
         object? result = "";
         Assert.That(code: () => { result = serializer.Deserialize(xml); }, Throws.Nothing);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.Null);
             Assert.That(serializer.ParsingErrors.ToString(), Does.Contain("not properly formatted"));
-        });
+        }
     }
 
     [Test]
@@ -128,11 +128,11 @@ internal class ExceptionTests
 
         object? result = "";
         Assert.That(code: () => { result = serializer.Deserialize(streamReader); }, Throws.Nothing);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.Null);
             Assert.That(serializer.ParsingErrors.ToString(), Does.Contain("not properly formatted"));
-        });
+        }
     }
 
     [Test]
@@ -179,11 +179,11 @@ internal class ExceptionTests
         using var xmlReader = XmlReader.Create(stream);
         object? result = "";
         Assert.That(code: () => { result = serializer.Deserialize(xmlReader); }, Throws.Nothing);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.Null);
             Assert.That(serializer.ParsingErrors.ToString(), Does.Contain("not properly formatted"));
-        });
+        }
     }
 
     [Test]
@@ -209,13 +209,13 @@ internal class ExceptionTests
             });
             serializer.Deserialize(bookXml);
         });
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ex?.HasLineInfo, Is.True);
             Assert.That(ex?.LineNumber, Is.EqualTo(6));
             Assert.That(ex?.LinePosition, Is.EqualTo(4));
             Assert.That(ex?.Message, Does.Contain("The format of the value specified for the property"));
-        });
+        }
     }
 
     [Test]
@@ -240,13 +240,13 @@ internal class ExceptionTests
             });
             serializer.Deserialize(bookXml);
         });
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ex?.HasLineInfo, Is.False);
             Assert.That(ex?.LineNumber, Is.EqualTo(0));
             Assert.That(ex?.LinePosition, Is.EqualTo(0));
             Assert.That(ex?.Message, Does.Contain("The format of the value specified for the property"));
-        });
+        }
     }
 
     [Test]
@@ -260,12 +260,12 @@ internal class ExceptionTests
             serializer.Serialize(new ClassWithDuplicateYaxAttribute());
         });
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ex?.ExpectedType, Is.EqualTo(typeof(Book)));
             Assert.That(ex?.ReceivedType, Is.EqualTo(typeof(ClassWithDuplicateYaxAttribute)));
             Assert.That(ex?.Message, Does.Contain("'Book'"));
-        });
+        }
         Assert.That(ex?.Message, Does.Contain("'ClassWithDuplicateYaxAttribute'"));
     }
 
@@ -292,12 +292,12 @@ internal class ExceptionTests
             });
             serializer.Deserialize(bookXml);
         });
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ex?.HasLineInfo, Is.True);
             Assert.That(ex?.LineNumber, Is.EqualTo(2));
             Assert.That(ex?.LinePosition, Is.EqualTo(2));
-        });
+        }
     }
 
     [Test]
@@ -323,12 +323,12 @@ internal class ExceptionTests
             });
             serializer.Deserialize(collectionXml);
         });
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ex?.HasLineInfo, Is.True);
             Assert.That(ex?.LineNumber, Is.EqualTo(2));
             Assert.That(ex?.LinePosition, Is.EqualTo(2));
-        });
+        }
     }
 
     [Test]
@@ -352,12 +352,12 @@ internal class ExceptionTests
             });
             serializer.Deserialize(bookXml);
         });
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ex?.HasLineInfo, Is.True);
             Assert.That(ex?.LineNumber, Is.EqualTo(1));
             Assert.That(ex?.LinePosition, Is.EqualTo(2));
-        });
+        }
     }
 
     [Test]

--- a/YAXLibTests/GenericDeserializationTests.cs
+++ b/YAXLibTests/GenericDeserializationTests.cs
@@ -57,10 +57,10 @@ public class GenericDeserializationTests : DeserializationTestBase
                 """;
         var serializer = new YAXSerializer<Book>();
         var got = serializer.Deserialize(xml);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(got, Is.Not.Null);
             Assert.That(Book.GetSampleInstance(), Is.EqualTo(got));
-        });
+        }
     }
 }

--- a/YAXLibTests/GenericSerializationTests.cs
+++ b/YAXLibTests/GenericSerializationTests.cs
@@ -75,10 +75,10 @@ public class GenericSerializationTests : SerializationTestBase
                 """;
         var serializer = new YAXSerializer<Book>();
         var got = serializer.Deserialize(xml);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(got, Is.Not.Null);
             Assert.That(Book.GetSampleInstance(), Is.EqualTo(got));
-        });
+        }
     }
 }

--- a/YAXLibTests/KnownTypeTests.cs
+++ b/YAXLibTests/KnownTypeTests.cs
@@ -29,12 +29,12 @@ public class KnownTypeTests
         var removeSuccess = WellKnownTypes.Remove(typeof(TimeSpan));
         var existsAfter = WellKnownTypes.TryGetKnownType(typeof(TimeSpan), out _);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(existsBefore, Is.True);
             Assert.That(removeSuccess, Is.True);
             Assert.That(existsAfter, Is.False);
-        });
+        }
     }
 
     [Test]
@@ -87,11 +87,11 @@ public class KnownTypeTests
         s.Serialize(typeExample.TheType, serialized, XNamespace.None, discardCtx);
         var deserialized = s.Deserialize(serialized, XNamespace.None, discardCtx);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized.ToString(), Is.EqualTo(expectedXml));
             Assert.That(deserialized!.ToString(), Is.EqualTo("YAXLibTests.KnownTypeTests"));
-        });
+        }
     }
 
     [Test]
@@ -108,11 +108,11 @@ public class KnownTypeTests
         var serialized = serializer.Serialize(typeExample);
         var deserialized = (TypeKnownTypeSample?) serializer.Deserialize(serialized);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized, Is.EqualTo(expectedXml));
             Assert.That(deserialized?.TheType?.UnderlyingSystemType, Is.EqualTo(typeExample.TheType?.UnderlyingSystemType));
-        });
+        }
     }
 
     [Test]
@@ -153,11 +153,11 @@ public class KnownTypeTests
         s.Serialize(typeExample.TheType, serialized, XNamespace.None, discardCtx);
         var deserialized = (Type?) s.Deserialize(serialized, XNamespace.None, discardCtx);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized.ToString(), Is.EqualTo(expectedXml));
             Assert.That(deserialized?.ToString(), Is.EqualTo("YAXLibTests.KnownTypeTests"));
-        });
+        }
     }
 
     [Test]
@@ -171,11 +171,11 @@ public class KnownTypeTests
         var serialized = serializer.Serialize(t);
         var deserialized = serializer.Deserialize(serialized);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized, Is.EqualTo(expectedXml));
             Assert.That(deserialized?.ToString(), Is.EqualTo("YAXLibTests.KnownTypeTests"));
-        });
+        }
     }
 
     [Test]
@@ -311,12 +311,12 @@ public class KnownTypeTests
         var deserializedAsNull =
             s.Deserialize(new XElement(XName.Get(nameof(dbNullExample))), XNamespace.None, discardCtx);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized.ToString(), Is.EqualTo(expectedXml));
             Assert.That(deserialized, Is.TypeOf<DBNull>());
             Assert.That(deserializedAsNull, Is.Null);
-        });
+        }
     }
 
     [Test]
@@ -503,7 +503,7 @@ public class KnownTypeTests
             var exceptionSerialized = ser.SerializeToXDocument(ex);
             var outerElement = exceptionSerialized.Root;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(outerElement?.Name.LocalName, Is.EqualTo("Exception"), "Element name should be 'Exception'");
                 Assert.That(outerElement?.Attribute("{http://www.sinairv.com/yaxlib/}realtype")?.Value,
@@ -511,17 +511,17 @@ public class KnownTypeTests
                     "Exception 'realtype' attribute should exist");
                 Assert.That(outerElement?.Element("Message")?.Value, Does.Contain(ex.Message),
                     "Exception message should exist");
-            });
+            }
 
             var innerElement = exceptionSerialized.Root?.Element("InnerException");
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(innerElement?.Attribute("{http://www.sinairv.com/yaxlib/}realtype")?.Value,
                             Is.EqualTo("System.DivideByZeroException"), "'InnerException 'realtype' attribute should exist");
                 Assert.That(innerElement?.Element("Message")?.Value, Does.Contain(ex.InnerException!.Message),
                     "InnerException message should exist");
-            });
+            }
         }
     }
 
@@ -545,25 +545,25 @@ public class KnownTypeTests
 
             var outerElement = exceptionSerialized.Root;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(outerElement?.Name.LocalName, Is.EqualTo("Exception"), "Element name should be 'Exception'");
                 Assert.That(outerElement?.Attribute("{http://www.sinairv.com/yaxlib/}realtype")?.Value,
                     Is.EqualTo("System.InvalidOperationException"), "Exception 'realtype' attribute should exist");
                 Assert.That(outerElement?.Element("Message")?.Value, Does.Contain(ex.Message),
                     "Exception message should exist");
-            });
+            }
 
             if (maxRecursion > 3)
             {
                 var innerElement = exceptionSerialized.Root?.Element(XName.Get("InnerException"));
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(innerElement?.Attribute("{http://www.sinairv.com/yaxlib/}realtype")?.Value,
                                     Is.EqualTo("System.ArgumentException"), "'InnerException 'realtype' attribute should exist");
                     Assert.That(innerElement?.Element("Message")?.Value, Does.Contain(ex.InnerException!.Message),
                         "InnerException message should exist");
-                });
+                }
             }
         }
     }
@@ -626,11 +626,11 @@ public class KnownTypeTests
         if (maxRecursion > 1)
         {
             Assert.That(deserialized?.InnerException, Is.TypeOf<DivideByZeroException>());
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(deserialized?.InnerException?.Message, Is.EqualTo("InnerException of CustomException"));
                 Assert.That(deserialized?.InnerException?.InnerException, Is.TypeOf<AbandonedMutexException>());
-            });
+            }
         }
     }
 
@@ -666,11 +666,11 @@ public class KnownTypeTests
             { SerializationOptions = YAXSerializationOptions.SerializeNullObjects });
         var deserialized = ser.Deserialize(toDeserialize);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized?.Message, Is.EqualTo("System exception unit test"));
             Assert.That(deserialized?.InnerException, Is.TypeOf<ArgumentException>());
-        });
+        }
         Assert.That(deserialized?.InnerException?.Message, Is.EqualTo("Inner exception unit test (Parameter 'arg')"));
     }
 
@@ -688,11 +688,11 @@ public class KnownTypeTests
         var deserialized = ser.Deserialize(toDeserialize);
 
         Assert.That(deserialized, Is.InstanceOf<InvalidOperationException>());
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized?.Message, Is.Empty);
             Assert.That(deserialized?.InnerException, Is.Null);
-        });
+        }
     }
 
     [Test]

--- a/YAXLibTests/NamespaceTest.cs
+++ b/YAXLibTests/NamespaceTest.cs
@@ -375,11 +375,11 @@ public class NamespaceTest
         });
         var serialized = serializer.Serialize(SingleNamespaceSample.GetInstance());
         var deserialized = serializer.Deserialize(serialized);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -392,11 +392,11 @@ public class NamespaceTest
         });
         var serialized = serializer.Serialize(MultipleNamespaceSample.GetSampleInstance());
         var deserialized = serializer.Deserialize(serialized);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -409,11 +409,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(AttributeNamespaceSample.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -426,11 +426,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(CellPhoneMemberAndClassDifferentNamespaces.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -443,11 +443,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(CellPhoneMemberAndClassDifferentNamespacePrefixes.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -461,11 +461,11 @@ public class NamespaceTest
             });
         var got = serializer.Serialize(CellPhoneMultiLevelMemberAndClassDifferentNamespaces.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -478,11 +478,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(CellPhoneDictionaryNamespaceForAllItems.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -495,11 +495,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(CellPhoneDictionaryNamespace.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -515,11 +515,11 @@ public class NamespaceTest
             .GetSampleInstance());
         var deserialized =
             serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -532,11 +532,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(CellPhoneCollectionNamespaceForAllItems.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -549,11 +549,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(CellPhoneYaxNamespaceOverridesImplicitNamespace.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -566,11 +566,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(MultilevelObjectsWithNamespaces.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -583,11 +583,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(WarehouseDictionary.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -600,11 +600,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(AttributeWithNamespace.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -617,11 +617,11 @@ public class NamespaceTest
         });
         var got = serializer.Serialize(AttributeWithNamespaceAsMember.GetSampleInstance());
         var deserialized = serializer.Deserialize(got);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -720,14 +720,14 @@ public class NamespaceTest
         var deserialized = serializer.Deserialize(xdoc.Root!);
 
         Assert.That(deserialized, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized!.Dict, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
             Assert.That(deserialized.Dict, Has.Count.EqualTo(2));
             Assert.That(deserialized.Dict["A"], Is.EqualTo("Value 0"));
             Assert.That(deserialized.Dict["B"], Is.EqualTo("Value 1"));
-        });
+        }
     }
 
     [Test]
@@ -746,14 +746,14 @@ public class NamespaceTest
         var deserialized = serializer.Deserialize(xdoc.Root!);
 
         Assert.That(deserialized, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized!.Dict, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
             Assert.That(deserialized.Dict, Has.Count.EqualTo(2));
             Assert.That(deserialized.Dict["A"], Is.EqualTo("Value 0"));
             Assert.That(deserialized.Dict["B"], Is.EqualTo("Value 1"));
-        });
+        }
     }
 
     [Test]
@@ -776,13 +776,13 @@ public class NamespaceTest
         Assert.That(deserialized, Is.Not.Null);
 
         // Only reached when deserialized is confirmed non-null; all failures reported together
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized!.Dict, Is.Not.Null);
             Assert.That(serializer.ParsingErrors, Has.Count.EqualTo(0));
             Assert.That(deserialized.Dict, Has.Count.EqualTo(2));
             Assert.That(deserialized.Dict["A"], Is.EqualTo("Value 0"));
             Assert.That(deserialized.Dict["B"], Is.EqualTo("Value 1"));
-        });
+        }
     }
 }

--- a/YAXLibTests/OverridingYAXLibMetadataTests.cs
+++ b/YAXLibTests/OverridingYAXLibMetadataTests.cs
@@ -42,11 +42,11 @@ public class OverridingYaxLibMetadataTests
 
         var desObj = (YaxLibMetadataOverridingWithNamespace?) ser.Deserialize(expected);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(desObj?.Obj?.ToString(), Is.EqualTo(sampleInstance.Obj?.ToString()));
             Assert.That(desObj?.IntArray?.Length, Is.EqualTo(sampleInstance.IntArray?.Length));
-        });
+        }
     }
 
     [Test]
@@ -79,11 +79,11 @@ public class OverridingYaxLibMetadataTests
 
         var desObj = (YaxLibMetadataOverridingWithNamespace?) ser.Deserialize(expected);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(desObj?.Obj?.ToString(), Is.EqualTo(sampleInstance.Obj?.ToString()));
             Assert.That(desObj?.IntArray?.Length, Is.EqualTo(sampleInstance.IntArray?.Length));
-        });
+        }
     }
 
     [Test]

--- a/YAXLibTests/Pooling/CollectionPoolTests.cs
+++ b/YAXLibTests/Pooling/CollectionPoolTests.cs
@@ -22,13 +22,13 @@ public class CollectionPoolTests
     {
         var cp = GetCollectionPool();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => cp.Get(), Throws.Nothing);
             Assert.That(cp.Pool.CountActive, Is.EqualTo(1));
             Assert.That(cp.Pool.CountInactive, Is.EqualTo(0));
             Assert.That(cp.Pool.CountAll, Is.EqualTo(1));
-        });
+        }
     }
 
     [Test]
@@ -38,14 +38,14 @@ public class CollectionPoolTests
 
         var list = cp.Get();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(cp.Pool.CountActive, Is.EqualTo(1));
             Assert.That(() => cp.Return(list), Throws.Nothing);
             Assert.That(cp.Pool.CountActive, Is.EqualTo(0));
             Assert.That(cp.Pool.CountInactive, Is.EqualTo(1));
             Assert.That(cp.Pool.CountAll, Is.EqualTo(1));
-        });
+        }
     }
 
     [Test]

--- a/YAXLibTests/Pooling/ConcurrentPoolingTests.cs
+++ b/YAXLibTests/Pooling/ConcurrentPoolingTests.cs
@@ -38,11 +38,11 @@ public class ConcurrentPoolingTests
                 pool.Return(someObject);
             }), Throws.Nothing);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(pool.CountActive, Is.EqualTo(0));
             Assert.That(pool.CountInactive, Is.GreaterThan(0));
-        });
+        }
     }
 
     [Test]
@@ -71,11 +71,11 @@ public class ConcurrentPoolingTests
         var result = list.OrderBy(e => e.ToString());
         long compareCounter = 1;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(list, Has.Count.EqualTo(maxLoops - 1));
             Assert.That(result.All(r => r == $"<String>{compareCounter++:0000}</String>"));
-        });
+        }
 
         foreach (var p in PoolingHelpers.GetAllPoolCounters())
         {
@@ -86,13 +86,13 @@ public class ConcurrentPoolingTests
             Console.WriteLine("""{0}: {1}""", nameof(IPoolCounters.CountInactive), p.Counters?.CountInactive);
 
             Console.WriteLine();
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(p.Counters!.CountActive, Is.EqualTo(0),
                             string.Join(" ", nameof(IPoolCounters.CountActive), p.Type?.ToString()));
                 Assert.That(p.Counters.CountInactive, Is.GreaterThan(0),
                     string.Join(" ", nameof(IPoolCounters.CountInactive), p.Type?.ToString()));
-            });
+            }
         }
     }
 }

--- a/YAXLibTests/Pooling/DictionaryPoolTests.cs
+++ b/YAXLibTests/Pooling/DictionaryPoolTests.cs
@@ -21,12 +21,12 @@ public class DictionaryPoolTests
     {
         var dictPool = GetDictionaryPool();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => dictPool.Get(), Throws.Nothing);
             Assert.That(dictPool.Pool.CountActive, Is.EqualTo(1));
             Assert.That(dictPool.Pool.CountInactive, Is.EqualTo(0));
             Assert.That(dictPool.Pool.CountAll, Is.EqualTo(1));
-        });
+        }
     }
 }

--- a/YAXLibTests/Pooling/HashSetPoolTests.cs
+++ b/YAXLibTests/Pooling/HashSetPoolTests.cs
@@ -21,12 +21,12 @@ public class HashSetPoolTests
     {
         var hsp = GetHashSetPool();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => hsp.Get(), Throws.Nothing);
             Assert.That(hsp.Pool.CountActive, Is.EqualTo(1));
             Assert.That(hsp.Pool.CountInactive, Is.EqualTo(0));
             Assert.That(hsp.Pool.CountAll, Is.EqualTo(1));
-        });
+        }
     }
 }

--- a/YAXLibTests/Pooling/ListPoolTests.cs
+++ b/YAXLibTests/Pooling/ListPoolTests.cs
@@ -21,12 +21,12 @@ public class ListPoolTests
     {
         var lp = GetListPool();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => lp.Get(), Throws.Nothing);
             Assert.That(lp.Pool.CountActive, Is.EqualTo(1));
             Assert.That(lp.Pool.CountInactive, Is.EqualTo(0));
             Assert.That(lp.Pool.CountAll, Is.EqualTo(1));
-        });
+        }
     }
 }

--- a/YAXLibTests/Pooling/ObjectPoolClassesTests.cs
+++ b/YAXLibTests/Pooling/ObjectPoolClassesTests.cs
@@ -67,13 +67,13 @@ public class ObjectPoolClassesTests
         pool.Clear(); // 'Clear' calls ActionOnDestroy
         var destroyed = obj.Value.ToLower();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(created, Is.EqualTo(nameof(created)), poolAsObj.GetType().Name);
             Assert.That(returned, Is.EqualTo(nameof(returned)), poolAsObj.GetType().Name);
             Assert.That(get, Is.EqualTo(nameof(get)), poolAsObj.GetType().Name);
             Assert.That(destroyed, Is.EqualTo(nameof(destroyed)), poolAsObj.GetType().Name);
-        });
+        }
     }
 
     [TestCaseSource(nameof(GetObjectPoolBasedPools), new object?[] { true })]
@@ -99,13 +99,13 @@ public class ObjectPoolClassesTests
         pool.Clear(); // 'Clear' calls ActionOnDestroy
         var destroyed = itemInPool.Value;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(created, Is.EqualTo(nameof(created)), poolAsObj.GetType().Name);
             Assert.That(returned, Is.EqualTo(nameof(returned)), poolAsObj.GetType().Name);
             Assert.That(get, Is.EqualTo(nameof(get)), poolAsObj.GetType().Name);
             Assert.That(destroyed, Is.EqualTo(nameof(destroyed)), poolAsObj.GetType().Name);
-        });
+        }
     }
 
     [TestCaseSource(nameof(GetObjectPoolBasedPools), new object?[] { true })]
@@ -159,7 +159,7 @@ public class ObjectPoolClassesTests
 
         pool.Clear();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Got 3 elements from the pool
             Assert.That(activeCount1, Is.EqualTo(3), poolAsObj.GetType().Name);
@@ -175,7 +175,7 @@ public class ObjectPoolClassesTests
             Assert.That(pool.CountAll, Is.EqualTo(0), poolAsObj.GetType().Name);
             Assert.That(pool.CountActive, Is.EqualTo(0), poolAsObj.GetType().Name);
             Assert.That(pool.CountInactive, Is.EqualTo(0), poolAsObj.GetType().Name);
-        });
+        }
     }
 
     [TestCaseSource(nameof(GetObjectPoolBasedPools), new object?[] { true })]
@@ -206,7 +206,7 @@ public class ObjectPoolClassesTests
 
         pool.Clear();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Got 'numOfCreated' elements from the pool
             Assert.That(activeCount1, Is.EqualTo(numOfCreated), poolAsObj.GetType().Name);
@@ -222,7 +222,7 @@ public class ObjectPoolClassesTests
             Assert.That(pool.CountAll, Is.EqualTo(0), poolAsObj.GetType().Name);
             Assert.That(pool.CountActive, Is.EqualTo(0), poolAsObj.GetType().Name);
             Assert.That(pool.CountInactive, Is.EqualTo(0), poolAsObj.GetType().Name);
-        });
+        }
     }
 
     [TestCaseSource(nameof(GetObjectPoolBasedPools), new object?[] { true })]
@@ -241,13 +241,13 @@ public class ObjectPoolClassesTests
 
         pool.Dispose();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(actualCreated, Is.EqualTo(shouldBeCreated), poolAsObj.GetType().Name);
             Assert.That(pool.CountAll, Is.EqualTo(0), poolAsObj.GetType().Name);
             Assert.That(pool.CountActive, Is.EqualTo(0), poolAsObj.GetType().Name);
             Assert.That(pool.CountInactive, Is.EqualTo(0), poolAsObj.GetType().Name);
             Assert.That(pool.PoolItems.Any(), Is.EqualTo(false), poolAsObj.GetType().Name);
-        });
+        }
     }
 }

--- a/YAXLibTests/Pooling/PoolBalanceTests.cs
+++ b/YAXLibTests/Pooling/PoolBalanceTests.cs
@@ -44,13 +44,13 @@ public class PoolBalanceTests
             if (p.Counters!.CountAll <= 0) continue;
 
             Console.WriteLine();
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(p.Counters.CountActive, Is.EqualTo(0),
                             string.Join(" ", nameof(IPoolCounters.CountActive), p.Type?.ToString()));
                 Assert.That(p.Counters.CountInactive, Is.GreaterThan(0),
                     string.Join(" ", nameof(IPoolCounters.CountInactive), p.Type?.ToString()));
-            });
+            }
         }
     }
 }

--- a/YAXLibTests/Pooling/SerializerPoolTests.cs
+++ b/YAXLibTests/Pooling/SerializerPoolTests.cs
@@ -22,13 +22,13 @@ public class SerializerPoolTests
     {
         var sbp = GetSerializerPool();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => sbp.Get(), Throws.Nothing);
             Assert.That(sbp.Pool.CountActive, Is.EqualTo(1));
             Assert.That(sbp.Pool.CountInactive, Is.EqualTo(0));
             Assert.That(sbp.Pool.CountAll, Is.EqualTo(1));
-        });
+        }
     }
 
     [Test]
@@ -42,12 +42,12 @@ public class SerializerPoolTests
         // Returning an item should clear the StringBuilder
         Assert.That(() => sp.Return(serializer), Throws.Nothing);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sp.Pool.CountActive, Is.EqualTo(0));
             Assert.That(sp.Pool.CountInactive, Is.EqualTo(1));
             Assert.That(sp.Pool.CountAll, Is.EqualTo(1));
-        });
+        }
     }
 
     [Test]
@@ -71,12 +71,12 @@ public class SerializerPoolTests
         sp.Return(serializer);
         sp.Reset();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sp.Pool.CountActive, Is.EqualTo(0));
             Assert.That(sp.Pool.CountInactive, Is.EqualTo(0));
             Assert.That(sp.Pool.CountAll, Is.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -87,10 +87,10 @@ public class SerializerPoolTests
         var serializer = sp?.Get();
         sp?.Dispose();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serializer, Is.Not.Null, "Serializer instance");
             Assert.That(sp?.Pool.CountAll ?? -1, Is.EqualTo(0), "CountAll");
-        });
+        }
     }
 }

--- a/YAXLibTests/Pooling/StringBuilderPoolTests.cs
+++ b/YAXLibTests/Pooling/StringBuilderPoolTests.cs
@@ -22,13 +22,13 @@ public class StringBuilderPoolTests
     {
         var sbp = GetStringBuilderPool();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => sbp.Get(), Throws.Nothing);
             Assert.That(sbp.Pool.CountActive, Is.EqualTo(1));
             Assert.That(sbp.Pool.CountInactive, Is.EqualTo(0));
             Assert.That(sbp.Pool.CountAll, Is.EqualTo(1));
-        });
+        }
     }
 
     [Test]
@@ -39,33 +39,33 @@ public class StringBuilderPoolTests
 
         var sb = sbp.Get();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sbp.Pool.CountActive, Is.EqualTo(1));
             Assert.That(sb.Capacity, Is.EqualTo(sbp.DefaultStringBuilderCapacity));
-        });
+        }
 
         sb.Append(new string('x', sbp.DefaultStringBuilderCapacity * 2)); // Exceed the default capacity
 
         // Returning an item should clear the StringBuilder
         Assert.That(() => sbp.Return(sb), Throws.Nothing);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sb.Length, Is.EqualTo(0));
 
             Assert.That(sbp.Pool.CountActive, Is.EqualTo(0));
             Assert.That(sbp.Pool.CountInactive, Is.EqualTo(1));
             Assert.That(sbp.Pool.CountAll, Is.EqualTo(1));
-        });
+        }
 
         sbp.Reset();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sbp.Pool.CountActive, Is.EqualTo(0));
             Assert.That(sbp.Pool.CountInactive, Is.EqualTo(0));
             Assert.That(sbp.Pool.CountAll, Is.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -86,10 +86,10 @@ public class StringBuilderPoolTests
         var stringBuilder = sbp?.Get();
         sbp?.Dispose();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(stringBuilder, Is.Not.Null, "StringBuilder instance");
             Assert.That(sbp?.Pool.CountAll ?? -1, Is.EqualTo(0), "CountAll");
-        });
+        }
     }
 }

--- a/YAXLibTests/ReflectionUtilsTest.cs
+++ b/YAXLibTests/ReflectionUtilsTest.cs
@@ -16,7 +16,7 @@ public class ReflectionUtilsTest
     [Test]
     public void IsArrayTest()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ReflectionUtils.IsArray(typeof(int[])), Is.True);
             Assert.That(ReflectionUtils.IsArray(typeof(int[,])), Is.True);
@@ -26,13 +26,13 @@ public class ReflectionUtilsTest
             Assert.That(ReflectionUtils.IsArray(typeof(Dictionary<,>)), Is.False);
             Assert.That(ReflectionUtils.IsArray(typeof(Dictionary<int, string>)), Is.False);
             Assert.That(ReflectionUtils.IsArray(typeof(string)), Is.False);
-        });
+        }
     }
 
     [Test]
     public void IsCollectionTypeTest()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ReflectionUtils.IsCollectionType(typeof(int[])), Is.True);
             Assert.That(ReflectionUtils.IsCollectionType(typeof(Array)), Is.True);
@@ -44,13 +44,13 @@ public class ReflectionUtilsTest
             Assert.That(ReflectionUtils.IsCollectionType(typeof(IEnumerable<>)), Is.True);
             Assert.That(ReflectionUtils.IsCollectionType(typeof(IEnumerable<int>)), Is.True);
             Assert.That(ReflectionUtils.IsCollectionType(typeof(string)), Is.False);
-        });
+        }
     }
 
     [Test]
     public void GetCollectionItemTypeTest()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ReflectionUtils.GetCollectionItemType(typeof(IEnumerable<int>)), Is.EqualTo(typeof(int)));
             Assert.That(ReflectionUtils.GetCollectionItemType(typeof(double[])), Is.EqualTo(typeof(double)));
@@ -61,7 +61,7 @@ public class ReflectionUtilsTest
                 ReflectionUtils.GetCollectionItemType(typeof(Dictionary<int, char>)), Is.EqualTo(typeof(KeyValuePair<int, char>)));
             Assert.That(
                 ReflectionUtils.GetCollectionItemType(typeof(Dictionary<Dictionary<int, double>, char>)), Is.EqualTo(typeof(KeyValuePair<Dictionary<int, double>, char>)));
-        });
+        }
 
         //Assert.That(ReflectionUtils.GetCollectionItemType(typeof(IEnumerable<>)) == typeof(object), Is.True);
     }
@@ -69,7 +69,7 @@ public class ReflectionUtilsTest
     [Test]
     public void IsTypeEqualOrInheritedFromTypeTest()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ReflectionUtils.IsTypeEqualOrInheritedFromType(typeof(int), typeof(object)), Is.True);
             Assert.That(ReflectionUtils.IsTypeEqualOrInheritedFromType(typeof(string), typeof(object)), Is.True);
@@ -97,13 +97,13 @@ public class ReflectionUtilsTest
                     typeof(IDictionary<int, Array>)), Is.False);
             Assert.That(ReflectionUtils.IsTypeEqualOrInheritedFromType(typeof(ICollection), typeof(IEnumerable)),
                 Is.True);
-        });
+        }
     }
 
     [Test]
     public void EqualsOrIsNullableOfTest()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(typeof(int).EqualsOrIsNullableOf(typeof(int)), Is.True);
             Assert.That(typeof(int?).EqualsOrIsNullableOf(typeof(int)), Is.True);
@@ -112,12 +112,12 @@ public class ReflectionUtilsTest
             Assert.That(typeof(double?).EqualsOrIsNullableOf(typeof(Nullable<>)), Is.False);
             Assert.That(typeof(double?).EqualsOrIsNullableOf(typeof(double)), Is.True);
             Assert.That(typeof(char?).EqualsOrIsNullableOf(typeof(char?)), Is.True);
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(typeof(char?).EqualsOrIsNullableOf(typeof(char?)), Is.True);
             Assert.That(typeof(int[]).EqualsOrIsNullableOf(typeof(Array)), Is.False);
-        });
+        }
     }
 
 #if NETFRAMEWORK
@@ -135,11 +135,11 @@ public class ReflectionUtilsTest
             $"System.Collections.Generic.List`1[[System.Int32, {coreLibName}]]");
         var type2 = ReflectionUtils.GetTypeByName("System.Collections.Generic.List`1[[System.Int32]]");
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(type1, Is.Not.Null);
             Assert.That(type2, Is.Not.Null);
-        });
+        }
         Assert.That(type2, Is.EqualTo(type1));
     }
 
@@ -165,7 +165,7 @@ public class ReflectionUtilsTest
         var baseClassField1AfterSet = ReflectionUtils.GetFieldValue(subClass, "_privateFieldFromBaseLevel1");
         var baseClassField2AfterSet = ReflectionUtils.GetFieldValue(subClass, "_privateFieldFromBaseLevel2");
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Initial values
             Assert.That(subClassField, Is.EqualTo(2));
@@ -175,15 +175,15 @@ public class ReflectionUtilsTest
                 // private base field not found
                 code: () => { ReflectionUtils.GetFieldValue(subClass, "_privateFieldFromBaseLevel1", false); },
                 Throws.Exception);
-        });
+        }
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Changed values
             Assert.That(subClassFieldAfterSet, Is.EqualTo(3));
             Assert.That(baseClassField1AfterSet, Is.EqualTo(13));
             Assert.That(baseClassField2AfterSet, Is.EqualTo(23));
-        });
+        }
     }
 
     [Test]
@@ -210,7 +210,7 @@ public class ReflectionUtilsTest
         var baseClassProperty2AfterSet =
             ReflectionUtils.GetPropertyValue(subClass, "PrivatePropertyFromBaseLevel2");
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Initial values
             Assert.That(subClassProperty, Is.EqualTo(1));
@@ -220,21 +220,21 @@ public class ReflectionUtilsTest
                 // private base property not found
                 code: () => { ReflectionUtils.GetPropertyValue(subClass, "PrivatePropertyFromBaseLevel1", false); },
                 Throws.Exception);
-        });
+        }
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Changed values
             Assert.That(subClassPropertyAfterSet, Is.EqualTo(111));
             Assert.That(baseClassProperty1AfterSet, Is.EqualTo(113));
             Assert.That(baseClassProperty2AfterSet, Is.EqualTo(123));
-        });
+        }
     }
 
     [Test]
     public void GetDefaultValueTest()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ReflectionUtils.GetDefaultValue(typeof(string)), Is.EqualTo(null));
             Assert.That(ReflectionUtils.GetDefaultValue(typeof(bool)), Is.EqualTo(default(bool)));
@@ -252,6 +252,6 @@ public class ReflectionUtilsTest
             Assert.That(ReflectionUtils.GetDefaultValue(typeof(decimal)), Is.EqualTo(default(decimal)));
             Assert.That(ReflectionUtils.GetDefaultValue(typeof(DateTime)), Is.EqualTo(default(DateTime)));
             Assert.That(ReflectionUtils.GetDefaultValue(typeof(DBNull)), Is.EqualTo(DBNull.Value));
-        });
+        }
     }
 }

--- a/YAXLibTests/SerializationContextTests.cs
+++ b/YAXLibTests/SerializationContextTests.cs
@@ -26,13 +26,13 @@ public class SerializationContextTests
         var memberWrapper = new MemberWrapper(memberInfo, serializer.Options);
         var sc = new SerializationContext(memberWrapper, udtWrapper, serializer);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sc.SerializerOptions, Is.EqualTo(serializer.Options));
             Assert.That(sc.TypeContext.Type!.Name, Is.EqualTo(sampleType.Name));
             Assert.That(sc.MemberContext!.TypeContext!.Type.Name, Is.EqualTo(nameof(String)));
             Assert.That(sc.MemberContext!.MemberDescriptor!.Name, Is.EqualTo(memberName));
-        });
+        }
     }
 
     [Test]
@@ -43,11 +43,11 @@ public class SerializationContextTests
         var udtWrapper = serializer.UdtWrapper;
         var sc = new SerializationContext(null, udtWrapper, serializer);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sc.SerializerOptions, Is.EqualTo(serializer.Options));
             Assert.That(sc.TypeContext.Type!.Name, Is.EqualTo(sampleType.Name));
-        });
+        }
     }
 
     [Test]
@@ -68,12 +68,12 @@ public class SerializationContextTests
         var lengthCtx = titleCtx!.TypeContext.GetFieldsForSerialization()
             .FirstOrDefault(p => p.MemberDescriptor.Name == nameof(string.Length));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sc.TypeContext.GetFieldsForSerialization().Count(), Is.EqualTo(3));
             Assert.That(sc.TypeContext.GetFieldsForDeserialization().Count(), Is.EqualTo(3));
             Assert.That(lengthCtx!.TypeContext.Type, Is.EqualTo(typeof(int)));
-        });
+        }
     }
 
     [Test]
@@ -84,11 +84,11 @@ public class SerializationContextTests
         var udtWrapper = serializer.UdtWrapper;
         var sc = new SerializationContext(null, udtWrapper, serializer);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sc.TypeContext.GetFieldsForSerialization().Count(), Is.EqualTo(3));
             Assert.That(sc.TypeContext.GetFieldsForDeserialization().Count(), Is.EqualTo(3));
-        });
+        }
     }
 
     [Test]

--- a/YAXLibTests/SerializationTestBase.cs
+++ b/YAXLibTests/SerializationTestBase.cs
@@ -103,11 +103,11 @@ public abstract class SerializationTestBase
                 Assert.That(book, Is.Not.Null);
             }), Throws.Nothing);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(MemberWrapperCache.Instance.CacheDictionary, Contains.Key((typeof(Book), serializerOptions)));
             Assert.That(UdtWrapperCache.Instance.CacheDictionary, Contains.Key((typeof(Book), serializerOptions)));
-        });
+        }
     }
 
     [Test]
@@ -148,7 +148,7 @@ public abstract class SerializationTestBase
         var got = serializer.Serialize(book);
         var gotDes = (Book?) serializer.Deserialize(got);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(book, Is.EqualTo(gotDes));
             Assert.That(got, Is.EqualTo(
@@ -160,7 +160,7 @@ public abstract class SerializationTestBase
               <Price>30.5</Price>
             </Book>
             """));
-        });
+        }
     }
 
     [TestCase("fr-FR")]
@@ -207,12 +207,12 @@ public abstract class SerializationTestBase
             });
 
         var desResult = serializer.Deserialize(serResult) as CultureSample;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serResult, Is.EqualTo(expected), $"Comparing serialized '{cultName}' with expected.");
             Assert.That(desResult!, Is.EqualTo(CultureSample.GetSampleInstance()),
                 $"Comparing deserialized '{cultName}' with deserialized expected.");
-        });
+        }
     }
 
     [Test]
@@ -291,11 +291,11 @@ public abstract class SerializationTestBase
         });
 
         var result = serializer.Serialize(BookStruct.GetSampleInstance());
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.EqualTo(xml));
             Assert.That(serializer.Deserialize(xml), Is.EqualTo(BookStruct.GetSampleInstance()));
-        });
+        }
     }
 
     [Test]
@@ -1211,11 +1211,11 @@ public abstract class SerializationTestBase
         var deserialized1 = serializer.Deserialize(xml1);
         var deserialized2 = serializer.Deserialize(xml2);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserialized1, Is.EqualTo(timeSpan));
             Assert.That(deserialized2, Is.EqualTo(timeSpan));
-        });
+        }
     }
 
     [Test]
@@ -2857,12 +2857,12 @@ public abstract class SerializationTestBase
                 </CalculatedPropertiesCanCauseInfiniteLoop>
                 """;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.EqualTo(expectedResult));
             Assert.That(ser.Options.MaxRecursion, Is.EqualTo(10));
             Assert.That(ser.GetRecursionCount(), Is.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -3105,7 +3105,7 @@ public abstract class SerializationTestBase
             sample.TextCDataEmbedding += "\u0003"; // 0x3 is illegal and should be stripped off
         var serialized = serializer.SerializeToXDocument(sample);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Serialization
             Assert.That(serialized.ToString().NormalizeLineEndings(), Is.EqualTo(xml),
@@ -3114,7 +3114,7 @@ public abstract class SerializationTestBase
                 $"null values are not handled by {nameof(YAXTextEmbeddingAttribute)}");
             Assert.That(serialized.Root!.Element("TextBase64Embedding")!.Value.FromBase64(Encoding.UTF8),
                 Is.EqualTo(sample.TextBase64Embedding), "Properly and fully Base64-encoded");
-        });
+        }
     }
 
     [Test]

--- a/YAXLibTests/StringUtilsTest.cs
+++ b/YAXLibTests/StringUtilsTest.cs
@@ -15,7 +15,7 @@ public class StringUtilsTest
     [Test]
     public void RefineElementNameTest()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(StringUtils.RefineLocationString(".."), Is.EqualTo(".."));
             Assert.That(StringUtils.RefineLocationString("."), Is.EqualTo("."));
@@ -45,7 +45,7 @@ public class StringUtilsTest
             Assert.That(StringUtils.RefineLocationString("-one"), Is.EqualTo("_one"));
             Assert.That(StringUtils.RefineLocationString("one."), Is.EqualTo("one."));
             Assert.That(StringUtils.RefineLocationString("one-"), Is.EqualTo("one-"));
-        });
+        }
     }
 
     [Test]
@@ -66,17 +66,17 @@ public class StringUtilsTest
     {
         string path, alias;
         StringUtils.ExtractPathAndAliasFromLocationString(locationString, out path, out alias);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(path, Is.EqualTo(expectedPath));
             Assert.That(alias, Is.EqualTo(expectedAlias));
-        });
+        }
     }
 
     [Test]
     public void IsLocationAllGenericTest()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(StringUtils.IsLocationAllGeneric(".."), Is.True);
             Assert.That(StringUtils.IsLocationAllGeneric("."), Is.True);
@@ -91,7 +91,7 @@ public class StringUtilsTest
             Assert.That(StringUtils.IsLocationAllGeneric("../one/../two"), Is.False);
             Assert.That(StringUtils.IsLocationAllGeneric("../one/../two/.."), Is.False);
             Assert.That(StringUtils.IsLocationAllGeneric("one/../two/.."), Is.False);
-        });
+        }
     }
 
     [Test]
@@ -102,66 +102,66 @@ public class StringUtilsTest
 
         var location = "..";
         var returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(newLocation, Is.EqualTo(".."));
             Assert.That(newElement, Is.Empty);
             Assert.That(returnValue, Is.False);
-        });
+        }
 
         location = ".";
         returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(newLocation, Is.EqualTo("."));
             Assert.That(newElement, Is.Empty);
             Assert.That(returnValue, Is.False);
-        });
+        }
 
         location = "../..";
         returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(newLocation, Is.EqualTo("../.."));
             Assert.That(newElement, Is.Empty);
             Assert.That(returnValue, Is.False);
-        });
+        }
 
         location = "../../folder";
         returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(newLocation, Is.EqualTo("../.."));
             Assert.That(newElement, Is.EqualTo("folder"));
             Assert.That(returnValue, Is.True);
-        });
+        }
 
         location = "../../folder/..";
         returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(newLocation, Is.EqualTo("../../folder/.."));
             Assert.That(newElement, Is.Empty);
             Assert.That(returnValue, Is.False);
-        });
+        }
 
         location = "one/two/three/four";
         returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(newLocation, Is.EqualTo("one/two/three"));
             Assert.That(newElement, Is.EqualTo("four"));
             Assert.That(returnValue, Is.True);
-        });
+        }
 
         location = "one";
         returnValue = StringUtils.DivideLocationOneStep(location, out newLocation, out newElement);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(newLocation, Is.EqualTo("."));
             Assert.That(newElement, Is.EqualTo("one"));
             Assert.That(returnValue, Is.True);
-        });
+        }
     }
 
     [Test]

--- a/YAXLibTests/XMLUtilsTest.cs
+++ b/YAXLibTests/XMLUtilsTest.cs
@@ -23,23 +23,23 @@ public class XmlUtilsTest
 
         Assert.That(XMLUtils.CanCreateLocation(elem, "level1/level2"), Is.True);
         var created = XMLUtils.CreateLocation(elem, "level1/level2");
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(created.Name.ToString(), Is.EqualTo("level2"));
             Assert.That(XMLUtils.LocationExists(elem, "level1/level2"), Is.True);
-        });
+        }
         created = XMLUtils.CreateLocation(elem, "level1/level3");
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(created.Name.ToString(), Is.EqualTo("level3"));
             Assert.That(XMLUtils.LocationExists(elem, "level1/level3"), Is.True);
-        });
+        }
     }
 
     [Test]
     public void ConvertObjectToXmlValue()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(default(object).ToXmlValue(CultureInfo.InvariantCulture), Is.EqualTo(string.Empty));
             Assert.That(true.ToXmlValue(CultureInfo.InvariantCulture), Is.EqualTo("true"));
@@ -47,6 +47,6 @@ public class XmlUtilsTest
             Assert.That(1.123f.ToXmlValue(CultureInfo.InvariantCulture), Is.EqualTo("1.123"));
             Assert.That(new BigInteger(1234567890).ToXmlValue(CultureInfo.InvariantCulture), Is.EqualTo("1234567890"));
             Assert.That(new StringBuilder("123.456").ToXmlValue(CultureInfo.InvariantCulture), Is.EqualTo("123.456"));
-        });
+        }
     }
 }


### PR DESCRIPTION
Update all unit tests
No change in code logic